### PR TITLE
Add create + visit methods for conversion opcodes

### DIFF
--- a/include/caffeine/IR/Operation.h
+++ b/include/caffeine/IR/Operation.h
@@ -415,7 +415,7 @@ public:
 };
 
 /**
- * Unary operations (e.g. not and fneg).
+ * Unary operations (e.g. not, fneg, conversion operations).
  *
  * Any more specific unary operations should inherit from this class.
  */
@@ -430,6 +430,16 @@ public:
   static ref<Operation> Create(Opcode op, const ref<Operation>& operand);
   static ref<Operation> CreateNot(const ref<Operation>& operand);
   static ref<Operation> CreateFNeg(const ref<Operation>& operand);
+
+  static ref<Operation> CreateTrunc(Type tgt, const ref<Operation>& operand);
+  static ref<Operation> CreateZExt(Type tgt, const ref<Operation>& operand);
+  static ref<Operation> CreateSExt(Type tgt, const ref<Operation>& operand);
+  static ref<Operation> CreateFpTrunc(Type tgt, const ref<Operation>& operand);
+  static ref<Operation> CreateFpExt(Type tgt, const ref<Operation>& operand);
+  static ref<Operation> CreateFpToUI(Type tgt, const ref<Operation>& operand);
+  static ref<Operation> CreateFpToSI(Type tgt, const ref<Operation>& operand);
+  static ref<Operation> CreateUIToFp(Type tgt, const ref<Operation>& operand);
+  static ref<Operation> CreateSIToFp(Type tgt, const ref<Operation>& operand);
 
   static bool classof(const Operation* op);
 };

--- a/include/caffeine/IR/Visitor.h
+++ b/include/caffeine/IR/Visitor.h
@@ -33,8 +33,8 @@ namespace detail {
  * To define your own visitor, inherit from either OpVisitor or ConstOpVisitor
  * depending on whether you want to be able to modify the instruction instances
  * being visited. Then, "override" the visitXXX method to get handle each
- * instruction variant. Note that all methods are staticly resolved, so override
- * doesn't actually declare a virtual method.
+ * instruction variant. Note that all methods are staticly resolved, so
+ * overriding them doesn't actually declare a virtual method.
  *
  * If you don't implement the visitXXX for some operation type, then the
  * visitXXX for its supertype will be called all the way up to the base
@@ -46,6 +46,28 @@ namespace detail {
  * specifies the type that the instruction visitation functions should return.
  * If you specify this, then you *MUST* provide an implementation of
  * visitInstruction.
+ *
+ * Example
+ * =======
+ * Suppose we want to create a visitor that could be used to count the number of
+ * symbolic constants that occur in an expression tree. It would look something
+ * like this:
+ * 
+ * ```cpp
+ * class CountingVisitor : ConstOpVisitor<CountingVisitor> {
+ * public:
+ *   size_t num_consts = 0;
+ * 
+ *   void visitOperation(const Operation& op) {
+ *     for (const Operation& operand : op.operands)
+ *       visit(operand);
+ *   }
+ * 
+ *   void visitConstant(const Constant&) {
+ *     num_constants += 1;
+ *   }
+ * };
+ * ```
  *
  * OpVisitorBase Details
  * =====================
@@ -63,6 +85,7 @@ private:
 
 public:
   RetTy visit(transform_t<Operation>& O);
+  RetTy visit(transform_t<Operation>* O);
 
   void visitOperation(transform_t<Operation>&) {}
 
@@ -101,6 +124,16 @@ public:
   // Unary operations
   RetTy visitNot (transform_t<UnaryOp>& O) { return CAFFEINE_OP_DELEGATE(UnaryOp); }
   RetTy visitFNeg(transform_t<UnaryOp>& O) { return CAFFEINE_OP_DELEGATE(UnaryOp); }
+
+  RetTy visitTrunc  (transform_t<UnaryOp>& O) { return CAFFEINE_OP_DELEGATE(UnaryOp); }
+  RetTy visitZExt   (transform_t<UnaryOp>& O) { return CAFFEINE_OP_DELEGATE(UnaryOp); }
+  RetTy visitSExt   (transform_t<UnaryOp>& O) { return CAFFEINE_OP_DELEGATE(UnaryOp); }
+  RetTy visitFpTrunc(transform_t<UnaryOp>& O) { return CAFFEINE_OP_DELEGATE(UnaryOp); }
+  RetTy visitFpExt  (transform_t<UnaryOp>& O) { return CAFFEINE_OP_DELEGATE(UnaryOp); }
+  RetTy visitFpToUI (transform_t<UnaryOp>& O) { return CAFFEINE_OP_DELEGATE(UnaryOp); }
+  RetTy visitFpToSI (transform_t<UnaryOp>& O) { return CAFFEINE_OP_DELEGATE(UnaryOp); }
+  RetTy visitUIToFp (transform_t<UnaryOp>& O) { return CAFFEINE_OP_DELEGATE(UnaryOp); }
+  RetTy visitSIToFp (transform_t<UnaryOp>& O) { return CAFFEINE_OP_DELEGATE(UnaryOp); }
   // clang-format on
 };
 

--- a/include/caffeine/IR/Visitor.inl
+++ b/include/caffeine/IR/Visitor.inl
@@ -60,6 +60,13 @@ RetTy OpVisitorBase<Transform, SubClass, RetTy>::visit(
 #undef DELEGATE
 }
 
+template <template <typename T> class Transform, typename SubClass,
+          typename RetTy>
+RetTy OpVisitorBase<Transform, SubClass, RetTy>::visit(
+    transform_t<Operation>* op) {
+  return visit(*op);
+}
+
 } // namespace caffeine
 
 #endif

--- a/src/IR/Operation.cpp
+++ b/src/IR/Operation.cpp
@@ -331,6 +331,68 @@ ref<Operation> UnaryOp::Create(Opcode op, const ref<Operation>& operand) {
 DECL_UNOP_CREATE(Not, ASSERT_INT);
 DECL_UNOP_CREATE(FNeg, ASSERT_FP);
 
+ref<Operation> UnaryOp::CreateTrunc(Type tgt, const ref<Operation>& operand) {
+  CAFFEINE_ASSERT(tgt.is_int());
+  CAFFEINE_ASSERT(operand->type().is_int());
+  CAFFEINE_ASSERT(tgt.bitwidth() < operand->type().bitwidth());
+
+  return ref<Operation>(new UnaryOp(Opcode::Trunc, tgt, operand));
+}
+ref<Operation> UnaryOp::CreateZExt(Type tgt, const ref<Operation>& operand) {
+  CAFFEINE_ASSERT(tgt.is_int());
+  CAFFEINE_ASSERT(operand->type().is_int());
+  CAFFEINE_ASSERT(tgt.bitwidth() > operand->type().bitwidth());
+
+  return ref<Operation>(new UnaryOp(Opcode::ZExt, tgt, operand));
+}
+ref<Operation> UnaryOp::CreateSExt(Type tgt, const ref<Operation>& operand) {
+  CAFFEINE_ASSERT(tgt.is_int());
+  CAFFEINE_ASSERT(operand->type().is_int());
+  CAFFEINE_ASSERT(tgt.bitwidth() > operand->type().bitwidth());
+
+  return ref<Operation>(new UnaryOp(Opcode::SExt, tgt, operand));
+}
+ref<Operation> UnaryOp::CreateFpTrunc(Type tgt, const ref<Operation>& operand) {
+  CAFFEINE_ASSERT(tgt.is_float());
+  CAFFEINE_ASSERT(operand->type().is_float());
+  CAFFEINE_ASSERT(tgt.exponent_bits() < operand->type().exponent_bits() &&
+                  tgt.mantissa_bits() < operand->type().mantissa_bits());
+
+  return ref<Operation>(new UnaryOp(Opcode::FpTrunc, tgt, operand));
+}
+ref<Operation> UnaryOp::CreateFpExt(Type tgt, const ref<Operation>& operand) {
+  CAFFEINE_ASSERT(tgt.is_float());
+  CAFFEINE_ASSERT(operand->type().is_float());
+  CAFFEINE_ASSERT(tgt.exponent_bits() > operand->type().exponent_bits() &&
+                  tgt.mantissa_bits() > operand->type().mantissa_bits());
+
+  return ref<Operation>(new UnaryOp(Opcode::FpExt, tgt, operand));
+}
+ref<Operation> UnaryOp::CreateFpToUI(Type tgt, const ref<Operation>& operand) {
+  CAFFEINE_ASSERT(tgt.is_int());
+  CAFFEINE_ASSERT(operand->type().is_float());
+
+  return ref<Operation>(new UnaryOp(Opcode::FpToUI, tgt, operand));
+}
+ref<Operation> UnaryOp::CreateFpToSI(Type tgt, const ref<Operation>& operand) {
+  CAFFEINE_ASSERT(tgt.is_int());
+  CAFFEINE_ASSERT(operand->type().is_float());
+
+  return ref<Operation>(new UnaryOp(Opcode::FpToSI, tgt, operand));
+}
+ref<Operation> UnaryOp::CreateUIToFp(Type tgt, const ref<Operation>& operand) {
+  CAFFEINE_ASSERT(tgt.is_float());
+  CAFFEINE_ASSERT(operand->type().is_int());
+
+  return ref<Operation>(new UnaryOp(Opcode::UIToFp, tgt, operand));
+}
+ref<Operation> UnaryOp::CreateSIToFp(Type tgt, const ref<Operation>& operand) {
+  CAFFEINE_ASSERT(tgt.is_float());
+  CAFFEINE_ASSERT(operand->type().is_int());
+
+  return ref<Operation>(new UnaryOp(Opcode::SIToFp, tgt, operand));
+}
+
 /***************************************************
  * SelectOp                                        *
  ***************************************************/


### PR DESCRIPTION
I noticed that the opcodes for these existed but didn't have any of the needed support operations. This PR implements the needed methods. Note that it isn't currently formatted exactly to match the code style to avoid causing conflicts with #20. (The new code should be formatted correctly, there's some spacing removal that I've kept out as it's also included in #20)