### PR TITLE
Move solver and assertions into Context

### DIFF
--- a/include/caffeine/IR/Assertion.h
+++ b/include/caffeine/IR/Assertion.h
@@ -16,7 +16,7 @@ private:
   ref<Operation> value_;
 
 public:
-  Assertion() = default;
+  Assertion();
   Assertion(const ref<Operation>& value);
 
   ref<Operation>& value() &;
@@ -26,6 +26,10 @@ public:
 
   bool is_empty() const;
   bool is_constant() const;
+
+  Assertion operator!() const;
+
+  static Assertion constant(bool value);
 };
 
 } // namespace caffeine

--- a/include/caffeine/Interpreter/Context.h
+++ b/include/caffeine/Interpreter/Context.h
@@ -5,6 +5,7 @@
 
 #include <llvm/IR/Function.h>
 
+#include "caffeine/IR/Assertion.h"
 #include "caffeine/Interpreter/StackFrame.h"
 #include "caffeine/Solver/Solver.h"
 
@@ -13,9 +14,12 @@ namespace caffeine {
 class Context {
 private:
   std::vector<StackFrame> stack;
+  // The current set of invariants for this context
+  std::vector<Assertion> assertions_;
+  std::shared_ptr<Solver> solver_;
 
 public:
-  Context(llvm::Function* func);
+  Context(llvm::Function* func, std::shared_ptr<Solver> solver);
 
   /**
    * Create a new context that is independent from this
@@ -31,6 +35,31 @@ public:
    * structures are implemented.
    */
   StackFrame& stack_top();
+
+  std::shared_ptr<Solver> solver() const;
+
+  /**
+   * Add a new assertion to this context.
+   */
+  void add(const Assertion& assertion);
+  void add(Assertion&& assertion);
+
+  /**
+   * Validate whether the set of assertions combined with the extra assertion is
+   * satisfiable.
+   *
+   * See the docs on Solver::check for more details.
+   */
+  SolverResult check(const Assertion& extra = Assertion::constant(true));
+
+  /**
+   * Validate whether the set of assertions combined with the extra assertion is
+   * satisfiable and, if so, return a model.
+   *
+   * See the docs on Solver::resolve for more details.
+   */
+  std::unique_ptr<Model>
+  resolve(const Assertion& extra = Assertion::constant(true));
 };
 
 } // namespace caffeine

--- a/include/caffeine/Interpreter/Interpreter.h
+++ b/include/caffeine/Interpreter/Interpreter.h
@@ -18,21 +18,13 @@ private:
   Context* ctx;
   Executor* queue;
 
-  /**
-   * The current set of invariants for this context
-   */
-  std::vector<Assertion> assertions;
-
-  std::shared_ptr<Solver> solver;
-
 public:
   /**
    * The interpreter constructor needs an executor and context
    *
    * TODO: Add failure tracker
    */
-  Interpreter(Executor* queue, Context* ctx,
-              const std::shared_ptr<Solver>& solver);
+  Interpreter(Executor* queue, Context* ct);
 
   void execute();
 

--- a/src/IR/Assertion.cpp
+++ b/src/IR/Assertion.cpp
@@ -4,6 +4,7 @@
 
 namespace caffeine {
 
+Assertion::Assertion() : Assertion(constant(true)) {}
 Assertion::Assertion(const ref<Operation>& value) : value_(value) {
   CAFFEINE_ASSERT(value, "created assertion with null expression");
   CAFFEINE_ASSERT(value->type() == Type::int_ty(1));
@@ -12,6 +13,16 @@ Assertion::Assertion(const ref<Operation>& value) : value_(value) {
 bool Assertion::is_constant() const {
   CAFFEINE_ASSERT(value_, "assertion had null value");
   return value_->is_constant();
+}
+
+Assertion Assertion::operator!() const {
+  CAFFEINE_ASSERT(value_, "assertion had null value");
+  return Assertion(UnaryOp::CreateNot(value_));
+}
+
+Assertion Assertion::constant(bool value) {
+  return Assertion(
+      ConstantInt::Create(llvm::APInt(1, static_cast<uint64_t>(value))));
 }
 
 } // namespace caffeine

--- a/src/Interpreter/Context.cpp
+++ b/src/Interpreter/Context.cpp
@@ -19,7 +19,8 @@ void assert_int(llvm::Type* type) {
   CAFFEINE_ABORT(message);
 }
 
-Context::Context(llvm::Function* function) {
+Context::Context(llvm::Function* function, std::shared_ptr<Solver> solver)
+    : solver_(std::move(solver)) {
   stack.emplace_back(function);
   StackFrame& frame = stack_top();
 
@@ -33,6 +34,24 @@ Context::Context(llvm::Function* function) {
 
 Context Context::fork() const {
   return Context{*this};
+}
+
+std::shared_ptr<Solver> Context::solver() const {
+  return solver_;
+}
+
+void Context::add(const Assertion& assertion) {
+  assertions_.push_back(assertion);
+}
+void Context::add(Assertion&& assertion) {
+  assertions_.push_back(std::move(assertion));
+}
+
+SolverResult Context::check(const Assertion& extra) {
+  return solver_->check(assertions_, extra);
+}
+std::unique_ptr<Model> Context::resolve(const Assertion& extra) {
+  return solver_->resolve(assertions_, extra);
 }
 
 } // namespace caffeine

--- a/src/Interpreter/Interpreter.cpp
+++ b/src/Interpreter/Interpreter.cpp
@@ -6,9 +6,8 @@
 
 namespace caffeine {
 
-Interpreter::Interpreter(Executor* queue, Context* ctx,
-                         const std::shared_ptr<Solver>& solver)
-    : ctx{ctx}, queue{queue}, solver{solver} {}
+Interpreter::Interpreter(Executor* queue, Context* ctx)
+    : ctx{ctx}, queue{queue} {}
 
 void Interpreter::execute() {
   ExecutionResult exec;


### PR DESCRIPTION
This is a small refactor so that the set of assertions associated with a context can be used outside of the interpreter.