### PR TITLE
[Memory 5/N] Implement memory heap management

### DIFF
--- a/include/caffeine/IR/Visitor.inl
+++ b/include/caffeine/IR/Visitor.inl
@@ -21,6 +21,8 @@ RetTy OpVisitorBase<Transform, SubClass, RetTy>::visit(
     return static_cast<SubClass*>(this)->visitICmp(*icmp);
   if (auto* fcmp = llvm::dyn_cast<transform_t<FCmpOp>>(&op))
     return static_cast<SubClass*>(this)->visitFCmp(*fcmp);
+  if (auto* cnst = llvm::dyn_cast<transform_t<Constant>>(&op))
+    return static_cast<SubClass*>(this)->visitConstant(*cnst);
 
   switch (op.opcode()) {
     DELEGATE(Add, BinaryOp);
@@ -46,7 +48,6 @@ RetTy OpVisitorBase<Transform, SubClass, RetTy>::visit(
     DELEGATE(FNeg, UnaryOp);
 
     DELEGATE(Select, SelectOp);
-    DELEGATE(Constant, Constant);
     DELEGATE(ConstantInt, ConstantInt);
     DELEGATE(ConstantFloat, ConstantFloat);
 
@@ -55,7 +56,7 @@ RetTy OpVisitorBase<Transform, SubClass, RetTy>::visit(
     DELEGATE(Load, LoadOp);
 
   case Operation::BinaryOpLast:
-  case Operaiton::UnaryOpLast:
+  case Operation::UnaryOpLast:
   case Operation::Invalid:
     CAFFEINE_ABORT("tried to visit an invalid operation");
 

--- a/include/caffeine/Interpreter/Context.h
+++ b/include/caffeine/Interpreter/Context.h
@@ -17,6 +17,7 @@ private:
   // The current set of invariants for this context
   std::vector<Assertion> assertions_;
   std::shared_ptr<Solver> solver_;
+  uint64_t constant_num_ = 0;
 
 public:
   Context(llvm::Function* func, std::shared_ptr<Solver> solver);
@@ -37,6 +38,15 @@ public:
   StackFrame& stack_top();
 
   std::shared_ptr<Solver> solver() const;
+
+  /**
+   * Get a unique constant number among all of the ones in this context.
+   *
+   * This is useful for creating the unnamed symbolic constants that are needed
+   * to implement stuff such as memory addresses and the like which can change
+   * from run to run.
+   */
+  uint64_t next_constant();
 
   /**
    * Add a new assertion to this context.

--- a/include/caffeine/Memory/MemHeap.h
+++ b/include/caffeine/Memory/MemHeap.h
@@ -1,0 +1,97 @@
+#ifndef CAFFEINE_MEMORY_MEMHEAP_H
+#define CAFFEINE_MEMORY_MEMHEAP_H
+
+#include "caffeine/IR/Operation.h"
+
+#include <llvm/ADT/APInt.h>
+#include <llvm/IR/DataLayout.h>
+
+#include <vector>
+
+namespace caffeine {
+
+class Context;
+class Assertion;
+
+/**
+ * A memory allocation (either alive or dead).
+ *
+ * In general, an allocation is a tuple (address, size, data, dead) where
+ * - address is the pointer to the start of the allocation.
+ * - size is the size in bytes of the allocation.
+ * - data is an array containing the bytes of the allocation.
+ * - dead indicates whether this allocation has been freed.
+ *
+ * Any of address, size, or data may be either concrete, symbolic, or, for data,
+ * some combination of the two. With the current design, dead will never be
+ * symbolic.
+ *
+ * See the docs for MemHeap for the invariants that are asserted for a new
+ * allocation and the procedure that is used for resolving a pointer to an
+ * allocation.
+ */
+class Allocation {
+private:
+  ref<Operation> address_;
+  ref<Operation> size_;
+  ref<Operation> data_;
+
+  mutable uint32_t refcount = 0;
+  bool dead_;
+
+  template <typename T, typename Deleter>
+  friend class ref;
+
+public:
+  Allocation(const ref<Operation>& address, const ref<Operation>& size,
+             const ref<Operation>& data, bool dead = false);
+  Allocation(const ref<Operation>& address, const ConstantInt& size,
+             const ref<Operation>& data, bool dead = false);
+
+  const ref<Operation>& size() const;
+  ref<Operation>& size();
+
+  const ref<Operation>& data() const;
+  ref<Operation>& data();
+
+  const ref<Operation>& address() const;
+  ref<Operation>& address();
+
+  bool dead() const;
+  bool& dead();
+
+  bool is_constant_size() const;
+
+  /**
+   * Update the internal data array of this allocation.
+   */
+  void overwrite(const ref<Operation>& newdata);
+  void overwrite(ref<Operation>&& newdata);
+
+  /**
+   * Assert that a read from this allocation at the given offset and with the
+   * given width would be a valid inbounds read.
+   */
+  Assertion check_inbounds(const ref<Operation>& offset, uint32_t width) const;
+
+  /**
+   * Read the specified type from the allocation at the given offset.
+   *
+   * Does not assert that the read is inbounds. Callers of this method should
+   * check the assertion first.
+   */
+  ref<Operation> read(const ref<Operation>& offset, const Type& t,
+                      const llvm::DataLayout& layout) const;
+  /**
+   * Write the value to the array at the given offset.
+   *
+   * Does not assert that the write is inbounds. Callers of this method should
+   * add the assertion first.
+   */
+  void write(const ref<Operation>& offset, const ref<Operation>& value,
+             const llvm::DataLayout& layout);
+};
+
+} // namespace caffeine
+
+#endif

--- a/include/caffeine/Memory/MemHeap.h
+++ b/include/caffeine/Memory/MemHeap.h
@@ -1,6 +1,7 @@
 #ifndef CAFFEINE_MEMORY_MEMHEAP_H
 #define CAFFEINE_MEMORY_MEMHEAP_H
 
+#include "caffeine/ADT/SlotMap.h"
 #include "caffeine/IR/Operation.h"
 
 #include <llvm/ADT/APInt.h>
@@ -12,6 +13,7 @@ namespace caffeine {
 
 class Context;
 class Assertion;
+class MemHeap;
 
 /**
  * A memory allocation (either alive or dead).
@@ -36,17 +38,16 @@ private:
   ref<Operation> size_;
   ref<Operation> data_;
 
-  mutable uint32_t refcount = 0;
-  bool dead_;
+  mutable size_t refcount = 0;
 
   template <typename T, typename Deleter>
   friend class ref;
 
 public:
   Allocation(const ref<Operation>& address, const ref<Operation>& size,
-             const ref<Operation>& data, bool dead = false);
+             const ref<Operation>& data);
   Allocation(const ref<Operation>& address, const ConstantInt& size,
-             const ref<Operation>& data, bool dead = false);
+             const ref<Operation>& data);
 
   const ref<Operation>& size() const;
   ref<Operation>& size();
@@ -56,9 +57,6 @@ public:
 
   const ref<Operation>& address() const;
   ref<Operation>& address();
-
-  bool dead() const;
-  bool& dead();
 
   bool is_constant_size() const;
 
@@ -90,6 +88,139 @@ public:
    */
   void write(const ref<Operation>& offset, const ref<Operation>& value,
              const llvm::DataLayout& layout);
+};
+
+using AllocId = typename slot_map<Allocation>::key_type;
+
+/**
+ * A pointer (either raw or to an allocation).
+ *
+ * Pointers have two possible representations:
+ * - An absolute pointer value. This is not known to be associated with any
+ *   allocation and so before it can be dereferenced it will have to be
+ *   re-associated with some allocation.
+ * - An allocation + an offset within that allocation. This is a pointer that is
+ *   known to be relative to an existing allocation.
+ *
+ * To go from the allocation + offset representation just call value(). This is
+ * cheap and quick to do. To go the other way it is necessary to call
+ * MemHeap::resolve. This is usually quite expensive so, where semantics permit,
+ * pointers should be kept as an allocation + offset pair as much as possible.
+ *
+ * # Working with Pointers
+ * The main rule to keep in mind is this: unless you know that the semantics
+ * disallow crossing between allocations (e.g. LLVM's GetElementPtr) then always
+ * use value() to get the absolute pointer and work with that. This will prevent
+ * situations where the code does something like this
+ *
+ * ```
+ * char* a = <allocation>;
+ * char* b = <allocation>;
+ * ptrdiff_t x = a - b;
+ * char v = *(a + x);
+ * ```
+ *
+ * being detected as an out-of-bounds pointer even though this is perfectly
+ * valid code.
+ */
+class Pointer {
+private:
+  AllocId alloc_;
+  ref<Operation> offset_;
+
+public:
+  explicit Pointer(const ref<Operation>& value);
+  Pointer(const AllocId& alloc, const ref<Operation>& offset);
+
+  AllocId alloc() const;
+  const ref<Operation>& offset() const;
+
+  /**
+   * The absolute value of this pointer.
+   *
+   * Pointers can be stored either as an absolute value or as an allocation +
+   * offset pair. This method normalizes it to just the absolute value. Use
+   * MemHeap::resolve to go the other way.
+   */
+  ref<Operation> value(const MemHeap& heap) const;
+
+  /**
+   * Whether this pointer has been resolved to a specific allocation.
+   *
+   * If not, then this is a pointer to an absolute address. Use MemHeap::resolve
+   * to convert it to a set of allocation pointers.
+   */
+  bool is_resolved() const;
+
+  /**
+   * Get an assertion to check if this pointer is a null pointer.
+   */
+  Assertion check_null(const MemHeap& heap) const;
+};
+
+class MemHeap {
+private:
+  slot_map<Allocation> allocs_;
+
+public:
+  MemHeap() = default;
+
+  Allocation& operator[](const AllocId& alloc);
+  const Allocation& operator[](const AllocId& alloc) const;
+
+  /**
+   * Creates a new allocation that has a distinct address from all currently
+   * live allocations.
+   *
+   * This will add the corresponding assertions to the context as well.
+   */
+  AllocId allocate(const ref<Operation>& size, const ref<Operation>& alignment,
+                   Context& ctx);
+
+  /**
+   * Deallocate an existing allocation.
+   *
+   * An assertion failure will result if the allocation is not a valid one for
+   * the current heap.
+   */
+  void deallocate(const AllocId& alloc);
+
+  /**
+   * Check whether the provided allocation is a live allocation on this heap.
+   */
+  bool check_live(const AllocId& alloc) const;
+
+  /**
+   * Get an assertion that checks whether the provided pointer could be a part
+   * of any allocation.
+   *
+   * If the pointer has already been resolved to an allocation then this simply
+   * checks that the offset is not greater than the size. Otherwise, it compares
+   * the absolute value with those of all existant allocations and returns an
+   * assertion that the pointer points within one of them.
+   */
+  Assertion check_valid(const Pointer& value);
+
+  /**
+   * Resolve all the allocations that a pointer could point to.
+   *
+   * This returns a resolved pointer for each allocation. Although it takes a
+   * non-const reference to the context instance, it makes no changes beyond
+   * those that a solver call would make.
+   *
+   * If the pointer is already resolved, then this is a no-op and it just
+   * returns the pointer.
+   *
+   * # Cost
+   * Unless the pointer has already been resolved to an allocation, this method
+   * requires a solver call for every possible allocation. Furthermore, it is
+   * likely to require that the interpreter fork for every returned allocation.
+   * If at all possible, it is recommended to try and avoid needing to call this
+   * method when an already known allocation can be preserved across multiple
+   * uses.
+   */
+  llvm::SmallVector<Pointer, 1> resolve(const Pointer& value,
+                                        Context& ctx) const;
 };
 
 } // namespace caffeine

--- a/include/caffeine/Memory/MemHeap.inl
+++ b/include/caffeine/Memory/MemHeap.inl
@@ -1,0 +1,42 @@
+#ifndef CAFFEINE_MEMORY_MEMHEAP_INL
+#define CAFFEINE_MEMORY_MEMHEAP_INL
+
+#include "caffeine/Memory/MemHeap.h"
+
+namespace caffeine {
+
+/***************************************************
+ * Allocation                                      *
+ ***************************************************/
+
+const ref<Operation>& Allocation::size() const {
+  return size_;
+}
+ref<Operation>& Allocation::size() {
+  return size_;
+}
+
+const ref<Operation>& Allocation::data() const {
+  return data_;
+}
+ref<Operation>& Allocation::data() {
+  return data_;
+}
+
+const ref<Operation>& Allocation::address() const {
+  return address_;
+}
+ref<Operation>& Allocation::address() {
+  return address_;
+}
+
+bool Allocation::dead() const {
+  return dead_;
+}
+bool& Allocation::dead() {
+  return dead_;
+}
+
+} // namespace caffeine
+
+#endif

--- a/include/caffeine/Memory/MemHeap.inl
+++ b/include/caffeine/Memory/MemHeap.inl
@@ -3,38 +3,52 @@
 
 #include "caffeine/Memory/MemHeap.h"
 
+#include <climits>
+
 namespace caffeine {
 
 /***************************************************
  * Allocation                                      *
  ***************************************************/
 
-const ref<Operation>& Allocation::size() const {
+inline const ref<Operation>& Allocation::size() const {
   return size_;
 }
-ref<Operation>& Allocation::size() {
+inline ref<Operation>& Allocation::size() {
   return size_;
 }
 
-const ref<Operation>& Allocation::data() const {
+inline const ref<Operation>& Allocation::data() const {
   return data_;
 }
-ref<Operation>& Allocation::data() {
+inline ref<Operation>& Allocation::data() {
   return data_;
 }
 
-const ref<Operation>& Allocation::address() const {
+inline const ref<Operation>& Allocation::address() const {
   return address_;
 }
-ref<Operation>& Allocation::address() {
+inline ref<Operation>& Allocation::address() {
   return address_;
 }
 
-bool Allocation::dead() const {
-  return dead_;
+/***************************************************
+ * Pointer                                         *
+ ***************************************************/
+
+inline AllocId Pointer::alloc() const {
+  return alloc_;
 }
-bool& Allocation::dead() {
-  return dead_;
+
+inline const ref<Operation>& Pointer::offset() const {
+  return offset_;
+}
+
+inline bool Pointer::is_resolved() const {
+  // TODO: This depends on some internal parts of slot_map which aren't really
+  //       meant to be exposed. It should be fine but if slotmap ever starts
+  //       using a different key type then it'll be necessary to rework this.
+  return alloc_.second == SIZE_MAX;
 }
 
 } // namespace caffeine

--- a/src/Interpreter/Context.cpp
+++ b/src/Interpreter/Context.cpp
@@ -54,4 +54,8 @@ std::unique_ptr<Model> Context::resolve(const Assertion& extra) {
   return solver_->resolve(assertions_, extra);
 }
 
+uint64_t Context::next_constant() {
+  return constant_num_++;
+}
+
 } // namespace caffeine

--- a/src/Memory/MemHeap.cpp
+++ b/src/Memory/MemHeap.cpp
@@ -1,8 +1,12 @@
 #include "caffeine/Memory/MemHeap.h"
 #include "caffeine/IR/Assertion.h"
+#include "caffeine/Interpreter/Context.h"
+#include "caffeine/Solver/Solver.h"
 #include "caffeine/Support/Assert.h"
 
 #include <llvm/ADT/SmallVector.h>
+
+#include <algorithm>
 
 namespace caffeine {
 
@@ -11,16 +15,15 @@ namespace caffeine {
  ***************************************************/
 
 Allocation::Allocation(const ref<Operation>& address,
-                       const ref<Operation>& size, const ref<Operation>& data,
-                       bool dead)
-    : address_(address), size_(size), data_(data), dead_(dead) {
+                       const ref<Operation>& size, const ref<Operation>& data)
+    : address_(address), size_(size), data_(data) {
   CAFFEINE_ASSERT(address->type().is_int());
   CAFFEINE_ASSERT(size->type().is_int());
   CAFFEINE_ASSERT(address->type().bitwidth() == size->type().bitwidth());
 }
 Allocation::Allocation(const ref<Operation>& address, const ConstantInt& size,
-                       const ref<Operation>& data, bool dead)
-    : Allocation(address, make_ref<Operation>(size), data, dead) {}
+                       const ref<Operation>& data)
+    : Allocation(address, make_ref<Operation>(size), data) {}
 
 void Allocation::overwrite(const ref<Operation>& newdata) {
   data_ = newdata;
@@ -135,6 +138,134 @@ void Allocation::write(const ref<Operation>& offset,
 
     overwrite(StoreOp::Create(data(), index, byte));
   }
+}
+
+/***************************************************
+ * Pointer                                         *
+ ***************************************************/
+
+Pointer::Pointer(const ref<Operation>& value)
+    : Pointer({SIZE_MAX, SIZE_MAX}, value) {}
+Pointer::Pointer(const AllocId& alloc, const ref<Operation>& offset)
+    : alloc_(alloc), offset_(offset) {}
+
+ref<Operation> Pointer::value(const MemHeap& heap) const {
+  if (is_resolved())
+    return BinaryOp::CreateAdd(heap[alloc()].address(), offset());
+  return offset();
+}
+
+Assertion Pointer::check_null(const MemHeap& heap) const {
+  return ICmpOp::CreateICmp(ICmpOpcode::EQ, value(heap), 0);
+}
+
+/***************************************************
+ * MemHeap                                         *
+ ***************************************************/
+
+Allocation& MemHeap::operator[](const AllocId& alloc) {
+  return allocs_.at(alloc);
+}
+const Allocation& MemHeap::operator[](const AllocId& alloc) const {
+  return allocs_.at(alloc);
+}
+
+AllocId MemHeap::allocate(const ref<Operation>& size,
+                          const ref<Operation>& alignment, Context& ctx) {
+  CAFFEINE_ASSERT(size->type() == alignment->type());
+  CAFFEINE_ASSERT(size->type().is_int());
+
+  auto allocation = Allocation(
+      Constant::Create(size->type(), ctx.next_constant()), size,
+      AllocOp::Create(size, ConstantInt::Create(llvm::APInt(8, 0xDC))));
+
+  // Ensure that the allocation is properly aligned
+  ctx.add(Assertion(ICmpOp::CreateICmp(
+      ICmpOpcode::EQ, BinaryOp::CreateURem(allocation.address(), alignment),
+      0)));
+
+  for (const auto& alloc : allocs_) {
+    /**
+     * Ensure that the new allocation doesn't overlap with any of the existing
+     * allocations.
+     */
+
+    auto new_start = allocation.address();
+    auto old_start = alloc.address();
+
+    auto new_end = BinaryOp::CreateAdd(allocation.address(), allocation.size());
+    auto old_end = BinaryOp::CreateAdd(alloc.address(), alloc.size());
+
+    auto cmp1 = ICmpOp::CreateICmp(ICmpOpcode::ULE, new_start, old_start);
+    auto cmp2 = ICmpOp::CreateICmp(ICmpOpcode::ULT, old_start, new_end);
+    auto cmp3 = ICmpOp::CreateICmp(ICmpOpcode::ULE, old_start, new_start);
+    auto cmp4 = ICmpOp::CreateICmp(ICmpOpcode::ULT, new_end, old_end);
+
+    ctx.add(!Assertion(BinaryOp::CreateOr(BinaryOp::CreateAnd(cmp1, cmp2),
+                                          BinaryOp::CreateAnd(cmp3, cmp4))));
+  }
+
+  return allocs_.insert(allocation);
+}
+
+void MemHeap::deallocate(const AllocId& alloc) {
+  auto value = allocs_.remove(alloc);
+
+  // Note: This likely means that we're trying to deallocate an allocation that
+  //       was created in an unrelated context.
+  CAFFEINE_ASSERT(value.has_value(),
+                  "tried to deallocate a nonexistant allocation");
+}
+
+bool MemHeap::check_live(const AllocId& alloc) const {
+  return allocs_.find(alloc) != allocs_.end();
+}
+
+Assertion MemHeap::check_valid(const Pointer& ptr) {
+  if (ptr.is_resolved()) {
+    return ICmpOp::CreateICmp(ICmpOpcode::ULE, ptr.offset(),
+                              (*this)[ptr.alloc()].size());
+  }
+
+  auto result = ConstantInt::Create(false);
+  auto value = ptr.value(*this);
+
+  for (const auto& alloc : allocs_) {
+    auto end = BinaryOp::CreateAdd(alloc.address(), alloc.size());
+    auto cmp1 = ICmpOp::CreateICmp(ICmpOpcode::ULE, alloc.address(), value);
+    auto cmp2 = ICmpOp::CreateICmp(ICmpOpcode::ULT, value, end);
+
+    // result |= (address <= value) && (value < address + size)
+    result = BinaryOp::CreateAnd(cmp1, cmp2);
+  }
+
+  return result;
+}
+
+llvm::SmallVector<Pointer, 1> MemHeap::resolve(const Pointer& ptr,
+                                               Context& ctx) const {
+  if (ptr.is_resolved())
+    return llvm::SmallVector<Pointer, 1>{ptr};
+
+  llvm::SmallVector<Pointer, 1> results;
+  auto value = ptr.value(*this);
+
+  auto end = allocs_.end();
+  for (auto it = allocs_.begin(); it != end; ++it) {
+    const auto& alloc = *it;
+
+    auto end = BinaryOp::CreateAdd(alloc.address(), alloc.size());
+    auto cmp1 = ICmpOp::CreateICmp(ICmpOpcode::ULE, alloc.address(), value);
+    auto cmp2 = ICmpOp::CreateICmp(ICmpOpcode::ULT, value, end);
+    auto assertion = BinaryOp::CreateAnd(cmp1, cmp2);
+
+    if (ctx.check(Assertion(assertion)) != SolverResult::UNSAT) {
+      results.push_back(
+          Pointer(it.key(), BinaryOp::CreateSub(value, alloc.address())));
+    }
+  }
+
+  return results;
 }
 
 } // namespace caffeine

--- a/src/Memory/MemHeap.cpp
+++ b/src/Memory/MemHeap.cpp
@@ -1,0 +1,140 @@
+#include "caffeine/Memory/MemHeap.h"
+#include "caffeine/IR/Assertion.h"
+#include "caffeine/Support/Assert.h"
+
+#include <llvm/ADT/SmallVector.h>
+
+namespace caffeine {
+
+/***************************************************
+ * Allocation                                      *
+ ***************************************************/
+
+Allocation::Allocation(const ref<Operation>& address,
+                       const ref<Operation>& size, const ref<Operation>& data,
+                       bool dead)
+    : address_(address), size_(size), data_(data), dead_(dead) {
+  CAFFEINE_ASSERT(address->type().is_int());
+  CAFFEINE_ASSERT(size->type().is_int());
+  CAFFEINE_ASSERT(address->type().bitwidth() == size->type().bitwidth());
+}
+Allocation::Allocation(const ref<Operation>& address, const ConstantInt& size,
+                       const ref<Operation>& data, bool dead)
+    : Allocation(address, make_ref<Operation>(size), data, dead) {}
+
+void Allocation::overwrite(const ref<Operation>& newdata) {
+  data_ = newdata;
+}
+void Allocation::overwrite(ref<Operation>&& newdata) {
+  data_ = std::move(newdata);
+}
+
+bool Allocation::is_constant_size() const {
+  return size()->is_constant();
+}
+
+Assertion Allocation::check_inbounds(const ref<Operation>& offset,
+                                     uint32_t width) const {
+  // Basic check: offset < size && offset + width < size.
+  // Need to check that the entire range is within the allocation.
+  // TODO: Should we check for wraparound, probably not worth it for now.
+
+  auto lower = ICmpOp::CreateICmp(ICmpOpcode::ULT, offset, size());
+  auto upper = ICmpOp::CreateICmp(
+      ICmpOpcode::ULT,
+      BinaryOp::CreateAdd(offset, ConstantInt::Create(llvm::APInt(
+                                      width, Type::pointer_ty().bitwidth()))),
+      size());
+
+  return Assertion(BinaryOp::CreateAnd(std::move(upper), std::move(lower)));
+}
+
+ref<Operation> Allocation::read(const ref<Operation>& offset, const Type& t,
+                                const llvm::DataLayout& llvm) const {
+  /**
+   * Reading data here is actually somewhat complex. We need to effectively
+   * reconstitute the type from its component bytes after we've read them
+   * out of the array.
+   */
+
+  CAFFEINE_ASSERT(!t.is_void(), "attempted to read a value of type void");
+  CAFFEINE_ASSERT(!t.is_array(), "attempted to read a value of type array");
+
+  uint32_t width = t.byte_size(llvm);
+  llvm::SmallVector<ref<Operation>, 8> bytes;
+  bytes.reserve(width);
+
+  for (uint32_t i = 0; i < width; ++i) {
+    auto index = BinaryOp::CreateAdd(
+        offset, ConstantInt::Create(llvm::APInt(offset->type().bitwidth(), i)));
+
+    bytes.push_back(LoadOp::Create(data(), index));
+  }
+
+  if (width == 1)
+    return std::move(bytes[0]);
+
+  uint32_t bitwidth = width * 8;
+  auto bitresult = UnaryOp::CreateZExt(Type::int_ty(bitwidth), bytes[0]);
+
+  for (uint32_t i = 1; i < width; ++i) {
+    // extended = zext(bytes[i], bitwidth) << (i * 8)
+    auto extended = BinaryOp::CreateShl(
+        UnaryOp::CreateZExt(Type::int_ty(bitwidth), bytes[i]),
+        ConstantInt::Create(llvm::APInt(bitwidth, i * 8)));
+    bitresult = BinaryOp::CreateOr(bitresult, extended);
+  }
+
+  if (t.is_int()) {
+    if (t.bitwidth() != bitwidth) {
+      CAFFEINE_ASSERT(t.bitwidth() < bitwidth,
+                      "t.byte_size() returned invalid value");
+
+      bitresult = UnaryOp::CreateTrunc(t, bitresult);
+    }
+
+    return bitresult;
+  }
+
+  return UnaryOp::CreateBitcast(t, bitresult);
+}
+
+void Allocation::write(const ref<Operation>& offset,
+                       const ref<Operation>& value_,
+                       const llvm::DataLayout& layout) {
+  /**
+   * This is essentially the same process as for read but executed in reverse.
+   */
+
+  CAFFEINE_ASSERT(offset->type().is_int(),
+                  "tried to write at non-integer offset");
+
+  auto value = value_;
+  Type t = value->type();
+  uint32_t width = t.byte_size(layout);
+
+  if (t.is_int()) {
+    if (t.bitwidth() == 8) {
+      overwrite(StoreOp::Create(data(), offset, value));
+      return;
+    }
+
+    if (t.bitwidth() != width * 8)
+      value = UnaryOp::CreateZExt(Type::int_ty(width * 8), value);
+  } else {
+    value = UnaryOp::CreateBitcast(Type::int_ty(width * 8), value);
+  }
+
+  for (uint32_t i = 0; i < width; ++i) {
+    auto byte = UnaryOp::CreateTrunc(
+        Type::int_ty(8),
+        BinaryOp::CreateLShr(
+            value, ConstantInt::Create(llvm::APInt(i * 8, width * 8))));
+    auto index = BinaryOp::CreateAdd(
+        offset, ConstantInt::Create(llvm::APInt(i, width * 8)));
+
+    overwrite(StoreOp::Create(data(), index, byte));
+  }
+}
+
+} // namespace caffeine


### PR DESCRIPTION
This PR is meant to implement enough memory support that it can be used within the interpreter.

Here's a list of the changes included in this PR
- Implement an allocation type that models allocations according to the design docs and provides methods to read and write memory as well as checking memory accesses.
- Implement a heap manager `MemHeap` that models allocation, deallocation, resolving pointers, and liveness checking.
- Implement a pointer type. `MemHeap` can be used to resolve these to concrete (allocation, pointer) pairs.

There are no tests at the moment. Being able to write tests is blocked on us having a solver that supports them (so need #19 to land first).

Stuff still TODO:
- Add support for `Load`, `Store`, and `Alloc` to the visitor within Model.
- Implement corresponding operations within `Interpreter`

# Notes for reviewers
The main files that need to be reviewed are `MemHeap.h` and `MemHeap.cpp`.

# Design note for `MemHeap`
It uses a slot_map (instead of storing reference-counted allocations) so that allocations can be shared across multiple forked contexts. (e.g. they're stable even when the allocation gets cloned).

This PR currently depends on #34 and #35 and includes their changes.