### PR TITLE
Add operation visitor

### DIFF
--- a/include/caffeine/ADT/Ref.h
+++ b/include/caffeine/ADT/Ref.h
@@ -204,4 +204,15 @@ ref<T> make_ref(Args&&... args) {
 
 } // namespace caffeine
 
+namespace std {
+
+template <typename T, typename Deleter>
+struct hash<caffeine::ref<T, Deleter>> {
+  std::size_t operator()(const caffeine::ref<T, Deleter>& ref) const noexcept {
+    return std::hash<T*>{}(ref.get());
+  }
+};
+
+} // namespace std
+
 #endif

--- a/include/caffeine/IR/Operation.h
+++ b/include/caffeine/IR/Operation.h
@@ -202,6 +202,8 @@ protected:
   template <typename T, typename Deleter>
   friend class ref;
 
+  friend llvm::hash_code hash_value(const Operation& op);
+
 protected:
   // Specialization that provides some sanity checking when
   // the caller is using a fixed-size array.

--- a/include/caffeine/IR/Operation.inl
+++ b/include/caffeine/IR/Operation.inl
@@ -2,6 +2,7 @@
 #ifndef CAFFEINE_IR_OPERATION_INL
 #define CAFFEINE_IR_OPERATION_INL
 
+#include <functional>
 #include <type_traits>
 
 #include "caffeine/IR/Operation.h"
@@ -324,6 +325,22 @@ inline bool FCmpOp::classof(const Operation* op) {
 
 #undef CAFFEINE_OP_DECL_CLASSOF
 
+/***************************************************
+ * hashing implementations                         *
+ ***************************************************/
+llvm::hash_code hash_value(const Operation& op);
+
 } // namespace caffeine
+
+namespace std {
+
+template <>
+struct hash<caffeine::Operation> {
+  std::size_t operator()(const caffeine::Operation& op) const noexcept {
+    return static_cast<std::size_t>(caffeine::hash_value(op));
+  }
+};
+
+} // namespace std
 
 #endif

--- a/include/caffeine/IR/Type.h
+++ b/include/caffeine/IR/Type.h
@@ -4,6 +4,8 @@
 #include <cstdint>
 #include <optional>
 
+#include <llvm/ADT/Hashing.h>
+
 #include "caffeine/ADT/Ref.h"
 
 namespace llvm {
@@ -47,6 +49,8 @@ private:
   uint32_t desc_ : 24;
 
   Type(Kind kind, uint32_t desc, llvm::Type* inner = nullptr);
+
+  friend llvm::hash_code hash_value(const Type& type);
 
 public:
   explicit Type(llvm::Type* type);

--- a/include/caffeine/IR/Type.inl
+++ b/include/caffeine/IR/Type.inl
@@ -46,6 +46,22 @@ inline bool Type::operator!=(const Type& b) const {
   return !(*this == b);
 }
 
+inline llvm::hash_code hash_value(const Type& type) {
+  return llvm::hash_combine(type.llvm_, type.kind_, type.desc_);
 }
+
+}
+
+namespace std {
+
+template <>
+struct hash<caffeine::Type> {
+  std::size_t operator()(const caffeine::Type& type) const noexcept {
+    using llvm::hash_value;
+    return hash_value(type);
+  }
+};
+
+} // namespace std
 
 #endif

--- a/include/caffeine/IR/Visitor.h
+++ b/include/caffeine/IR/Visitor.h
@@ -1,0 +1,127 @@
+#ifndef CAFFEINE_IR_VISITOR_H
+#define CAFFEINE_IR_VISITOR_H
+
+#include "caffeine/IR/Operation.h"
+
+#include <llvm/IR/InstVisitor.h>
+
+namespace caffeine {
+
+namespace detail {
+  template <typename T>
+  struct as_const {
+    typedef const T type;
+  };
+
+  template <typename T>
+  struct identity {
+    typedef T type;
+  };
+} // namespace detail
+
+#define CAFFEINE_OP_DELEGATE(class)                                            \
+  static_cast<SubClass*>(this)->visit##class(                                  \
+      static_cast<transform_t<class>&>(O))
+
+/**
+ * Base class for operation visitors.
+ *
+ * An operation visitor is used when you want to perform different actions for
+ * different kinds of operations without having to write out lots of casts and a
+ * big switch statement.
+ *
+ * To define your own visitor, inherit from either OpVisitor or ConstOpVisitor
+ * depending on whether you want to be able to modify the instruction instances
+ * being visited. Then, "override" the visitXXX method to get handle each
+ * instruction variant. Note that all methods are staticly resolved, so override
+ * doesn't actually declare a virtual method.
+ *
+ * If you don't implement the visitXXX for some operation type, then the
+ * visitXXX for its supertype will be called all the way up to the base
+ * visitOperation method. If you handle the visitXXX for the operation
+ * superclass then as new operations are added in the future they will be
+ * automatically supported.
+ *
+ * The optional second template argument for OpVisitor and ConstOpVisitor
+ * specifies the type that the instruction visitation functions should return.
+ * If you specify this, then you *MUST* provide an implementation of
+ * visitInstruction.
+ *
+ * OpVisitorBase Details
+ * =====================
+ * The OpVisitorBase class has a 3rd leading template parameter which can
+ * transform the instruction type before being used as a parameter type. See the
+ * template structs within the details block at the start of this header to get
+ * an example of how this works.
+ */
+template <template <typename T> class Transform, typename SubClass,
+          typename RetTy = void>
+class OpVisitorBase {
+private:
+  template <typename T>
+  using transform_t = typename Transform<T>::type;
+
+public:
+  RetTy visit(transform_t<Operation>& O);
+
+  void visitOperation(transform_t<Operation>&) {}
+
+  // clang-format off
+  RetTy visitConstant     (transform_t<Constant>     & O) { return CAFFEINE_OP_DELEGATE(Operation); }
+  RetTy visitConstantInt  (transform_t<ConstantInt>  & O) { return CAFFEINE_OP_DELEGATE(Operation); }
+  RetTy visitConstantFloat(transform_t<ConstantFloat>& O) { return CAFFEINE_OP_DELEGATE(Operation); }
+
+  RetTy visitBinaryOp(transform_t<BinaryOp>& O) { return CAFFEINE_OP_DELEGATE(Operation); }
+  RetTy visitUnaryOp (transform_t<UnaryOp> & O) { return CAFFEINE_OP_DELEGATE(Operation); }
+  RetTy visitSelectOp(transform_t<SelectOp>& O) { return CAFFEINE_OP_DELEGATE(Operation); }
+
+  // Binary operations
+  RetTy visitAdd (transform_t<BinaryOp>& O) { return CAFFEINE_OP_DELEGATE(BinaryOp); }
+  RetTy visitSub (transform_t<BinaryOp>& O) { return CAFFEINE_OP_DELEGATE(BinaryOp); }
+  RetTy visitMul (transform_t<BinaryOp>& O) { return CAFFEINE_OP_DELEGATE(BinaryOp); }
+  RetTy visitUDiv(transform_t<BinaryOp>& O) { return CAFFEINE_OP_DELEGATE(BinaryOp); }
+  RetTy visitSDiv(transform_t<BinaryOp>& O) { return CAFFEINE_OP_DELEGATE(BinaryOp); }
+  RetTy visitURem(transform_t<BinaryOp>& O) { return CAFFEINE_OP_DELEGATE(BinaryOp); }
+  RetTy visitSRem(transform_t<BinaryOp>& O) { return CAFFEINE_OP_DELEGATE(BinaryOp); }
+  RetTy visitAnd (transform_t<BinaryOp>& O) { return CAFFEINE_OP_DELEGATE(BinaryOp); }
+  RetTy visitOr  (transform_t<BinaryOp>& O) { return CAFFEINE_OP_DELEGATE(BinaryOp); }
+  RetTy visitXor (transform_t<BinaryOp>& O) { return CAFFEINE_OP_DELEGATE(BinaryOp); }
+  RetTy visitShl (transform_t<BinaryOp>& O) { return CAFFEINE_OP_DELEGATE(BinaryOp); }
+  RetTy visitLShr(transform_t<BinaryOp>& O) { return CAFFEINE_OP_DELEGATE(BinaryOp); }
+  RetTy visitAShr(transform_t<BinaryOp>& O) { return CAFFEINE_OP_DELEGATE(BinaryOp); }
+  RetTy visitFAdd(transform_t<BinaryOp>& O) { return CAFFEINE_OP_DELEGATE(BinaryOp); }
+  RetTy visitFSub(transform_t<BinaryOp>& O) { return CAFFEINE_OP_DELEGATE(BinaryOp); }
+  RetTy visitFMul(transform_t<BinaryOp>& O) { return CAFFEINE_OP_DELEGATE(BinaryOp); }
+  RetTy visitFDiv(transform_t<BinaryOp>& O) { return CAFFEINE_OP_DELEGATE(BinaryOp); }
+  RetTy visitFRem(transform_t<BinaryOp>& O) { return CAFFEINE_OP_DELEGATE(BinaryOp); }
+
+  RetTy visitICmp(transform_t<ICmpOp>& O) { return CAFFEINE_OP_DELEGATE(BinaryOp); }
+  RetTy visitFCmp(transform_t<FCmpOp>& O) { return CAFFEINE_OP_DELEGATE(BinaryOp); }
+
+  // Unary operations
+  RetTy visitNot (transform_t<UnaryOp>& O) { return CAFFEINE_OP_DELEGATE(UnaryOp); }
+  RetTy visitFNeg(transform_t<UnaryOp>& O) { return CAFFEINE_OP_DELEGATE(UnaryOp); }
+  // clang-format on
+};
+
+/**
+ * Operation vistor.
+ * 
+ * See the docs on OpVisitorBase for more detailed docs.
+ */
+template <typename SubClass, typename RetTy = void>
+using OpVisitor = OpVisitorBase<detail::identity, SubClass, RetTy>;
+
+/**
+ * Const operation visitor.
+ * 
+ * See the docs on OpVisitorBase for more detailed docs.
+ */
+template <typename SubClass, typename RetTy = void>
+using ConstOpVisitor = OpVisitorBase<detail::as_const, SubClass, RetTy>;
+
+#undef CAFFEINE_OP_DELEGATE
+
+} // namespace caffeine
+
+#endif

--- a/include/caffeine/IR/Visitor.inl
+++ b/include/caffeine/IR/Visitor.inl
@@ -1,0 +1,65 @@
+#ifndef CAFFEINE_IR_VISITOR_INL
+#define CAFFEINE_IR_VISITOR_INL
+
+#include "caffeine/IR/Visitor.h"
+
+#include <llvm/Support/Casting.h>
+
+namespace caffeine {
+
+template <template <typename T> class Transform, typename SubClass,
+          typename RetTy>
+RetTy OpVisitorBase<Transform, SubClass, RetTy>::visit(
+    transform_t<Operation>& op) {
+#define DELEGATE(opcode, type_)                                                \
+  case Operation::opcode:                                                      \
+    return static_cast<SubClass*>(this)->visit##opcode(                        \
+        *static_cast<transform_t<type_>*>(&op))
+
+  // Special case for icmp and fcmp since they have multiple opcodes
+  if (auto* icmp = llvm::dyn_cast<transform_t<ICmpOp>>(&op))
+    return static_cast<SubClass*>(this)->visitICmp(*icmp);
+  if (auto* fcmp = llvm::dyn_cast<transform_t<FCmpOp>>(&op))
+    return static_cast<SubClass*>(this)->visitFCmp(*fcmp);
+
+  switch (op.opcode()) {
+    DELEGATE(Add, BinaryOp);
+    DELEGATE(Sub, BinaryOp);
+    DELEGATE(Mul, BinaryOp);
+    DELEGATE(UDiv, BinaryOp);
+    DELEGATE(SDiv, BinaryOp);
+    DELEGATE(URem, BinaryOp);
+    DELEGATE(SRem, BinaryOp);
+    DELEGATE(And, BinaryOp);
+    DELEGATE(Or, BinaryOp);
+    DELEGATE(Xor, BinaryOp);
+    DELEGATE(Shl, BinaryOp);
+    DELEGATE(LShr, BinaryOp);
+    DELEGATE(AShr, BinaryOp);
+    DELEGATE(FAdd, BinaryOp);
+    DELEGATE(FSub, BinaryOp);
+    DELEGATE(FMul, BinaryOp);
+    DELEGATE(FDiv, BinaryOp);
+    DELEGATE(FRem, BinaryOp);
+
+    DELEGATE(Not, UnaryOp);
+    DELEGATE(FNeg, UnaryOp);
+
+    DELEGATE(SelectOp, SelectOp);
+    DELEGATE(Constant, Constant);
+    DELEGATE(ConstantInt, ConstantInt);
+    DELEGATE(ConstantFloat, ConstantFloat);
+
+  case Operation::Invalid:
+    CAFFEINE_ABORT("tried to visit an invalid operation");
+  
+  default:
+    CAFFEINE_ABORT("unknown operation opcode");
+  }
+
+#undef DELEGATE
+}
+
+} // namespace caffeine
+
+#endif

--- a/src/IR/Type.cpp
+++ b/src/IR/Type.cpp
@@ -2,6 +2,7 @@
 
 #include <llvm/ADT/APFloat.h>
 #include <llvm/ADT/APInt.h>
+#include <llvm/ADT/Hashing.h>
 #include <llvm/IR/DerivedTypes.h>
 #include <llvm/IR/LLVMContext.h>
 #include <llvm/IR/Type.h>


### PR DESCRIPTION
This is similar to LLVM's InstVisitor but for operations. This PR also adds hashing support to Type and Operation.