### PR TITLE
Define expression IR

### DIFF
--- a/include/caffeine/ADT/Ref.h
+++ b/include/caffeine/ADT/Ref.h
@@ -1,0 +1,207 @@
+#ifndef CAFFEINE_ADT_REF_H
+#define CAFFEINE_ADT_REF_H
+
+#include <memory>
+#include <type_traits>
+
+namespace caffeine {
+
+/**
+ * Intrusive reference-counted pointer.
+ *
+ * This type is analogous to std::shared_ptr except that it uses an internal
+ * member of T to store the reference count. Whether ref is thread-safe or not
+ * depends on the type of the refcount within T.
+ *
+ * Implementing a Pointee Type
+ * ===========================
+ * There is only one requirement for a pointee type: It should have a member
+ * with name refcount that supports the following operations
+ *  - operator++ (preincrement)
+ *  - operator-- (predecrement)
+ *  - operator size_t
+ *  - operator ! - if operator size_t is implicit then that can be used instead.
+ *
+ * Upon construction, the refcount should be initialized with 0 (or whatever
+ * value is equivalent for the type.)
+ *
+ * If you want to support constant refs (i.e. ref<const T>) then it is
+ * necessary to declare the refcount field as mutable.
+ */
+template <typename T, typename Deleter = std::default_delete<T>>
+class ref : Deleter {
+private:
+  T* value;
+
+  static const bool is_nothrow_destructible =
+      std::is_nothrow_destructible<T>::value;
+
+  enum raw_t { raw };
+  constexpr ref(raw_t, T* value, Deleter deleter)
+      : Deleter(deleter), value(value) {}
+
+public:
+  constexpr ref() : value(nullptr) {}
+
+  /**
+   * Take ownership of the pointer.
+   *
+   * This will increment the refcount of value.
+   */
+  ref(T* value, const Deleter& deleter = Deleter())
+      : Deleter(deleter), value(value) {
+    increment();
+  }
+
+  // References are implicitly convertable to const references.
+  operator ref<const T>() const {
+    return ref<const T>(get(), this->deleter());
+  }
+
+  /**
+   * Create a ref without incrementing the refcount.
+   *
+   * Note that UB will occur if there are more references than the
+   * refcount indicates.
+   */
+  static ref<T> from_raw(T* value, const Deleter& deleter = Deleter()) {
+    return ref<T>(raw, value, deleter);
+  }
+
+  size_t refcount() const {
+    if (!value)
+      return 0;
+    return static_cast<size_t>(value->refcount);
+  }
+
+  Deleter& deleter() & {
+    return *this;
+  }
+  const Deleter& deleter() const& {
+    return *this;
+  }
+  Deleter&& deleter() && {
+    return *this;
+  }
+  const Deleter&& deleter() const&& {
+    return *this;
+  }
+
+  /**
+   * Take the internal pointer from this reference without changing the
+   * refcount.
+   *
+   * Note that UB will occur if there are more references than the refcount
+   * indicates.
+   */
+  T* take() {
+    auto prev = value;
+    value = nullptr;
+    return prev;
+  }
+
+  constexpr T* get() {
+    return value;
+  }
+  constexpr const T* get() const {
+    return value;
+  }
+
+  constexpr T* operator->() {
+    return get();
+  }
+  constexpr const T* operator->() const {
+    return get();
+  }
+
+  T& operator*() & {
+    return *get();
+  }
+  T&& operator*() && {
+    return *get();
+  }
+  const T& operator*() const& {
+    return *get();
+  }
+  const T&& operator*() const&& {
+    return *get();
+  }
+
+  operator bool() const {
+    return get();
+  }
+  bool operator!() const {
+    return !get();
+  }
+
+  bool operator==(const ref<T>& r) const {
+    return value == r.value;
+  }
+  bool operator!=(const ref<T>& r) const {
+    return value != r.value;
+  }
+
+  ref(const ref<T>& r) noexcept(std::is_nothrow_copy_constructible_v<Deleter>)
+      : Deleter(r.deleter()), value(r.value) {
+    increment();
+  }
+  ref(ref<T>&& r) noexcept(std::is_nothrow_move_constructible_v<Deleter>)
+      : Deleter(r.deleter()), value(r.value) {
+    r.value = nullptr;
+  }
+
+  ref<T>& operator=(const ref<T>& r) noexcept(
+      is_nothrow_destructible&& std::is_nothrow_copy_assignable_v<Deleter>) {
+    decrement();
+    value = r.value;
+    *(Deleter*)this = r.deleter();
+    increment();
+    return *this;
+  }
+  ref<T>& operator=(ref<T>&& r) noexcept(
+      is_nothrow_destructible&& std::is_nothrow_move_assignable_v<Deleter>) {
+    decrement();
+    value = r.value;
+    r.value = nullptr;
+    *(Deleter*)this = std::move(r.deleter());
+    return *this;
+  }
+
+  ref<T>& operator=(std::nullptr_t) noexcept(is_nothrow_destructible) {
+    decrement();
+    value = nullptr;
+    return *this;
+  }
+
+  ~ref() noexcept(is_nothrow_destructible) {
+    decrement();
+  }
+
+private:
+  void increment() {
+    if (value) {
+      ++value->refcount;
+    }
+  }
+  void decrement() {
+    if (!value)
+      return;
+
+    // Note: Because refcount may be an atomic, the only valid time to check
+    //       the refcount is at the same time that we're decrementing it.
+    if (!(--value->refcount)) {
+      // Use the deleter
+      this->operator()(const_cast<typename std::remove_const<T>::type*>(value));
+      value = nullptr;
+    }
+  }
+};
+
+template <typename T, typename... Args>
+ref<T> make_ref(Args&&... args) {
+  return ref<T>(new T(std::forward<Args>(args)...));
+}
+
+} // namespace caffeine
+
+#endif

--- a/include/caffeine/ADT/Ref.h
+++ b/include/caffeine/ADT/Ref.h
@@ -48,7 +48,7 @@ public:
    *
    * This will increment the refcount of value.
    */
-  ref(T* value, const Deleter& deleter = Deleter())
+  explicit ref(T* value, const Deleter& deleter = Deleter())
       : Deleter(deleter), value(value) {
     increment();
   }

--- a/include/caffeine/IR/Operation.h
+++ b/include/caffeine/IR/Operation.h
@@ -1,0 +1,433 @@
+#ifndef CAFFEINE_IR_OPERATION_H
+#define CAFFEINE_IR_OPERATION_H
+
+#include <cstdint>
+
+#include <llvm/ADT/APFloat.h>
+#include <llvm/ADT/APInt.h>
+#include <llvm/ADT/iterator_range.h>
+#include <llvm/Support/Casting.h>
+
+#include "caffeine/ADT/Ref.h"
+#include "caffeine/IR/Type.h"
+#include "caffeine/Support/Assert.h"
+
+namespace caffeine {
+
+namespace detail {
+  // This is meant for internal use within Operation only.
+  constexpr uint16_t opcode(uint16_t op, uint16_t nargs, uint16_t aux = 0) {
+    if (nargs >= 4)
+      CAFFEINE_ABORT("invalid number of arguments for opcode");
+    if (nargs >= 0x10)
+      CAFFEINE_ABORT("aux data was too large");
+    return (op << 6) | (aux << 2) | nargs;
+  }
+
+  template <typename T>
+  class double_deref_iterator;
+} // namespace detail
+
+enum class ICmpOp : uint8_t {
+  EQ = 0x8,
+  NE = 0x9,
+  UGT = (0 << 2) | 0x0,
+  UGE = (0 << 2) | 0x1,
+  ULT = (0 << 2) | 0x2,
+  ULE = (0 << 2) | 0x3,
+  SGT = (1 << 2) | 0x0,
+  SGE = (1 << 2) | 0x1,
+  SLT = (1 << 2) | 0x2,
+  SLE = (1 << 2) | 0x3
+};
+
+enum class FCmpOp : uint8_t {
+  OEQ = 000,
+  OGT = 001,
+  OGE = 002,
+  OLT = 003,
+  OLE = 004,
+  ONE = 005,
+  ORD = 006,
+  UEQ = 010,
+  UGT = 011,
+  UGE = 012,
+  ULT = 013,
+  ULE = 014,
+  UNE = 015,
+  UNO = 016,
+};
+
+/**
+ * An individual expression node.
+ *
+ * In general, an expression node has
+ * 1. An opcode
+ * 2. A type
+ * 3. 0-3 opcodes
+ *
+ * The base operation class provides access to operands, types, and the
+ * opcode. Custom payloads (e.g. for constants) can only be accessed by
+ * first downcasting to the relevant class using llvm::dyn_cast.
+ *
+ * All derived operation types should have the same as the base Operation
+ * class (no new members) so it will always be safe to copy Operation
+ * instances around.
+ *
+ * Adding a new opcode
+ * ===================
+ * To define a new opcode
+ *
+ * 1. Add the actual opcode to the Opcode enum within Operation. Make sure
+ *    to properly set the embedded operand count.
+ * 2. (Optional) Define a new derived class that provides opcode-specific
+ *    helper functions. It will also need the correct member functions
+ *    derived so that llvm::dyn_cast and llvm::isa work.
+ * 3. Add a builder function `CreateXXX` to the proper derived class that
+ *    builds the correct Operation instance.
+ */
+class Operation {
+public:
+  /**
+   * Notes on bit representation:
+   *  - bits 0..1 contain the number of arguments
+   *    (note that ConstantInt and ConstantFloat have 0)
+   *  - bits 2..6 are used for instruction-specific data
+   *    (e.g. comparison operation for fcmp variants) or grouping various
+   *    opcodes together when they don't have auxiliary data.
+   *  - the remaining bits are the opcode number.
+   */
+  enum Opcode : uint16_t {
+    Invalid = 0,
+
+    // Constants
+    ConstantInt = detail::opcode(1, 0, 0),
+    ConstantFloat = detail::opcode(1, 0, 1),
+
+    // Integer opcodes
+    Add = detail::opcode(3, 2),
+    Sub = detail::opcode(4, 2),
+    Mul = detail::opcode(5, 2),
+    UDiv = detail::opcode(6, 2),
+    SDiv = detail::opcode(7, 2),
+    URem = detail::opcode(8, 2),
+    SRem = detail::opcode(9, 2),
+
+    And = detail::opcode(10, 2),
+    Or = detail::opcode(11, 2),
+    Xor = detail::opcode(12, 2),
+    Shl = detail::opcode(13, 2),
+    LShr = detail::opcode(14, 2),
+    AShr = detail::opcode(15, 2),
+    Not = detail::opcode(16, 1),
+
+    // Floating-point opcodes
+    FAdd = detail::opcode(17, 2),
+    FSub = detail::opcode(18, 2),
+    FMul = detail::opcode(19, 2),
+    FDiv = detail::opcode(20, 2),
+    FRem = detail::opcode(21, 2),
+    FNeg = detail::opcode(22, 1),
+
+    // Conversion opcodes
+    Trunc = detail::opcode(23, 1),
+    SExt = detail::opcode(24, 1),
+    ZExt = detail::opcode(25, 1),
+    FpTrunc = detail::opcode(26, 1),
+    FpExt = detail::opcode(27, 1),
+    FpToUI = detail::opcode(28, 1),
+    FpToSI = detail::opcode(29, 1),
+    UIToFp = detail::opcode(30, 1),
+    SIToFp = detail::opcode(31, 1),
+
+    // Integer comparison operations
+    ICmpEq = detail::opcode(32, 2, (uint16_t)ICmpOp::EQ),
+    ICmpNe = detail::opcode(32, 2, (uint16_t)ICmpOp::NE),
+    ICmpUgt = detail::opcode(32, 2, (uint16_t)ICmpOp::UGT),
+    ICmpUge = detail::opcode(32, 2, (uint16_t)ICmpOp::UGE),
+    ICmpUlt = detail::opcode(32, 2, (uint16_t)ICmpOp::ULT),
+    ICmpUle = detail::opcode(32, 2, (uint16_t)ICmpOp::ULE),
+    ICmpSgt = detail::opcode(32, 2, (uint16_t)ICmpOp::SGT),
+    ICmpSge = detail::opcode(32, 2, (uint16_t)ICmpOp::SGE),
+    ICmpSlt = detail::opcode(32, 2, (uint16_t)ICmpOp::SLT),
+    ICmpSle = detail::opcode(32, 2, (uint16_t)ICmpOp::SLE),
+
+    // Floating-point comparison operations
+    // See the corresponding predicates in llvm's CmpInst to understand
+    // what each of these mean.
+    // TODO: Should these be broken down?
+    FCmpOeq = detail::opcode(33, 2, (uint16_t)FCmpOp::OEQ),
+    FCmpOGt = detail::opcode(33, 2, (uint16_t)FCmpOp::OGT),
+    FCmpOge = detail::opcode(33, 2, (uint16_t)FCmpOp::OGE),
+    FCmpOlt = detail::opcode(33, 2, (uint16_t)FCmpOp::OLT),
+    FCmpOle = detail::opcode(33, 2, (uint16_t)FCmpOp::OLE),
+    FCmpOne = detail::opcode(33, 2, (uint16_t)FCmpOp::ONE),
+    FCmpOrd = detail::opcode(33, 2, (uint16_t)FCmpOp::ORD),
+    FCmpUno = detail::opcode(33, 2, (uint16_t)FCmpOp::UNO),
+    FCmpUeq = detail::opcode(33, 2, (uint16_t)FCmpOp::UEQ),
+    FCmpUgt = detail::opcode(33, 2, (uint16_t)FCmpOp::UGT),
+    FCmpUge = detail::opcode(33, 2, (uint16_t)FCmpOp::UGE),
+    FCmpUlt = detail::opcode(33, 2, (uint16_t)FCmpOp::ULT),
+    FCmpUle = detail::opcode(33, 2, (uint16_t)FCmpOp::ULE),
+    FCmpUne = detail::opcode(33, 2, (uint16_t)FCmpOp::UNE),
+
+    // Other instructions
+    Select = detail::opcode(34, 3)
+  };
+
+protected:
+  uint16_t opcode_;
+  uint16_t dummy_ = 0; // Unused, used for padding
+  // When multithreading is implemented this will need to become atomic.
+  //
+  // Needs to be mutable so that const refs (ref<const Operation>) work.
+  mutable uint32_t refcount = 0;
+  Type type_;
+
+  union { // TODO: Pointers? Might need a ConstantPointer type
+    ref<Operation> operands_[3];
+    llvm::APInt iconst_;
+    llvm::APFloat fconst_;
+  };
+
+  // So ref can get at the refcount field.
+  //
+  // Ideally, this be a friend only for ref<[const] Operation, Deleter>
+  // but C++ doesn't allow friend declarations to refer to partial
+  // specializations we'll have to settle for all ref instances being
+  // friends with us.
+  template <typename T, typename Deleter>
+  friend class ref;
+
+protected:
+  // Specialization that provides some sanity checking when
+  // the caller is using a fixed-size array.
+  template <size_t N>
+  Operation(Opcode op, Type t, ref<Operation> (&operands)[N]);
+  Operation(Opcode op, Type t, ref<Operation>* operands);
+
+  Operation(Opcode op, const llvm::APInt& iconst);
+  Operation(Opcode op, llvm::APInt&& iconst);
+
+  Operation(Opcode op, const llvm::APFloat& fconst);
+  Operation(Opcode op, llvm::APFloat&& fconst);
+
+  Operation(Opcode op, Type t, const ref<Operation>& op0);
+  Operation(Opcode op, Type t, const ref<Operation>& op0,
+            const ref<Operation>& op1);
+  Operation(Opcode op, Type t, const ref<Operation>& op0,
+            const ref<Operation>& op1, const ref<Operation>& op2);
+
+  Operation();
+
+public:
+  /**
+   * Indicate whether this Operation instance is valid.
+   *
+   * It's not possible to construct an invalid instance directly but one
+   * can be created by moving out of an existing operation.
+   */
+  bool valid() const;
+
+  // Get the opcode
+  uint16_t opcode() const;
+
+  // Read-only access to the refcount. If this is 0 then this is not a
+  // reference-counted Operation instance.
+  uint32_t refcnt() const;
+
+  // The type of this operation node.
+  Type type() const;
+
+  /**
+   * Go from a pointer/cpp reference to a ref.
+   *
+   * This is only valid if the operation instance is already refcounted
+   * (i.e. refcnt() > 0). If not, then calling as_ref will cause an assertion
+   * failure.
+   */
+  ref<Operation> as_ref();
+  ref<const Operation> as_ref() const;
+
+  typedef detail::double_deref_iterator<ref<Operation>> operand_iterator;
+  typedef detail::double_deref_iterator<const ref<Operation>>
+      const_operand_iterator;
+
+  size_t num_operands() const;
+  llvm::iterator_range<operand_iterator> operands();
+  llvm::iterator_range<const_operand_iterator> operands() const;
+
+  bool operator==(const Operation& op) const;
+  bool operator!=(const Operation& op) const;
+
+  bool is_constant() const;
+
+  // Need to manually define these since we have an internal union.
+  Operation(const Operation& op) noexcept;
+  Operation(Operation&& op) noexcept;
+
+  Operation& operator=(const Operation& op) noexcept;
+  Operation& operator=(Operation&& op) noexcept;
+
+  ~Operation();
+
+private:
+  void invalidate() noexcept;
+};
+
+/**
+ * Integer constant.
+ *
+ * This represents a constant integer value in an expression.
+ * As an example, this would be the 2 in the expression 2 * x.
+ */
+class ConstantInt : public Operation {
+private:
+  ConstantInt(const llvm::APInt& iconst);
+  ConstantInt(llvm::APInt&& iconst);
+
+public:
+  llvm::APInt& value();
+  const llvm::APInt& value() const;
+
+  static ref<Operation> Create(const llvm::APInt& iconst);
+  static ref<Operation> Create(llvm::APInt&& iconst);
+
+  static bool classof(const Operation* op);
+};
+
+/**
+ * Floating point constant.
+ *
+ * This represents a constant floating point value in an expression.
+ * As an example, this would be the 2.0f in the expression 2.0f * x.
+ */
+class ConstantFloat : public Operation {
+private:
+  ConstantFloat(const llvm::APFloat& fconst);
+  ConstantFloat(llvm::APFloat&& fconst);
+
+public:
+  llvm::APFloat& value();
+  const llvm::APFloat& value() const;
+
+  static ref<Operation> Create(const llvm::APFloat& fconst);
+  static ref<Operation> Create(llvm::APFloat&& fconst);
+
+  static bool classof(const Operation* op);
+};
+
+/**
+ * Binary expression (e.g. +, -, etc.).
+ *
+ * Any more specific operations with 2 operands should inherit from this class.
+ */
+class BinaryOp : public Operation {
+protected:
+  BinaryOp(Opcode op, Type t, const ref<Operation>& lhs,
+           const ref<Operation>& rhs);
+
+public:
+  const ref<Operation>& lhs() const;
+  const ref<Operation>& rhs() const;
+
+  ref<Operation>& lhs();
+  ref<Operation>& rhs();
+
+  static ref<Operation> Create(Opcode op, const ref<Operation>& lhs,
+                               const ref<Operation>& rhs);
+
+  static ref<Operation> CreateAdd(const ref<Operation>& lhs,
+                                  const ref<Operation>& rhs);
+  static ref<Operation> CreateSub(const ref<Operation>& lhs,
+                                  const ref<Operation>& rhs);
+  static ref<Operation> CreateMul(const ref<Operation>& lhs,
+                                  const ref<Operation>& rhs);
+  static ref<Operation> CreateUDiv(const ref<Operation>& lhs,
+                                   const ref<Operation>& rhs);
+  static ref<Operation> CreateSDiv(const ref<Operation>& lhs,
+                                   const ref<Operation>& rhs);
+  static ref<Operation> CreateURem(const ref<Operation>& lhs,
+                                   const ref<Operation>& rhs);
+  static ref<Operation> CreateSRem(const ref<Operation>& lhs,
+                                   const ref<Operation>& rhs);
+
+  static ref<Operation> CreateAnd(const ref<Operation>& lhs,
+                                  const ref<Operation>& rhs);
+  static ref<Operation> CreateOr(const ref<Operation>& lhs,
+                                 const ref<Operation>& rhs);
+  static ref<Operation> CreateXor(const ref<Operation>& lhs,
+                                  const ref<Operation>& rhs);
+  static ref<Operation> CreateShl(const ref<Operation>& lhs,
+                                  const ref<Operation>& rhs);
+  static ref<Operation> CreateLShr(const ref<Operation>& lhs,
+                                   const ref<Operation>& rhs);
+  static ref<Operation> CreateAShr(const ref<Operation>& lhs,
+                                   const ref<Operation>& rhs);
+
+  static ref<Operation> CreateFAdd(const ref<Operation>& lhs,
+                                   const ref<Operation>& rhs);
+  static ref<Operation> CreateFSub(const ref<Operation>& lhs,
+                                   const ref<Operation>& rhs);
+  static ref<Operation> CreateFMul(const ref<Operation>& lhs,
+                                   const ref<Operation>& rhs);
+  static ref<Operation> CreateFDiv(const ref<Operation>& lhs,
+                                   const ref<Operation>& rhs);
+  static ref<Operation> CreateFRem(const ref<Operation>& lhs,
+                                   const ref<Operation>& rhs);
+
+  static bool classof(const Operation* op);
+};
+
+/**
+ * Unary operations (e.g. not and fneg).
+ *
+ * Any more specific unary operations should inherit from this class.
+ */
+class UnaryOp : public Operation {
+protected:
+  UnaryOp(Opcode op, Type t, const ref<Operation>& operand);
+
+public:
+  ref<Operation>& operand();
+  const ref<Operation>& operand() const;
+
+  static ref<Operation> Create(Opcode op, const ref<Operation>& operand);
+  static ref<Operation> CreateNot(const ref<Operation>& operand);
+  static ref<Operation> CreateFNeg(const ref<Operation>& operand);
+
+  static bool classof(const Operation* op);
+};
+
+/**
+ * Select instruction.
+ *
+ * Represented as
+ * select %cond, %true_value, %false_value
+ */
+class Select : public Operation {
+protected:
+  Select(Type t, const ref<Operation>& cond, const ref<Operation>& true_val,
+         const ref<Operation>& false_val);
+
+public:
+  ref<Operation>& condition();
+  ref<Operation>& true_value();
+  ref<Operation>& false_value();
+
+  const ref<Operation>& condition() const;
+  const ref<Operation>& true_value() const;
+  const ref<Operation>& false_value() const;
+
+  static ref<Operation> Create(const ref<Operation>& cond,
+                               const ref<Operation>& true_value,
+                               const ref<Operation>& false_value);
+
+  bool classof(const Operation* op);
+};
+
+} // namespace caffeine
+
+#include "caffeine/IR/Operation.inl"
+
+#endif

--- a/include/caffeine/IR/Operation.h
+++ b/include/caffeine/IR/Operation.h
@@ -64,7 +64,7 @@ enum class FCmpOpcode : uint8_t {
  * In general, an expression node has
  * 1. An opcode
  * 2. A type
- * 3. 0-3 opcodes
+ * 3. 0-3 operands
  *
  * The base operation class provides access to operands, types, and the
  * opcode. Custom payloads (e.g. for constants) can only be accessed by

--- a/include/caffeine/IR/Operation.inl
+++ b/include/caffeine/IR/Operation.inl
@@ -1,0 +1,266 @@
+
+#ifndef CAFFEINE_IR_OPERATION_INL
+#define CAFFEINE_IR_OPERATION_INL
+
+#include <type_traits>
+
+#include "caffeine/IR/Operation.h"
+
+/**
+ * This file is meant to hold one-liners so that they can be inlined.
+ * This way we still get the optimization advantages but they don't
+ * obscure the interface of the operation classes.
+ *
+ * If a method is either
+ *  - bigger than a few lines, or
+ *  - would need an extra header
+ * then it shouldn't go in this file and should instead be put within
+ * Operation.cpp so as to minimize compile time.
+ *
+ * The exception here is any template methods. Those should be declared
+ * in the header and defined here.
+ */
+
+namespace caffeine {
+
+// All derived operation types should be the same size
+static_assert(sizeof(ConstantInt) == sizeof(Operation));
+static_assert(sizeof(ConstantFloat) == sizeof(Operation));
+
+namespace detail {
+  template <typename T>
+  class double_deref_iterator {
+  private:
+    T* inner;
+
+    using self = double_deref_iterator<T>;
+
+  public:
+    using iterator_category = std::random_access_iterator_tag;
+    using value_type = std::remove_reference_t<decltype(*std::declval<T>())>;
+    using difference_type = std::ptrdiff_t;
+    using pointer = value_type*;
+    using reference = value_type&;
+
+    double_deref_iterator(T* inner) : inner(inner) {}
+
+    reference operator*() const {
+      return **inner;
+    }
+    pointer operator->() const {
+      return std::addressof(**inner);
+    }
+
+    self& operator++() {
+      inner++;
+      return *this;
+    }
+    self& operator--() {
+      inner--;
+      return *this;
+    }
+
+    self operator++(int) {
+      return self(inner++);
+    }
+    self operator--(int) {
+      return self(inner--);
+    }
+
+    self operator+(difference_type n) const {
+      return self(inner + n);
+    }
+    self operator-(difference_type n) const {
+      return self(inner - n);
+    }
+
+    self& operator+=(difference_type n) {
+      inner += n;
+      return *this;
+    }
+    self& operator-=(difference_type n) {
+      inner -= n;
+      return *this;
+    }
+
+    difference_type operator-(self b) const {
+      return self(inner - b.inner);
+    }
+
+    bool operator==(self b) const {
+      return inner == b.inner;
+    }
+    bool operator!=(self b) const {
+      return inner != b.inner;
+    }
+
+    bool operator<=(self b) const {
+      return inner <= b.inner;
+    }
+    bool operator>=(self b) const {
+      return inner >= b.inner;
+    }
+    bool operator<(self b) const {
+      return inner < b.inner;
+    }
+    bool operator>(self b) const {
+      return inner > b.inner;
+    }
+
+    reference operator[](difference_type n) const {
+      return *(*this + n);
+    }
+  };
+
+  template <typename T>
+  double_deref_iterator<T>
+  operator+(typename double_deref_iterator<T>::difference_type n,
+            double_deref_iterator<T> a) {
+    return a + n;
+  }
+} // namespace detail
+
+template <size_t N>
+Operation::Operation(Opcode op, Type t, ref<Operation> (&operands)[N])
+    : Operation(([&] {
+                  // Need the lambda so that this is evaluated before the
+                  // delegated constructor runs.
+                  CAFFEINE_ASSERT(((uint16_t)op & 0x3) <= N);
+                  return op;
+                })(),
+                t, (ref<Opcode>*)operands) {}
+
+inline bool Operation::valid() const {
+  return opcode_ != 0;
+}
+
+inline uint16_t Operation::opcode() const {
+  return opcode_;
+}
+
+inline uint32_t Operation::refcnt() const {
+  return refcount;
+}
+
+inline size_t Operation::num_operands() const {
+  return opcode_ & 0x3;
+}
+
+inline ref<Operation> Operation::as_ref() {
+  CAFFEINE_ASSERT(refcount != 0, "Unable to convert non-refcounted Operation "
+                                 "instance to a refcounted one");
+  return ref<Operation>(this);
+}
+inline ref<const Operation> Operation::as_ref() const {
+  CAFFEINE_ASSERT(refcount != 0, "Unable to convert non-refcounted Operation "
+                                 "instance to a refcounted one");
+  return ref<const Operation>(this);
+}
+
+inline llvm::iterator_range<Operation::operand_iterator> Operation::operands() {
+  return llvm::iterator_range<Operation::operand_iterator>{
+      operand_iterator(operands_),
+      operand_iterator(operands_ + num_operands())};
+}
+inline llvm::iterator_range<Operation::const_operand_iterator>
+Operation::operands() const {
+  return llvm::iterator_range<Operation::const_operand_iterator>{
+      const_operand_iterator(operands_),
+      const_operand_iterator(operands_ + num_operands())};
+}
+
+/***************************************************
+ * ConstantInt                                     *
+ ***************************************************/
+inline llvm::APInt& ConstantInt::value() {
+  return iconst_;
+}
+inline const llvm::APInt& ConstantInt::value() const {
+  return iconst_;
+}
+
+/***************************************************
+ * ConstantFloat                                   *
+ ***************************************************/
+inline llvm::APFloat& ConstantFloat::value() {
+  return fconst_;
+}
+inline const llvm::APFloat& ConstantFloat::value() const {
+  return fconst_;
+}
+
+/***************************************************
+ * BinaryOp                                        *
+ ***************************************************/
+inline const ref<Operation>& BinaryOp::lhs() const {
+  return operands_[0];
+}
+inline const ref<Operation>& BinaryOp::rhs() const {
+  return operands_[1];
+}
+
+inline ref<Operation>& BinaryOp::lhs() {
+  return operands_[0];
+}
+inline ref<Operation>& BinaryOp::rhs() {
+  return operands_[1];
+}
+
+/***************************************************
+ * UnaryOp                                         *
+ ***************************************************/
+inline ref<Operation>& UnaryOp::operand() {
+  return operands_[0];
+}
+inline const ref<Operation>& UnaryOp::operand() const {
+  return operands_[0];
+}
+
+/***************************************************
+ * Select                                          *
+ ***************************************************/
+inline ref<Operation>& Select::condition() {
+  return operands_[0];
+}
+inline ref<Operation>& Select::true_value() {
+  return operands_[1];
+}
+inline ref<Operation>& Select::false_value() {
+  return operands_[2];
+}
+
+inline const ref<Operation>& Select::condition() const {
+  return operands_[0];
+}
+inline const ref<Operation>& Select::true_value() const {
+  return operands_[1];
+}
+inline const ref<Operation>& Select::false_value() const {
+  return operands_[2];
+}
+
+/***************************************************
+ * classof method function impls                   *
+ ***************************************************/
+#define CAFFEINE_OP_DECL_CLASSOF(derived, opcode_)                             \
+  inline bool derived::classof(const Operation* op) {                          \
+    return op->opcode() == Operation::opcode_;                                 \
+  }                                                                            \
+  static_assert(true)
+
+CAFFEINE_OP_DECL_CLASSOF(ConstantInt, ConstantInt);
+CAFFEINE_OP_DECL_CLASSOF(ConstantFloat, ConstantFloat);
+CAFFEINE_OP_DECL_CLASSOF(Select, Select);
+
+inline bool BinaryOp::classof(const Operation* op) {
+  return op->num_operands() == 2;
+}
+inline bool UnaryOp::classof(const Operation* op) {
+  return op->num_operands() == 1;
+}
+
+#undef CAFFEINE_OP_DECL_CLASSOF
+
+} // namespace caffeine
+
+#endif

--- a/include/caffeine/IR/Type.h
+++ b/include/caffeine/IR/Type.h
@@ -1,0 +1,36 @@
+#ifndef CAFFEINE_IR_TYPE_H
+#define CAFFEINE_IR_TYPE_H
+
+#include <cstdint>
+
+namespace llvm {
+  class APInt;
+  class APFloat;
+}
+
+namespace caffeine {
+  
+/**
+ * TODO: Figure out representation here.
+ */
+class Type {
+private:
+public:
+  bool is_int() const;
+  bool is_fp() const;
+  bool is_pointer() const;
+
+  static Type int_ty(uint32_t bitwidth);
+  static Type void_ty();
+  static Type fp_ty(uint32_t exponent, uint32_t mantissa);
+
+  static Type type_of(const llvm::APInt& apint);
+  static Type type_of(const llvm::APFloat& apfloat);
+};
+
+bool operator==(const Type& a, const Type& b);
+bool operator!=(const Type& a, const Type& b);
+
+}
+
+#endif

--- a/include/caffeine/IR/Type.h
+++ b/include/caffeine/IR/Type.h
@@ -2,35 +2,93 @@
 #define CAFFEINE_IR_TYPE_H
 
 #include <cstdint>
+#include <optional>
+
+#include "caffeine/ADT/Ref.h"
 
 namespace llvm {
-  class APInt;
-  class APFloat;
-}
+class APInt;
+class APFloat;
+class Type;
+class FunctionType;
+class LLVMContext;
+} // namespace llvm
 
 namespace caffeine {
-  
+
 /**
- * TODO: Figure out representation here.
+ * Expression type.
+ *
+ * This is deliberately meant to be a simplification of LLVM's type hierachy. It
+ * has 5 main type kinds.
+ * - Void: An empty type. No expression node should have this type but it is
+ *   useful for marking an invalid node.
+ * - Integer: An integer type. Supports all integer bitwidths supported in LLVM.
+ * - Floating Point: A floating point type. Supports arbitrary exponent and
+ *   mantissa sizes up to 2^12 - 1. Note that the mantissa size includes the
+ *   leading 1 bit (this is implicit in the binary representation for IEEE 754).
+ * - Pointer: An untyped pointer. This is effectively an integer with a
+ *   target-defined width.
+ * - Function Pointer.
  */
 class Type {
-private:
 public:
+  enum Kind : uint8_t {
+    Void,
+    Integer,
+    FloatingPoint,
+    Pointer,
+    FunctionPointer
+  };
+
+private:
+  llvm::Type* llvm_;
+  uint32_t kind_ : 8;
+  uint32_t desc_ : 24;
+
+  Type(Kind kind, uint32_t desc, llvm::Type* inner = nullptr);
+
+public:
+  explicit Type(llvm::Type* type);
+
+  Kind kind() const;
+
+  bool is_void() const;
   bool is_int() const;
-  bool is_fp() const;
+  bool is_float() const;
   bool is_pointer() const;
+  bool is_function_pointer() const;
+
+  uint32_t bitwidth() const;
+  uint32_t mantissa_bits() const;
+  uint32_t exponent_bits() const;
+
+  // Signature of a function pointer.
+  llvm::FunctionType* signature() const;
 
   static Type int_ty(uint32_t bitwidth);
   static Type void_ty();
-  static Type fp_ty(uint32_t exponent, uint32_t mantissa);
+  static Type float_ty(uint32_t exponent, uint32_t mantissa);
+  // TODO: Address spaces? Not sure if we want to model them
+  static Type pointer_ty();
+
+  static Type from_llvm(llvm::Type* type);
 
   static Type type_of(const llvm::APInt& apint);
   static Type type_of(const llvm::APFloat& apfloat);
+
+  bool operator==(const Type& b) const;
+  bool operator!=(const Type& b) const;
+
+  Type(const Type&) = default;
+  Type(Type&&) = default;
+
+  Type& operator=(const Type&) = default;
+  Type& operator=(Type&&) = default;
 };
 
-bool operator==(const Type& a, const Type& b);
-bool operator!=(const Type& a, const Type& b);
+} // namespace caffeine
 
-}
+#include "caffeine/IR/Type.inl"
 
 #endif

--- a/include/caffeine/IR/Type.inl
+++ b/include/caffeine/IR/Type.inl
@@ -1,0 +1,51 @@
+#ifndef CAFFEINE_IR_TYPE_INL
+#define CAFFEINE_IR_TYPE_INL
+
+#include "caffeine/IR/Type.h"
+#include "caffeine/Support/Assert.h"
+
+namespace caffeine {
+
+Type::Kind Type::kind() const {
+  return static_cast<Kind>(kind_);
+}
+
+bool Type::is_int() const {
+  return kind() == Integer;
+}
+bool Type::is_float() const {
+  return kind() == FloatingPoint;
+}
+bool Type::is_pointer() const {
+  return kind() == Pointer;
+}
+bool Type::is_void() const {
+  return kind() == Void;
+}
+bool Type::is_function_pointer() const {
+  return kind() == FunctionPointer;
+}
+
+uint32_t Type::bitwidth() const {
+  CAFFEINE_ASSERT(is_int());
+  return desc_;
+}
+uint32_t Type::mantissa_bits() const {
+  CAFFEINE_ASSERT(is_float());
+  return desc_ & 0xFFF;
+}
+uint32_t Type::exponent_bits() const {
+  CAFFEINE_ASSERT(is_float());
+  return desc_ >> 12;
+}
+
+bool Type::operator==(const Type& b) const {
+  return kind_ == b.kind_ && desc_ == b.desc_ && llvm_ == b.llvm_;
+}
+bool Type::operator!=(const Type& b) const {
+  return !(*this == b);
+}
+
+}
+
+#endif

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,6 +1,7 @@
 
 file(
   GLOB_RECURSE sources
+  CONFIGURE_DEPENDS
   *.cpp
   *.hpp
   *.h
@@ -8,6 +9,7 @@ file(
 
 file(
   GLOB_RECURSE headers
+  CONFIGURE_DEPENDS
   "${CMAKE_SOURCE_DIR}/include/*.hpp"
   "${CMAKE_SOURCE_DIR}/include/*.h"
   "${CMAKE_SOURCE_DIR}/include/*.inl"
@@ -17,5 +19,13 @@ add_library(caffeine STATIC ${sources} ${headers})
 
 target_include_directories(caffeine 
   PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}"
-  PUBLIC "${CMAKE_SOURCE_DIR}/include"
+  PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/../include"
+)
+
+# The SYSTEM should silence warnings within these headers
+target_include_directories(caffeine SYSTEM
+  PUBLIC "${LLVM_INCLUDE_DIRS}"
+  PUBLIC "${Z3_INCLUDE_DIRS}"
+  PUBLIC "${FMT_INCLUDE_DIRS}"
+  PUBLIC "${Boost_INCLUDE_DIRS}"
 )

--- a/src/IR/Operation.cpp
+++ b/src/IR/Operation.cpp
@@ -255,7 +255,7 @@ ref<Operation> BinaryOp::Create(Opcode op, const ref<Operation>& lhs,
 }
 
 #define ASSERT_INT(op) CAFFEINE_ASSERT((op)->type().is_int())
-#define ASSERT_FP(op) CAFFEINE_ASSERT((op)->type().is_fp())
+#define ASSERT_FP(op) CAFFEINE_ASSERT((op)->type().is_float())
 
 // There's a lot of these so template them out using a macro
 #define DECL_BINOP_CREATE(opcode, assert)                                      \
@@ -369,7 +369,7 @@ ref<Operation> FCmpOp::CreateFCmp(FCmpOpcode cmp, const ref<Operation>& lhs,
   CAFFEINE_ASSERT(lhs, "lhs was null");
   CAFFEINE_ASSERT(rhs->type() == lhs->type(),
                   "cannot compare icmp operands with different types");
-  CAFFEINE_ASSERT(lhs->type().is_fp(),
+  CAFFEINE_ASSERT(lhs->type().is_float(),
                   "icmp can only be created with integer operands");
 
   return ref<Operation>(new FCmpOp(cmp, lhs->type(), lhs, rhs));

--- a/src/IR/Operation.cpp
+++ b/src/IR/Operation.cpp
@@ -1,0 +1,305 @@
+#include "caffeine/IR/Operation.h"
+
+namespace caffeine {
+
+Operation::Operation() : opcode_(Invalid), type_(Type::void_ty()) {}
+
+// clang-format off
+Operation::Operation(Opcode op, Type t, ref<Operation>* operands)
+    : opcode_(static_cast<uint16_t>(op)),
+      type_(t), operands_{(opcode_ & 0x3) > 0 ? operands[0] : ref<Operation>(),
+                          (opcode_ & 0x3) > 1 ? operands[0] : ref<Operation>(),
+                          (opcode_ & 0x3) > 2 ? operands[0] : ref<Operation>()} 
+{
+  CAFFEINE_ASSERT((opcode_ >> 6) != 1,
+                  "Tried to create a constant with operands");
+  // Don't use this constructor to create an invalid opcode.
+  // It'll mess up constructors and destructors.
+  CAFFEINE_ASSERT(op != Invalid);
+  // No opcodes have > 3 operands
+  CAFFEINE_ASSERT(num_operands() <= 3, "Invalid opcode");
+}
+// clang-format on
+
+Operation::Operation(Opcode op, const llvm::APInt& iconst)
+    : opcode_(op), type_(Type::type_of(iconst)), iconst_(iconst) {
+  // Currently only ConstantInt is valid here
+  CAFFEINE_ASSERT(op == ConstantInt);
+}
+Operation::Operation(Opcode op, llvm::APInt&& iconst)
+    : opcode_(op), type_(Type::type_of(iconst)), iconst_(iconst) {
+  // Currently only ConstantInt is valid here
+  CAFFEINE_ASSERT(op == ConstantInt);
+}
+
+Operation::Operation(Opcode op, const llvm::APFloat& fconst)
+    : opcode_(op), type_(Type::type_of(fconst)), fconst_(fconst) {
+  CAFFEINE_ASSERT(op == ConstantFloat);
+}
+Operation::Operation(Opcode op, llvm::APFloat&& fconst)
+    : opcode_(op), type_(Type::type_of(fconst)), fconst_(fconst) {
+  CAFFEINE_ASSERT(op == ConstantFloat);
+}
+
+Operation::Operation(const Operation& op) noexcept
+    : opcode_(op.opcode_), type_(op.type_) {
+  if (is_constant()) {
+    switch (opcode_) {
+    case ConstantInt:
+      new (&iconst_) llvm::APInt(op.iconst_);
+      break;
+    case ConstantFloat:
+      new (&fconst_) llvm::APFloat(op.fconst_);
+      break;
+    default:
+      CAFFEINE_UNREACHABLE();
+    }
+  } else {
+    new (&operands_[0]) ref<Operation>(op.operands_[0]);
+    new (&operands_[1]) ref<Operation>(op.operands_[1]);
+    new (&operands_[2]) ref<Operation>(op.operands_[2]);
+  }
+}
+Operation::Operation(Operation&& op) noexcept
+    : opcode_(op.opcode_), type_(op.type_) {
+  if (is_constant()) {
+    switch (opcode_) {
+    case ConstantInt:
+      new (&iconst_) llvm::APInt(std::move(op.iconst_));
+      break;
+    case ConstantFloat:
+      new (&fconst_) llvm::APFloat(std::move(op.fconst_));
+      break;
+    default:
+      CAFFEINE_UNREACHABLE();
+    }
+  } else {
+    new (&operands_[0]) ref<Operation>(std::move(op.operands_[0]));
+    new (&operands_[1]) ref<Operation>(std::move(op.operands_[1]));
+    new (&operands_[2]) ref<Operation>(std::move(op.operands_[2]));
+  }
+}
+
+Operation::Operation(Opcode op, Type t, const ref<Operation>& op0)
+    : opcode_(static_cast<uint16_t>(op)),
+      type_(t), operands_{op0, ref<Operation>(), ref<Operation>()} {
+  CAFFEINE_ASSERT((opcode_ >> 6) != 1,
+                  "Tried to create a constant with operands");
+  CAFFEINE_ASSERT(num_operands() == 1);
+}
+Operation::Operation(Opcode op, Type t, const ref<Operation>& op0,
+                     const ref<Operation>& op1)
+    : opcode_(static_cast<uint16_t>(op)),
+      type_(t), operands_{op0, op1, ref<Operation>()} {
+  CAFFEINE_ASSERT((opcode_ >> 6) != 1,
+                  "Tried to create a constant with operands");
+  CAFFEINE_ASSERT(num_operands() == 2);
+}
+Operation::Operation(Opcode op, Type t, const ref<Operation>& op0,
+                     const ref<Operation>& op1, const ref<Operation>& op2)
+    : opcode_(static_cast<uint16_t>(op)), type_(t), operands_{op0, op1, op2} {
+  CAFFEINE_ASSERT((opcode_ >> 6) != 1,
+                  "Tried to create a constant with operands");
+  CAFFEINE_ASSERT(num_operands() == 3);
+}
+
+Operation& Operation::operator=(const Operation& op) noexcept {
+  invalidate();
+
+  opcode_ = op.opcode_;
+  type_ = op.type_;
+  if (is_constant()) {
+    switch (opcode_) {
+    case ConstantInt:
+      new (&iconst_) llvm::APInt(op.iconst_);
+      break;
+    case ConstantFloat:
+      new (&fconst_) llvm::APFloat(op.fconst_);
+      break;
+    default:
+      CAFFEINE_UNREACHABLE();
+    }
+  } else {
+    new (&operands_[0]) ref<Operation>(op.operands_[0]);
+    new (&operands_[1]) ref<Operation>(op.operands_[1]);
+    new (&operands_[2]) ref<Operation>(op.operands_[2]);
+  }
+
+  return *this;
+}
+Operation& Operation::operator=(Operation&& op) noexcept {
+  invalidate();
+
+  opcode_ = op.opcode_;
+  type_ = op.type_;
+  if (is_constant()) {
+    switch (opcode_) {
+    case ConstantInt:
+      new (&iconst_) llvm::APInt(std::move(op.iconst_));
+      break;
+    case ConstantFloat:
+      new (&fconst_) llvm::APFloat(std::move(op.fconst_));
+      break;
+    default:
+      CAFFEINE_UNREACHABLE();
+    }
+  } else {
+    new (&operands_[0]) ref<Operation>(std::move(op.operands_[0]));
+    new (&operands_[1]) ref<Operation>(std::move(op.operands_[1]));
+    new (&operands_[2]) ref<Operation>(std::move(op.operands_[2]));
+  }
+
+  return *this;
+}
+
+Operation::~Operation() {
+  invalidate();
+}
+
+void Operation::invalidate() noexcept {
+  if (is_constant()) {
+    switch (opcode_) {
+    case ConstantInt:
+      iconst_.~APInt();
+      break;
+    case ConstantFloat:
+      fconst_.~APFloat();
+      break;
+    default:
+      CAFFEINE_UNREACHABLE();
+    }
+  } else {
+    operands_[0].~ref();
+    operands_[1].~ref();
+    operands_[2].~ref();
+  }
+
+  opcode_ = Invalid;
+}
+
+/***************************************************
+ * ConstantInt                                     *
+ ***************************************************/
+ConstantInt::ConstantInt(const llvm::APInt& iconst)
+    : Operation(Operation::ConstantInt, iconst) {}
+ConstantInt::ConstantInt(llvm::APInt&& iconst)
+    : Operation(Operation::ConstantInt, iconst) {}
+
+ref<Operation> ConstantInt::Create(const llvm::APInt& iconst) {
+  return ref<Operation>(new ConstantInt(iconst));
+}
+ref<Operation> ConstantInt::Create(llvm::APInt&& iconst) {
+  return ref<Operation>(new ConstantInt(iconst));
+}
+
+/***************************************************
+ * ConstantFloat                                   *
+ ***************************************************/
+ConstantFloat::ConstantFloat(const llvm::APFloat& fconst)
+    : Operation(Operation::ConstantFloat, fconst) {}
+ConstantFloat::ConstantFloat(llvm::APFloat&& fconst)
+    : Operation(Operation::ConstantFloat, fconst) {}
+
+ref<Operation> ConstantFloat::Create(const llvm::APFloat& fconst) {
+  return ref<Operation>(new ConstantFloat(fconst));
+}
+ref<Operation> ConstantFloat::Create(llvm::APFloat&& fconst) {
+  return ref<Operation>(new ConstantFloat(fconst));
+}
+
+/***************************************************
+ * BinaryOp                                        *
+ ***************************************************/
+BinaryOp::BinaryOp(Opcode op, Type t, const ref<Operation>& lhs,
+                   const ref<Operation>& rhs)
+    : Operation(op, t, lhs, rhs) {}
+
+ref<Operation> BinaryOp::Create(Opcode op, const ref<Operation>& lhs,
+                                const ref<Operation>& rhs) {
+  CAFFEINE_ASSERT((op & 0x3) == 2, "Opcode doesn't have 2 operands");
+  CAFFEINE_ASSERT(lhs, "lhs was null");
+  CAFFEINE_ASSERT(rhs, "rhs was null");
+  CAFFEINE_ASSERT(lhs->type() == rhs->type(),
+                  "BinaryOp created from operands with different types");
+
+  return ref<Operation>(new BinaryOp(op, lhs->type(), lhs, rhs));
+}
+
+#define ASSERT_INT(op) CAFFEINE_ASSERT((op)->type().is_int())
+#define ASSERT_FP(op) CAFFEINE_ASSERT((op)->type().is_fp())
+
+// There's a lot of these so template them out using a macro
+#define DECL_BINOP_CREATE(opcode, assert)                                      \
+  ref<Operation> BinaryOp::Create##opcode(const ref<Operation>& lhs,           \
+                                          const ref<Operation>& rhs) {         \
+    CAFFEINE_ASSERT(lhs, "lhs was null");                                      \
+    CAFFEINE_ASSERT(rhs, "rhs was null");                                      \
+    assert(lhs);                                                               \
+    assert(rhs);                                                               \
+                                                                               \
+    return Create(Opcode::opcode, lhs, rhs);                                   \
+  }                                                                            \
+  static_assert(true)
+
+DECL_BINOP_CREATE(Add, ASSERT_INT);
+DECL_BINOP_CREATE(Sub, ASSERT_INT);
+DECL_BINOP_CREATE(Mul, ASSERT_INT);
+DECL_BINOP_CREATE(UDiv, ASSERT_INT);
+DECL_BINOP_CREATE(SDiv, ASSERT_INT);
+DECL_BINOP_CREATE(URem, ASSERT_INT);
+DECL_BINOP_CREATE(SRem, ASSERT_INT);
+
+DECL_BINOP_CREATE(And, ASSERT_INT);
+DECL_BINOP_CREATE(Or, ASSERT_INT);
+DECL_BINOP_CREATE(Xor, ASSERT_INT);
+DECL_BINOP_CREATE(Shl, ASSERT_INT);
+DECL_BINOP_CREATE(LShr, ASSERT_INT);
+DECL_BINOP_CREATE(AShr, ASSERT_INT);
+
+DECL_BINOP_CREATE(FAdd, ASSERT_FP);
+DECL_BINOP_CREATE(FSub, ASSERT_FP);
+DECL_BINOP_CREATE(FMul, ASSERT_FP);
+DECL_BINOP_CREATE(FDiv, ASSERT_FP);
+DECL_BINOP_CREATE(FRem, ASSERT_FP);
+
+/***************************************************
+ * UnaryOp                                         *
+ ***************************************************/
+UnaryOp::UnaryOp(Opcode op, Type t, const ref<Operation>& operand)
+    : Operation(op, t, operand) {}
+
+#define DECL_UNOP_CREATE(opcode, assert)                                       \
+  ref<Operation> UnaryOp::Create##opcode(const ref<Operation>& operand) {      \
+    CAFFEINE_ASSERT(operand, "operand was null");                              \
+    assert(operand);                                                           \
+                                                                               \
+    return Create(Opcode::opcode, operand);                                    \
+  }                                                                            \
+  static_assert(true)
+
+DECL_UNOP_CREATE(Not, ASSERT_INT);
+DECL_UNOP_CREATE(FNeg, ASSERT_FP);
+
+/***************************************************
+ * Select                                          *
+ ***************************************************/
+Select::Select(Type t, const ref<Operation>& cond,
+               const ref<Operation>& true_val, const ref<Operation>& false_val)
+    : Operation(Opcode::Select, t, cond, true_val, false_val) {}
+
+ref<Operation> Select::Create(const ref<Operation>& cond,
+                              const ref<Operation>& true_value,
+                              const ref<Operation>& false_value) {
+  CAFFEINE_ASSERT(cond, "cond was null");
+  CAFFEINE_ASSERT(true_value, "true_value was null");
+  CAFFEINE_ASSERT(false_value, "false_value was null");
+
+  CAFFEINE_ASSERT(cond->type() == Type::int_ty(1),
+                  "select condition was not an i1");
+  CAFFEINE_ASSERT(true_value->type() == false_value->type(),
+                  "select values had different types");
+
+  return new Select(true_value->type(), cond, true_value, false_value);
+}
+
+} // namespace caffeine

--- a/src/IR/Type.cpp
+++ b/src/IR/Type.cpp
@@ -1,0 +1,114 @@
+#include "caffeine/IR/Type.h"
+
+#include <llvm/ADT/APFloat.h>
+#include <llvm/ADT/APInt.h>
+#include <llvm/IR/LLVMContext.h>
+#include <llvm/IR/Type.h>
+#include <llvm/IR/DerivedTypes.h>
+
+using llvm::LLVMContext;
+
+namespace caffeine {
+
+Type::Type(Kind kind, uint32_t desc, llvm::Type* inner)
+    : llvm_(inner), kind_(kind), desc_(desc) {
+  CAFFEINE_ASSERT(desc < (UINT32_C(1) << 24));
+}
+
+Type::Type(llvm::Type* type) : Type(Type::from_llvm(type)) {}
+
+Type Type::int_ty(uint32_t bitwidth) {
+  CAFFEINE_ASSERT(bitwidth != 0 && bitwidth < (UINT32_C(1) << 24));
+  return Type(Integer, bitwidth);
+}
+
+Type Type::void_ty() {
+  return Type(Void, 0);
+}
+
+Type Type::float_ty(uint32_t exponent, uint32_t mantissa) {
+  CAFFEINE_ASSERT(exponent != 0 && exponent < (UINT32_C(1) << 12));
+  CAFFEINE_ASSERT(mantissa != 0 && mantissa < (UINT32_C(1) << 12));
+
+  return Type(FloatingPoint, (exponent << 12) | mantissa);
+}
+
+Type Type::pointer_ty() {
+  return Type(Pointer, 0);
+}
+
+llvm::FunctionType* Type::signature() const {
+  CAFFEINE_ASSERT(is_function_pointer());
+
+  auto fnty = llvm::dyn_cast_or_null<llvm::FunctionType>(llvm_);
+  CAFFEINE_ASSERT(fnty, "function type didn't contain a signature");
+
+  return fnty;
+}
+
+Type Type::type_of(const llvm::APInt& apint) {
+  return Type::int_ty(apint.getBitWidth());
+}
+Type Type::type_of(const llvm::APFloat& apfloat) {
+  using llvm::APFloat;
+
+  const llvm::fltSemantics& semantics = apfloat.getSemantics();
+
+  uint32_t mantissa = APFloat::semanticsPrecision(semantics);
+  uint32_t exponent = APFloat::semanticsSizeInBits(semantics) - mantissa;
+
+  return Type::float_ty(exponent, mantissa);
+}
+
+Type Type::from_llvm(llvm::Type* type) {
+  CAFFEINE_ASSERT(!type->isVectorTy(),
+                  "vector types are not supported in expressions");
+  CAFFEINE_ASSERT(!type->isTokenTy(),
+                  "token types are not supported in expressions");
+  CAFFEINE_ASSERT(!type->isMetadataTy(),
+                  "metadata types are not supported in expressions");
+  CAFFEINE_ASSERT(!type->isLabelTy(),
+                  "label types are not supported in expressions");
+  // Note: we can have pointers to structs, arrays, functions, etc. but
+  //       we can't represent them directly.
+  CAFFEINE_ASSERT(!type->isStructTy(),
+                  "struct types are not supported in expressions");
+  CAFFEINE_ASSERT(!type->isFunctionTy(),
+                  "functions can only be used as function pointer types");
+  CAFFEINE_ASSERT(!type->isArrayTy(),
+                  "array types are not supported in expressions");
+
+  if (type->isVoidTy())
+    return Type::void_ty();
+
+  // Handle floating point types
+  if (type->isHalfTy())
+    return Type::float_ty(5, 11);
+  if (type->isFloatTy())
+    return Type::float_ty(8, 24);
+  if (type->isDoubleTy())
+    return Type::float_ty(11, 53);
+  if (type->isFP128Ty())
+    return Type::float_ty(15, 113);
+  if (type->isX86_FP80Ty())
+    return Type::float_ty(15, 64);
+  // Not entirely sure how the PPC implements it's FP128 type.
+  // Leave it out for now.
+  if (type->isPPC_FP128Ty())
+    CAFFEINE_UNIMPLEMENTED();
+
+  if (type->isIntegerTy())
+    return Type::int_ty(type->getIntegerBitWidth());
+
+  if (type->isPointerTy()) {
+    auto contained = type->getContainedType(0);
+
+    if (contained->isFunctionTy())
+      return Type(FunctionPointer, 0, contained);
+    return Type(Pointer, 0);
+  }
+
+  CAFFEINE_UNIMPLEMENTED();
+}
+
+} // namespace caffeine

--- a/test/unit/ADT/Ref.cpp
+++ b/test/unit/ADT/Ref.cpp
@@ -1,0 +1,94 @@
+
+#include "caffeine/ADT/Ref.h"
+
+#include <gtest/gtest.h>
+
+#include <cstdint>
+
+using namespace caffeine;
+
+class tracking_refcountable {
+public:
+  uint32_t* copy_ctr;
+  uint32_t* dtor_ctr;
+  mutable uint32_t refcount = 0;
+
+  tracking_refcountable(uint32_t* copy_ctr, uint32_t* dtor_ctr)
+      : copy_ctr(copy_ctr), dtor_ctr(dtor_ctr) {}
+  ~tracking_refcountable() {
+    if (dtor_ctr) {
+      ++*dtor_ctr;
+    }
+  }
+
+  tracking_refcountable(const tracking_refcountable& ref)
+      : copy_ctr(ref.copy_ctr), dtor_ctr(ref.dtor_ctr) {
+    if (copy_ctr) {
+      ++*copy_ctr;
+    }
+  }
+};
+
+TEST(adt_ref, ctor_dtor_correct) {
+  uint32_t cctr1 = 0, cctr2 = 0;
+  uint32_t dctr1 = 0, dctr2 = 0;
+
+  {
+    auto ref1 = make_ref<tracking_refcountable>(&cctr1, &dctr1);
+    auto ref2 = make_ref<tracking_refcountable>(&cctr2, &dctr2);
+
+    // Should be able to implicitly cast to const ref
+    ref<const tracking_refcountable> cref = ref1;
+
+    ASSERT_EQ(ref1->refcount, 2);
+    ASSERT_EQ(ref2->refcount, 1);
+    ASSERT_NE(ref1, ref2);
+
+    auto otherref = ref2;
+    otherref = ref1;
+    ref2 = ref1;
+
+    ASSERT_EQ(dctr1, 0);
+    ASSERT_EQ(dctr2, 1);
+    ASSERT_EQ(ref1, ref2);
+  }
+
+  ASSERT_EQ(dctr1, 1);
+  ASSERT_EQ(dctr2, 1);
+
+  ASSERT_EQ(cctr1, 0);
+  ASSERT_EQ(cctr2, 0);
+}
+
+TEST(adt_ref, take) {
+  uint32_t dctr = 0;
+  auto ref = make_ref<tracking_refcountable>(nullptr, &dctr);
+
+  ASSERT_EQ(ref->refcount, 1);
+
+  auto* raw = ref.take();
+
+  ASSERT_EQ(dctr, 0);
+  ASSERT_TRUE(!ref);
+  ASSERT_TRUE(raw);
+  ASSERT_EQ(raw->refcount, 1);
+
+  delete raw;
+
+  ASSERT_EQ(dctr, 1);
+}
+
+TEST(adt_ref, from_raw) {
+  uint32_t dctr = 0;
+  auto ptr = new tracking_refcountable(nullptr, &dctr);
+  ptr->refcount = 1;
+  auto val = ref<tracking_refcountable>::from_raw(ptr);
+
+  ASSERT_EQ(val->refcount, 1);
+  ASSERT_EQ(val.refcount(), 1);
+  ASSERT_EQ(dctr, 0);
+
+  val = nullptr;
+
+  ASSERT_EQ(dctr, 1);
+}


### PR DESCRIPTION
This PR adds the expression IR. The design is (loosely) based off of the way LLVM's IR works but with a few key differences:
1. Everything is done through intrusive reference-counted pointers.
2. All IR nodes have exactly the same size and fields (so that they can be serialized to an array).

At the center of the design there are two main classes.
- The `Type` class represents the type of a value. It is currently stubbed out so I'll expand on this more once I've written the code for it.
- The `Operation` class represents an expression node. It consists of an opcode, a type, 0-3 operands, and in some cases, some constant data.

There are also a number of derived operation types that offer named accessors to the operands (e.g. `lhs` and `rhs` for BinaryOp).