### PR TITLE
Add default implementation of Model::evaluate

### DIFF
--- a/include/caffeine/IR/Operation.h
+++ b/include/caffeine/IR/Operation.h
@@ -86,6 +86,13 @@ enum class FCmpOpcode : uint8_t {
  *    derived so that llvm::dyn_cast and llvm::isa work.
  * 3. Add a builder function `CreateXXX` to the proper derived class that
  *    builds the correct Operation instance.
+ * 4. Add the correct delegation method to the OpVisitorBase class in Visitor.h.
+ *    See the other methods there as to how it should be written.
+ * 5. Add the opcode + its corresponding name to the switch statement within
+ *    opcode_name.
+ * 6. Add the logic required to handle the new opcode to ExprEvaluator within
+ *    Visitor.cpp. This may also require adding new built-in methods to the
+ *    Value type.
  */
 class Operation {
 public:
@@ -159,7 +166,7 @@ public:
     // what each of these mean.
     // TODO: Should these be broken down?
     FCmpOeq = detail::opcode(33, 2, (uint16_t)FCmpOpcode::OEQ),
-    FCmpOGt = detail::opcode(33, 2, (uint16_t)FCmpOpcode::OGT),
+    FCmpOgt = detail::opcode(33, 2, (uint16_t)FCmpOpcode::OGT),
     FCmpOge = detail::opcode(33, 2, (uint16_t)FCmpOpcode::OGE),
     FCmpOlt = detail::opcode(33, 2, (uint16_t)FCmpOpcode::OLT),
     FCmpOle = detail::opcode(33, 2, (uint16_t)FCmpOpcode::OLE),
@@ -239,6 +246,11 @@ public:
   // Get the opcode
   uint16_t opcode() const;
 
+  // Get a static string that contains the opcode name. Returns "Unknown" on
+  // unknown opcode.
+  const char* opcode_name() const;
+  static const char* opcode_name(Opcode op);
+
   // Read-only access to the refcount. If this is 0 then this is not a
   // reference-counted Operation instance.
   uint32_t refcnt() const;
@@ -263,6 +275,9 @@ public:
   size_t num_operands() const;
   llvm::iterator_range<operand_iterator> operands();
   llvm::iterator_range<const_operand_iterator> operands() const;
+
+  Operation& operator[](size_t idx);
+  const Operation& operator[](size_t idx) const;
 
   bool operator==(const Operation& op) const;
   bool operator!=(const Operation& op) const;

--- a/include/caffeine/IR/Operation.inl
+++ b/include/caffeine/IR/Operation.inl
@@ -182,8 +182,21 @@ inline Type Operation::type() const {
 }
 
 inline bool Operation::is_constant() const {
-  // Needs to be updated if constant opcode representation changes
+  // The opcodes of constant operations are currently represented as (1, 0,
+  // <arbitrary aux data>). If this representation change then we'll have to
+  // update this function.
   return (opcode_ >> 6) == 1;
+}
+
+inline Operation& Operation::operator[](size_t idx) {
+  CAFFEINE_ASSERT(idx < num_operands(),
+                  "Tried to access out-of-bounds operand");
+  return *operands_[idx];
+}
+inline const Operation& Operation::operator[](size_t idx) const {
+  CAFFEINE_ASSERT(idx < num_operands(),
+                  "Tried to access out-of-bounds operand");
+  return *operands_[idx];
 }
 
 /***************************************************

--- a/include/caffeine/IR/Type.h
+++ b/include/caffeine/IR/Type.h
@@ -73,6 +73,7 @@ public:
   static Type int_ty(uint32_t bitwidth);
   static Type void_ty();
   static Type float_ty(uint32_t exponent, uint32_t mantissa);
+  static Type bool_ty();
   // TODO: Address spaces? Not sure if we want to model them
   static Type pointer_ty();
 

--- a/include/caffeine/IR/Type.inl
+++ b/include/caffeine/IR/Type.inl
@@ -50,7 +50,7 @@ inline llvm::hash_code hash_value(const Type& type) {
   return llvm::hash_combine(type.llvm_, type.kind_, type.desc_);
 }
 
-}
+} // namespace caffeine
 
 namespace std {
 

--- a/include/caffeine/IR/Value.h
+++ b/include/caffeine/IR/Value.h
@@ -1,0 +1,113 @@
+#ifndef CAFFEINE_IR_VALUE_H
+#define CAFFEINE_IR_VALUE_H
+
+#include <llvm/ADT/APFloat.h>
+#include <llvm/ADT/APInt.h>
+
+namespace caffeine {
+
+class Type;
+class ConstantInt;
+class ConstantFloat;
+
+/**
+ * A concrete value that may be the result of an expression.
+ *
+ * This class is meant to be used anywhere it's needed to evaluate an expression
+ * to a concrete value. This includes evaluating models and as a utility within
+ * optimizations.
+ *
+ * A value can either be
+ * - A fixed-width (with arbitrary width) integer (via llvm::APInt)
+ * - A floating-point type (via llvm::APFloat)
+ * - An empty value
+ *
+ * Each of these representations have a set of operations that are valid on them
+ * (e.g. bvxxx for integers, fxxx for floats). All operations assert that their
+ * operands have the correct type class and should only be used with operations
+ * which have the same bitwidths.
+ */
+class Value {
+public:
+  enum Kind { Empty, Int, Float };
+
+private:
+  Kind kind_;
+  union {
+    llvm::APInt apint_;
+    llvm::APFloat apfloat_;
+  };
+
+public:
+  Value();
+
+  Value(const llvm::APInt& apint);
+  Value(llvm::APInt&& apint);
+
+  Value(const llvm::APFloat& apfloat);
+  Value(llvm::APFloat&& apfloat);
+
+  Value(const ConstantInt& constant);
+  Value(const ConstantFloat& constant);
+
+  // clang-format off
+  bool is_int()   const { return kind_ == Int;   }
+  bool is_float() const { return kind_ == Float; }
+  bool is_empty() const { return kind_ == Empty; }
+
+  Kind kind() const { return kind_; }
+  Type type() const;
+  // clang-format on
+
+  // Note: floating-point values are compared using bitwise equality. *NOT* the
+  //       IEEE-754 equality predicate.
+  bool operator==(const Value& v) const;
+  bool operator!=(const Value& v) const;
+
+  llvm::APInt& apint();
+  const llvm::APInt& apint() const;
+
+  llvm::APFloat& apfloat();
+  const llvm::APFloat& apfloat() const;
+
+  // Value operations
+  static Value bvadd(const Value& lhs, const Value& rhs);
+  static Value bvsub(const Value& lhs, const Value& rhs);
+  static Value bvmul(const Value& lhs, const Value& rhs);
+  static Value bvudiv(const Value& lhs, const Value& rhs);
+  static Value bvsdiv(const Value& lhs, const Value& rhs);
+  static Value bvurem(const Value& lhs, const Value& rhs);
+  static Value bvsrem(const Value& lhs, const Value& rhs);
+
+  static Value bvand(const Value& lhs, const Value& rhs);
+  static Value bvor(const Value& lhs, const Value& rhs);
+  static Value bvxor(const Value& lhs, const Value& rhs);
+  static Value bvshl(const Value& lhs, const Value& rhs);
+  static Value bvlshr(const Value& lhs, const Value& rhs);
+  static Value bvashr(const Value& lhs, const Value& rhs);
+  static Value bvnot(const Value& v);
+
+  static Value fadd(const Value& lhs, const Value& rhs);
+  static Value fsub(const Value& lhs, const Value& rhs);
+  static Value fmul(const Value& lhs, const Value& rhs);
+  static Value fdiv(const Value& lhs, const Value& rhs);
+  static Value frem(const Value& lhs, const Value& rhs);
+  static Value fneg(const Value& v);
+
+  static Value select(const Value& cond, const Value& t, const Value& f);
+
+  // These need to be defined since Value has an internal union
+  Value(const Value&);
+  Value(Value&&);
+  Value& operator=(const Value&);
+  Value& operator=(Value&&);
+
+  ~Value();
+
+private:
+  void invalidate();
+};
+
+} // namespace caffeine
+
+#endif

--- a/include/caffeine/IR/Visitor.h
+++ b/include/caffeine/IR/Visitor.h
@@ -52,17 +52,17 @@ namespace detail {
  * Suppose we want to create a visitor that could be used to count the number of
  * symbolic constants that occur in an expression tree. It would look something
  * like this:
- * 
+ *
  * ```cpp
  * class CountingVisitor : ConstOpVisitor<CountingVisitor> {
  * public:
  *   size_t num_consts = 0;
- * 
+ *
  *   void visitOperation(const Operation& op) {
  *     for (const Operation& operand : op.operands)
  *       visit(operand);
  *   }
- * 
+ *
  *   void visitConstant(const Constant&) {
  *     num_constants += 1;
  *   }
@@ -139,7 +139,7 @@ public:
 
 /**
  * Operation vistor.
- * 
+ *
  * See the docs on OpVisitorBase for more detailed docs.
  */
 template <typename SubClass, typename RetTy = void>
@@ -147,7 +147,7 @@ using OpVisitor = OpVisitorBase<detail::identity, SubClass, RetTy>;
 
 /**
  * Const operation visitor.
- * 
+ *
  * See the docs on OpVisitorBase for more detailed docs.
  */
 template <typename SubClass, typename RetTy = void>

--- a/include/caffeine/IR/Visitor.inl
+++ b/include/caffeine/IR/Visitor.inl
@@ -52,7 +52,7 @@ RetTy OpVisitorBase<Transform, SubClass, RetTy>::visit(
 
   case Operation::Invalid:
     CAFFEINE_ABORT("tried to visit an invalid operation");
-  
+
   default:
     CAFFEINE_ABORT("unknown operation opcode");
   }

--- a/include/caffeine/Solver/Solver.h
+++ b/include/caffeine/Solver/Solver.h
@@ -5,6 +5,7 @@
 #include <vector>
 
 #include "caffeine/ADT/Ref.h"
+#include "caffeine/IR/Value.h"
 
 namespace caffeine {
 
@@ -39,7 +40,7 @@ public:
    *
    * It is invalid to call this method if the model is not SAT.
    */
-  virtual ref<Operation> evaluate(const ref<Operation>& expr) const = 0;
+  virtual Value evaluate(const Operation& expr) const;
 
   /**
    * Look up the value of a symbolic constant in this model. Returns an
@@ -49,7 +50,7 @@ public:
    *
    * It is invalid to call this method if the model is not SAT.
    */
-  virtual ref<Operation> lookup(const Constant& constant) const = 0;
+  virtual Value lookup(const Constant& constant) const = 0;
 
 protected:
   Model(const Model&) = default;

--- a/src/IR/Operation.cpp
+++ b/src/IR/Operation.cpp
@@ -222,6 +222,83 @@ void Operation::invalidate() noexcept {
   opcode_ = Invalid;
 }
 
+const char* Operation::opcode_name() const {
+  return opcode_name(static_cast<Opcode>(opcode()));
+}
+const char* Operation::opcode_name(Opcode op) {
+  // clang-format off
+  switch (op) {
+  case Invalid:       return "Invalid";
+  case Constant:      return "Constant";
+  case ConstantInt:   return "ConstantInt";
+  case ConstantFloat: return "ConstantFloat";
+
+  case Add:   return "Add";
+  case Sub:   return "Sub";
+  case Mul:   return "Mul";
+  case UDiv:  return "UDiv";
+  case SDiv:  return "SDiv";
+  case URem:  return "URem";
+  case SRem:  return "SRem";
+  case And:   return "And";
+  case Or:    return "Or";
+  case Xor:   return "Xor";
+  case Shl:   return "Shl";
+  case LShr:  return "LShr";
+  case AShr:  return "AShr";
+  case Not:   return "Not";
+
+  case FAdd:  return "FAdd";
+  case FSub:  return "FSub";
+  case FMul:  return "FMul";
+  case FDiv:  return "FDiv";
+  case FRem:  return "FRem";
+  case FNeg:  return "FNeg";
+
+  case Trunc:   return "Trunc";
+  case SExt:    return "SExt";
+  case ZExt:    return "ZExt";
+  case FpTrunc: return "FpTrunc";
+  case FpExt:   return "FpExt";
+  case FpToUI:  return "FpToUI";
+  case FpToSI:  return "FpToSI";
+  case UIToFp:  return "UIToFp";
+  case SIToFp:  return "SIToFp";
+
+  case ICmpEq:
+  case ICmpNe:
+  case ICmpUgt:
+  case ICmpUge:
+  case ICmpUlt:
+  case ICmpUle:
+  case ICmpSgt:
+  case ICmpSge:
+  case ICmpSlt:
+  case ICmpSle:
+    return "ICmp";
+
+  case FCmpOeq:
+  case FCmpOgt:
+  case FCmpOge:
+  case FCmpOlt:
+  case FCmpOle:
+  case FCmpOne:
+  case FCmpOrd:
+  case FCmpUno:
+  case FCmpUeq:
+  case FCmpUgt:
+  case FCmpUge:
+  case FCmpUlt:
+  case FCmpUle:
+  case FCmpUne:
+    return "FCmp";
+
+  case Select: return "Select";
+  }
+  // clang-format on
+  return "Unknown";
+}
+
 /***************************************************
  * ConstantInt                                     *
  ***************************************************/

--- a/src/IR/Type.cpp
+++ b/src/IR/Type.cpp
@@ -27,6 +27,10 @@ Type Type::void_ty() {
   return Type(Void, 0);
 }
 
+Type Type::bool_ty() {
+  return Type::int_ty(1);
+}
+
 Type Type::float_ty(uint32_t exponent, uint32_t mantissa) {
   CAFFEINE_ASSERT(exponent != 0 && exponent < (UINT32_C(1) << 12));
   CAFFEINE_ASSERT(mantissa != 0 && mantissa < (UINT32_C(1) << 12));

--- a/src/IR/Value.cpp
+++ b/src/IR/Value.cpp
@@ -1,0 +1,277 @@
+#include "caffeine/IR/Value.h"
+#include "caffeine/IR/Operation.h"
+#include "caffeine/IR/Type.h"
+#include "caffeine/Support/Assert.h"
+
+namespace caffeine {
+
+Value::Value() : kind_(Empty) {}
+
+Value::Value(const llvm::APInt& apint) : kind_(Int), apint_(apint) {}
+Value::Value(llvm::APInt&& apint) : kind_(Int), apint_(std::move(apint)) {}
+
+Value::Value(const llvm::APFloat& apfloat) : kind_(Float), apfloat_(apfloat) {}
+Value::Value(llvm::APFloat&& apfloat) : kind_(Float), apfloat_(apfloat) {}
+
+Value::Value(const ConstantInt& constant) : Value(constant.value()) {}
+Value::Value(const ConstantFloat& constant) : Value(constant.value()) {}
+
+Value::Value(const Value& v) : kind_(Empty) {
+  switch (v.kind()) {
+  case Empty:
+    break;
+  case Int:
+    new (&apint_) llvm::APInt(v.apint_);
+    break;
+  case Float:
+    new (&apfloat_) llvm::APFloat(v.apfloat_);
+    break;
+  }
+
+  kind_ = v.kind();
+}
+Value::Value(Value&& v) : kind_(Empty) {
+  switch (v.kind()) {
+  case Empty:
+    break;
+  case Int:
+    new (&apint_) llvm::APInt(std::move(v.apint_));
+    break;
+  case Float:
+    new (&apfloat_) llvm::APFloat(std::move(v.apfloat_));
+    break;
+  }
+
+  kind_ = v.kind();
+}
+Value& Value::operator=(const Value& v) {
+  invalidate();
+
+  switch (v.kind()) {
+  case Empty:
+    break;
+  case Int:
+    new (&apint_) llvm::APInt(v.apint_);
+    break;
+  case Float:
+    new (&apfloat_) llvm::APFloat(v.apfloat_);
+    break;
+  }
+
+  kind_ = v.kind();
+  return *this;
+}
+Value& Value::operator=(Value&& v) {
+  invalidate();
+
+  switch (v.kind()) {
+  case Empty:
+    break;
+  case Int:
+    new (&apint_) llvm::APInt(std::move(v.apint_));
+    break;
+  case Float:
+    new (&apfloat_) llvm::APFloat(std::move(v.apfloat_));
+    break;
+  }
+
+  kind_ = v.kind();
+  return *this;
+}
+
+Value::~Value() {
+  invalidate();
+}
+
+void Value::invalidate() {
+  auto kind = kind_;
+  kind_ = Empty;
+
+  switch (kind) {
+  case Empty:
+    break;
+  case Int:
+    apint_.~APInt();
+    break;
+  case Float:
+    apfloat_.~APFloat();
+    break;
+  }
+}
+
+Type Value::type() const {
+  switch (kind()) {
+  case Empty:
+    return Type::void_ty();
+  case Int:
+    return Type::type_of(apfloat_);
+  case Float:
+    return Type::type_of(apint_);
+  }
+
+  CAFFEINE_UNREACHABLE();
+}
+
+llvm::APInt& Value::apint() {
+  CAFFEINE_ASSERT(is_int());
+  return apint_;
+}
+const llvm::APInt& Value::apint() const {
+  CAFFEINE_ASSERT(is_int());
+  return apint_;
+}
+
+llvm::APFloat& Value::apfloat() {
+  CAFFEINE_ASSERT(is_float());
+  return apfloat_;
+}
+const llvm::APFloat& Value::apfloat() const {
+  CAFFEINE_ASSERT(is_float());
+  return apfloat_;
+}
+
+bool Value::operator==(const Value& v) const {
+  if (kind() != v.kind())
+    return false;
+
+  switch (kind()) {
+  case Empty:
+    return true;
+  case Int:
+    return apint() == v.apint();
+  case Float:
+    return apfloat().bitwiseIsEqual(v.apfloat());
+  }
+
+  CAFFEINE_UNREACHABLE();
+}
+bool Value::operator!=(const Value& v) const {
+  return !(*this == v);
+}
+
+Value Value::bvadd(const Value& lhs, const Value& rhs) {
+  CAFFEINE_ASSERT(lhs.is_int());
+  CAFFEINE_ASSERT(rhs.is_int());
+
+  return lhs.apint_ + rhs.apint_;
+}
+Value Value::bvsub(const Value& lhs, const Value& rhs) {
+  CAFFEINE_ASSERT(lhs.is_int());
+  CAFFEINE_ASSERT(rhs.is_int());
+
+  return lhs.apint_ - rhs.apint_;
+}
+Value Value::bvmul(const Value& lhs, const Value& rhs) {
+  CAFFEINE_ASSERT(lhs.is_int());
+  CAFFEINE_ASSERT(rhs.is_int());
+
+  return lhs.apint_ * rhs.apint_;
+}
+Value Value::bvudiv(const Value& lhs, const Value& rhs) {
+  CAFFEINE_ASSERT(lhs.is_int());
+  CAFFEINE_ASSERT(rhs.is_int());
+
+  return lhs.apint_.udiv(rhs.apint_);
+}
+Value Value::bvsdiv(const Value& lhs, const Value& rhs) {
+  CAFFEINE_ASSERT(lhs.is_int());
+  CAFFEINE_ASSERT(rhs.is_int());
+
+  return lhs.apint_.sdiv(rhs.apint_);
+}
+Value Value::bvurem(const Value& lhs, const Value& rhs) {
+  CAFFEINE_ASSERT(lhs.is_int());
+  CAFFEINE_ASSERT(rhs.is_int());
+
+  return lhs.apint_.urem(rhs.apint_);
+}
+Value Value::bvsrem(const Value& lhs, const Value& rhs) {
+  CAFFEINE_ASSERT(lhs.is_int());
+  CAFFEINE_ASSERT(rhs.is_int());
+
+  return lhs.apint_.srem(rhs.apint_);
+}
+
+Value Value::bvand(const Value& lhs, const Value& rhs) {
+  CAFFEINE_ASSERT(lhs.is_int());
+  CAFFEINE_ASSERT(rhs.is_int());
+
+  return lhs.apint_ & rhs.apint_;
+}
+Value Value::bvor(const Value& lhs, const Value& rhs) {
+  CAFFEINE_ASSERT(lhs.is_int());
+  CAFFEINE_ASSERT(rhs.is_int());
+
+  return lhs.apint_ | rhs.apint_;
+}
+Value Value::bvxor(const Value& lhs, const Value& rhs) {
+  CAFFEINE_ASSERT(lhs.is_int());
+  CAFFEINE_ASSERT(rhs.is_int());
+
+  return lhs.apint_ ^ rhs.apint_;
+}
+Value Value::bvshl(const Value& lhs, const Value& rhs) {
+  CAFFEINE_ASSERT(lhs.is_int());
+  CAFFEINE_ASSERT(rhs.is_int());
+
+  return lhs.apint_ << rhs.apint_;
+}
+Value Value::bvlshr(const Value& lhs, const Value& rhs) {
+  CAFFEINE_ASSERT(lhs.is_int());
+  CAFFEINE_ASSERT(rhs.is_int());
+
+  return lhs.apint_.lshr(rhs.apint_);
+}
+Value Value::bvashr(const Value& lhs, const Value& rhs) {
+  CAFFEINE_ASSERT(lhs.is_int());
+  CAFFEINE_ASSERT(rhs.is_int());
+
+  return lhs.apint_.ashr(rhs.apint_);
+}
+Value Value::bvnot(const Value& v) {
+  CAFFEINE_ASSERT(v.is_int());
+
+  return ~v.apint_;
+}
+
+Value Value::fadd(const Value& lhs, const Value& rhs) {
+  CAFFEINE_ASSERT(lhs.is_float());
+  CAFFEINE_ASSERT(rhs.is_float());
+
+  return lhs.apfloat_ + rhs.apfloat_;
+}
+Value Value::fsub(const Value& lhs, const Value& rhs) {
+  CAFFEINE_ASSERT(lhs.is_float());
+  CAFFEINE_ASSERT(rhs.is_float());
+
+  return lhs.apfloat_ - rhs.apfloat_;
+}
+Value Value::fmul(const Value& lhs, const Value& rhs) {
+  CAFFEINE_ASSERT(lhs.is_float());
+  CAFFEINE_ASSERT(rhs.is_float());
+
+  return lhs.apfloat_ * rhs.apfloat_;
+}
+Value Value::fdiv(const Value& lhs, const Value& rhs) {
+  CAFFEINE_ASSERT(lhs.is_float());
+  CAFFEINE_ASSERT(rhs.is_float());
+
+  return lhs.apfloat_ / rhs.apfloat_;
+}
+Value Value::frem(const Value& lhs, const Value& rhs) {
+  CAFFEINE_ASSERT(lhs.is_float());
+  CAFFEINE_ASSERT(rhs.is_float());
+
+  auto value = lhs.apfloat_;
+  value.remainder(rhs.apfloat_);
+  return value;
+}
+
+Value Value::select(const Value& cond, const Value& t, const Value& f) {
+  CAFFEINE_ASSERT(cond.type() == Type::bool_ty());
+  CAFFEINE_ASSERT(t.type() == f.type());
+
+  return cond.apint() == 1 ? t : f;
+}
+
+} // namespace caffeine

--- a/src/Solver/Solver.cpp
+++ b/src/Solver/Solver.cpp
@@ -1,9 +1,75 @@
 #include "caffeine/Solver/Solver.h"
 #include "caffeine/IR/Assertion.h"
+#include "caffeine/IR/Value.h"
+#include "caffeine/IR/Visitor.h"
+
+#include <fmt/format.h>
 
 namespace caffeine {
 
+class ExprEvaluator : public ConstOpVisitor<ExprEvaluator, Value> {
+public:
+  ExprEvaluator(const Model* model) : model_(model) {}
+
+  Value visitOperation(const Operation& op) {
+    CAFFEINE_ABORT(fmt::format("Unknown operation: {}", op.opcode_name()));
+  }
+
+  Value visitConstant(const Constant& op) {
+    return model_->lookup(op);
+  }
+  Value visitConstantInt(const ConstantInt& op) {
+    return op.value();
+  }
+  Value visitConstantFloat(const ConstantFloat& op) {
+    return op.value();
+  }
+
+#define DECL_BINOP(opcode, func)                                               \
+  Value visit##opcode(const BinaryOp& op) {                                    \
+    return Value::func(visit(op[0]), visit(op[1]));                            \
+  }                                                                            \
+  static_assert(true)
+
+  DECL_BINOP(Add, bvadd);
+  DECL_BINOP(Sub, bvsub);
+  DECL_BINOP(Mul, bvmul);
+  DECL_BINOP(UDiv, bvudiv);
+  DECL_BINOP(SDiv, bvsdiv);
+  DECL_BINOP(URem, bvurem);
+  DECL_BINOP(SRem, bvsrem);
+  DECL_BINOP(And, bvand);
+  DECL_BINOP(Or, bvor);
+  DECL_BINOP(Xor, bvxor);
+  DECL_BINOP(Shl, bvshl);
+  DECL_BINOP(LShr, bvlshr);
+  DECL_BINOP(AShr, bvashr);
+  DECL_BINOP(FAdd, fadd);
+  DECL_BINOP(FSub, fsub);
+  DECL_BINOP(FMul, fmul);
+  DECL_BINOP(FDiv, fdiv);
+  DECL_BINOP(FRem, frem);
+
+  Value visitNot(const UnaryOp& op) {
+    return Value::bvnot(visit(op[0]));
+  }
+  Value visitFNeg(const UnaryOp& op) {
+    return Value::fneg(visit(op[0]));
+  }
+
+  Value visitSelectOp(const SelectOp& select) {
+    return Value::select(visit(select[0]), visit(select[1]), visit(select[2]));
+  }
+
+private:
+  const Model* model_;
+};
+
 Model::Model(SolverResult result) : result_(result) {}
+
+Value Model::evaluate(const Operation& expr) const {
+  return ExprEvaluator(this).visit(expr);
+}
 
 SolverResult Solver::check(std::vector<Assertion>& assertions) {
   return check(assertions, Assertion());

--- a/test/unit/IR/Value.cpp
+++ b/test/unit/IR/Value.cpp
@@ -1,0 +1,24 @@
+#include "caffeine/IR/Value.h"
+
+#include <gtest/gtest.h>
+
+using namespace caffeine;
+
+#define BITWIDTH 32
+#define DECL_TEST(op, vop, lhs_, rhs_)                                         \
+  TEST(ir_value, op) {                                                         \
+    llvm::APInt lhs{BITWIDTH, lhs_};                                           \
+    llvm::APInt rhs{BITWIDTH, rhs_};                                           \
+    ASSERT_EQ(Value::op(lhs, rhs), lhs vop rhs);                               \
+  }                                                                            \
+  static_assert(true)
+
+// These are mostly just tests to prevent implementation typos
+DECL_TEST(bvadd, +, 0xFF0, 0x00F);
+DECL_TEST(bvsub, -, 0xFF0, 0x00F);
+DECL_TEST(bvmul, *, 0xFF0, 0x00F);
+
+DECL_TEST(bvand, &, 0xFF0, 0x0FF);
+DECL_TEST(bvor, |, 0xFF0, 0x0FF);
+DECL_TEST(bvxor, ^, 0xFF0, 0x0FF);
+DECL_TEST(bvshl, <<, 0xFF, 3);


### PR DESCRIPTION
The logic to actually implement this is decently complicated (it requires walking the expression tree) an is entirely implementable using only the `Model::lookup` function. This PR implements `Model::evaluate` in terms of `Model::lookup`. Note that the implementation is still incomplete, I'll actually fill everything out in a follow-up PR.

To do this I found I needed to introduce a new `Value` as having the representation be an operation that's constrained to be either `ConstantInt` or `ConstantFloat` ended up being basically unusable for actually performing arithmetic. I've also changed the model interface to use `Value` as that made far more sense.

While doing this I went and added some utility methods to `Operation` and `Type` as I discovered that I needed them. As a result, there's now a method to get the opcode name as a string, a shortcut for creating boolean types, and operation operands can now be accessed through the indexing operator.

@Skrinikov This PR changes the model interface slightly so it's going to require some minor changes to your PR.