### PR TITLE
Make ctest output show all unit tests

### DIFF
--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -1,4 +1,6 @@
 
+include(GoogleTest)
+
 file(
   GLOB_RECURSE tests
   CONFIGURE_DEPENDS
@@ -8,9 +10,15 @@ file(
 )
 
 add_executable(caffeine-unittest ${tests})
-add_test(NAME unit-tests COMMAND caffeine-unittest)
 
 target_link_libraries(caffeine-unittest PRIVATE caffeine)
 target_link_libraries(caffeine-unittest PRIVATE GTest::GTest)
 target_include_directories(caffeine-unittest PRIVATE "${CMAKE_SOURCE_DIR}/include")
 target_include_directories(caffeine-unittest PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}")
+
+if (${CMAKE_VERSION} VERSION_LESS "3.10.0")
+  add_test(NAME unit-tests COMMAND caffeine-unittest)
+else()
+  # This lists all the tests individually 
+  gtest_discover_tests(caffeine-unittest TEST_PREFIX unit.)
+endif()


### PR DESCRIPTION
This just means that all unit tests are shown when running ctest. It will still be necessary to run ctest with `--output-on-failure` to get the output when a test case fails.