### PR TITLE
Implement solver API

### DIFF
--- a/include/caffeine/IR/Assertion.h
+++ b/include/caffeine/IR/Assertion.h
@@ -1,0 +1,29 @@
+#ifndef CAFFEINE_IR_ASSERTION_H
+#define CAFFEINE_IR_ASSERTION_H
+
+#include "caffeine/IR/Operation.h"
+
+namespace caffeine {
+
+class Assertion {
+private:
+  ref<Operation> value_;
+
+public:
+  Assertion() = default;
+  Assertion(const ref<Operation>& value);
+
+  ref<Operation>& value() &;
+  ref<Operation>&& value() &&;
+  const ref<Operation>& value() const&;
+  const ref<Operation>&& value() const&&;
+
+  bool is_empty() const;
+  bool is_constant() const;
+};
+
+} // namespace caffeine
+
+#include "caffeine/IR/Assertion.inl"
+
+#endif

--- a/include/caffeine/IR/Assertion.h
+++ b/include/caffeine/IR/Assertion.h
@@ -5,6 +5,12 @@
 
 namespace caffeine {
 
+/**
+ * An expression that has boolean (i1) type. Optionally, it can be empty which
+ * is semantically equivalent to a constant `true` value.
+ *
+ * These are what is actually passed in to the solver.
+ */
 class Assertion {
 private:
   ref<Operation> value_;

--- a/include/caffeine/IR/Assertion.inl
+++ b/include/caffeine/IR/Assertion.inl
@@ -1,0 +1,27 @@
+#ifndef CAFFEINE_IR_ASSERTION_INL
+#define CAFFEINE_IR_ASSERTION_INL
+
+#include "caffeine/IR/Assertion.h"
+
+namespace caffeine {
+
+inline ref<Operation>& Assertion::value() & {
+  return value_;
+}
+inline ref<Operation>&& Assertion::value() && {
+  return std::move(value_);
+}
+inline const ref<Operation>& Assertion::value() const& {
+  return value_;
+}
+inline const ref<Operation>&& Assertion::value() const&& {
+  return std::move(value_);
+}
+
+inline bool Assertion::is_empty() const {
+  return !value_;
+}
+
+} // namespace caffeine
+
+#endif

--- a/include/caffeine/IR/Operation.h
+++ b/include/caffeine/IR/Operation.h
@@ -2,6 +2,7 @@
 #define CAFFEINE_IR_OPERATION_H
 
 #include <cstdint>
+#include <string>
 
 #include <llvm/ADT/APFloat.h>
 #include <llvm/ADT/APInt.h>
@@ -101,6 +102,7 @@ public:
     Invalid = 0,
 
     // Constants
+    Constant = detail::opcode(1, 0, 2),
     ConstantInt = detail::opcode(1, 0, 0),
     ConstantFloat = detail::opcode(1, 0, 1),
 
@@ -188,6 +190,7 @@ protected:
     ref<Operation> operands_[3];
     llvm::APInt iconst_;
     llvm::APFloat fconst_;
+    std::string name_;
   };
 
   // So ref can get at the refcount field.
@@ -211,6 +214,8 @@ protected:
 
   Operation(Opcode op, const llvm::APFloat& fconst);
   Operation(Opcode op, llvm::APFloat&& fconst);
+
+  Operation(Opcode op, Type t, const std::string& name);
 
   Operation(Opcode op, Type t, const ref<Operation>& op0);
   Operation(Opcode op, Type t, const ref<Operation>& op0,
@@ -281,6 +286,24 @@ protected:
 
 private:
   void invalidate() noexcept;
+};
+
+/**
+ * 
+ */
+class Constant : public Operation {
+private:
+  Constant(Type t, const std::string& name);
+  Constant(Type t, std::string&& name);
+
+public:
+  std::string& name();
+  const std::string& name() const;
+
+  static ref<Operation> Create(Type t, const std::string& name);
+  static ref<Operation> Create(Type t, std::string&& name);
+
+  static bool classof(const Operation* op);
 };
 
 /**

--- a/include/caffeine/IR/Operation.h
+++ b/include/caffeine/IR/Operation.h
@@ -289,7 +289,9 @@ private:
 };
 
 /**
+ * Symbolic constant.
  * 
+ * Symbolic constants are uniquely identified by a string name.
  */
 class Constant : public Operation {
 private:

--- a/include/caffeine/IR/Operation.inl
+++ b/include/caffeine/IR/Operation.inl
@@ -26,6 +26,10 @@ namespace caffeine {
 // All derived operation types should be the same size
 static_assert(sizeof(ConstantInt) == sizeof(Operation));
 static_assert(sizeof(ConstantFloat) == sizeof(Operation));
+static_assert(sizeof(Constant) == sizeof(Operation));
+static_assert(sizeof(BinaryOp) == sizeof(Operation));
+static_assert(sizeof(UnaryOp) == sizeof(Operation));
+static_assert(sizeof(SelectOp) == sizeof(Operation));
 
 namespace detail {
   template <typename T>
@@ -177,8 +181,18 @@ inline Type Operation::type() const {
 }
 
 inline bool Operation::is_constant() const {
-  // Needs to be updated if constant opcode representation changes 
+  // Needs to be updated if constant opcode representation changes
   return (opcode_ >> 6) == 1;
+}
+
+/***************************************************
+ * Constant                                        *
+ ***************************************************/
+inline std::string& Constant::name() {
+  return name_;
+}
+inline const std::string& Constant::name() const {
+  return name_;
 }
 
 /***************************************************
@@ -292,6 +306,7 @@ inline bool FCmpOp::is_unordered() const {
 
 CAFFEINE_OP_DECL_CLASSOF(ConstantInt, ConstantInt);
 CAFFEINE_OP_DECL_CLASSOF(ConstantFloat, ConstantFloat);
+CAFFEINE_OP_DECL_CLASSOF(Constant, Constant);
 CAFFEINE_OP_DECL_CLASSOF(SelectOp, Select);
 
 inline bool BinaryOp::classof(const Operation* op) {

--- a/include/caffeine/Solver/Solver.h
+++ b/include/caffeine/Solver/Solver.h
@@ -1,0 +1,138 @@
+#ifndef CAFFEINE_SOLVER_SOLVER_H
+#define CAFFEINE_SOLVER_SOLVER_H
+
+#include <memory>
+#include <string_view>
+#include <vector>
+
+#include "caffeine/ADT/Ref.h"
+
+namespace caffeine {
+
+class Assertion;
+class Operation;
+
+enum SolverResult { UNSAT, SAT, Unknown };
+
+/**
+ * A set of concrete value assignments to constants that satisfy the set of
+ * assertions passed to a solver.
+ *
+ * In the case of the model being UNSAT or Unknown there are no such possible
+ * assignments and so trying to use them is an error.
+ */
+class Model {
+private:
+  SolverResult result_;
+
+public:
+  Model(SolverResult result);
+  virtual ~Model() = default;
+
+  SolverResult result() const {
+    return result_;
+  }
+
+  /**
+   * Evaluate an expression using this model. Returns an appropriate constant
+   * expression (i.e. is_constant returns true) with the value of said constant.
+   *
+   * It is invalid to call this method if the model is not SAT.
+   */
+  virtual ref<Operation> evaluate(const ref<Operation>& expr) const = 0;
+
+  /**
+   * Look up the value of a symbolic constant in this model. Returns an
+   * appropriate constant expression with the value of said constant.
+   *
+   * If there are no constants with the given name then returns a null pointer.
+   *
+   * It is invalid to call this method if the model is not SAT.
+   */
+  virtual ref<Operation> lookup(std::string_view name) const = 0;
+
+protected:
+  Model(const Model&) = default;
+  Model(Model&&) = default;
+
+  Model& operator=(const Model&) = default;
+  Model& operator=(Model&&) = default;
+};
+
+/**
+ * SAT solver interface.
+ *
+ * TODO: Better explanation of how it should usually be used.
+ */
+class Solver {
+public:
+  Solver() = default;
+  virtual ~Solver() = default;
+
+  /**
+   * Validate whether the set of assertions combined with the extra assertion,
+   * if it isn't empty, is satisfiable.
+   *
+   * Solvers are free to perform any modifications to the assertions vector
+   * provided as long as they
+   * 1. don't change the satisfiability of the end result or the space of valid
+   *    models, and
+   * 2. don't incorporate any information from `extra`. As an example, if the
+   *    assertion vector contains `x < 5` and `x = 2` then it would be valid to
+   *    simplify that to `true` and `x = 2`. But if extra is `x = 2` then it
+   *    wouldn't be valid to perform that simplification. Note, however, that
+   *    the final SAT/UNSAT result should take extra into account.
+   *
+   * This includes modifying the backing expression trees and so on. Note that
+   * care must be taken not to modify expressions that have multiple references
+   * (refcount > 1) as that could modify unrelated expressions.
+   *
+   * Default Implementation
+   * ======================
+   * By default this is implemented by calling resolve and then throwing away
+   * the model.
+   *
+   * Solver adapters should forward this method (after performing any applicable
+   * modifications to the assertions) as it may be more efficient for some
+   * solvers.
+   */
+  virtual SolverResult check(std::vector<Assertion>& assertions,
+                             const Assertion& extra);
+  // Calls check with an empty extra assertion.
+  SolverResult check(std::vector<Assertion>& assertions);
+
+  /**
+   * Validate whether the set of assertions combined with the extra assertion,
+   * if it isn't empty, is satisfiable and return a model.
+   *
+   * Solvers are free to perform any modifications to the assertions vector
+   * provided as long as they
+   * 1. don't change the satisfiability of the end result or the space of valid
+   *    models, and
+   * 2. don't incorporate any information from `extra`. As an example, if the
+   *    assertion vector contains `x < 5` and `x = 2` then it would be valid to
+   *    simplify that to `true` and `x = 2`. But if extra is `x = 2` then it
+   *    wouldn't be valid to perform that simplification. Note, however, that
+   *    the final SAT/UNSAT result should take extra into account.
+   *
+   * This includes modifying the backing expression trees and so on. Note that
+   * care must be taken not to modify expressions that have multiple references
+   * (refcount > 1) as that could modify unrelated expressions.
+   */
+  virtual std::unique_ptr<Model> resolve(std::vector<Assertion>& assertions,
+                                         const Assertion& extra) = 0;
+  // Calls resolve with an empty extra assertion.
+  std::unique_ptr<Model> resolve(std::vector<Assertion>& assertions);
+
+protected:
+  // Protected so that derived classes can still be copyable if they so choose.
+  Solver(const Solver&) = default;
+  Solver(Solver&&) = default;
+
+  Solver& operator=(const Solver&) = default;
+  Solver& operator=(Solver&&) = default;
+};
+
+} // namespace caffeine
+
+#endif

--- a/include/caffeine/Solver/Solver.h
+++ b/include/caffeine/Solver/Solver.h
@@ -2,7 +2,6 @@
 #define CAFFEINE_SOLVER_SOLVER_H
 
 #include <memory>
-#include <string_view>
 #include <vector>
 
 #include "caffeine/ADT/Ref.h"
@@ -11,6 +10,7 @@ namespace caffeine {
 
 class Assertion;
 class Operation;
+class Constant;
 
 enum SolverResult { UNSAT, SAT, Unknown };
 
@@ -49,7 +49,7 @@ public:
    *
    * It is invalid to call this method if the model is not SAT.
    */
-  virtual ref<Operation> lookup(std::string_view name) const = 0;
+  virtual ref<Operation> lookup(const Constant& constant) const = 0;
 
 protected:
   Model(const Model&) = default;

--- a/src/IR/Assertion.cpp
+++ b/src/IR/Assertion.cpp
@@ -1,0 +1,17 @@
+
+#include "caffeine/IR/Assertion.h"
+#include "caffeine/Support/Assert.h"
+
+namespace caffeine {
+
+Assertion::Assertion(const ref<Operation>& value) : value_(value) {
+  CAFFEINE_ASSERT(value, "created assertion with null expression");
+  CAFFEINE_ASSERT(value->type() == Type::int_ty(1));
+}
+
+bool Assertion::is_constant() const {
+  CAFFEINE_ASSERT(value_, "assertion had null value");
+  return value_->is_constant();
+}
+
+} // namespace caffeine

--- a/src/Solver/Solver.cpp
+++ b/src/Solver/Solver.cpp
@@ -1,0 +1,21 @@
+#include "caffeine/Solver/Solver.h"
+#include "caffeine/IR/Assertion.h"
+
+namespace caffeine {
+
+Model::Model(SolverResult result) : result_(result) {}
+
+SolverResult Solver::check(std::vector<Assertion>& assertions) {
+  return check(assertions, Assertion());
+}
+
+SolverResult Solver::check(std::vector<Assertion>& assertions,
+                           const Assertion& extra) {
+  return resolve(assertions, extra)->result();
+}
+
+std::unique_ptr<Model> Solver::resolve(std::vector<Assertion>& assertions) {
+  return resolve(assertions, Assertion());
+}
+
+} // namespace caffeine

--- a/test/unit/IR/Assertion.cpp
+++ b/test/unit/IR/Assertion.cpp
@@ -1,0 +1,13 @@
+
+#include "caffeine/IR/Assertion.h"
+
+#include <gtest/gtest.h>
+
+using namespace caffeine;
+
+TEST(ir_assertion, check_constant) {
+  auto constant = ConstantInt::Create(llvm::APInt(1, 1));
+  Assertion assertion(constant);
+
+  ASSERT_TRUE(assertion.is_constant());
+}


### PR DESCRIPTION
This implements a fairly simple solver interface that has two main methods:
- `check`: Check whether the assertions are satisfiable and return `SAT`, `UNSAT`, or `Unknown` as applicable. This should be faster if a model isn't needed.
- `resolve`: Check whether the assertions are satisfiable and return a model that has the necessary assigned symbolic values.

It also adds an `Assertion` type (which is an expression that is always a boolean) and a new `Constant` expression that represents a symbolic constant.