### PR TITLE
Add shortcut methods for creating operations involving constants

### DIFF
--- a/include/caffeine/IR/Operation.h
+++ b/include/caffeine/IR/Operation.h
@@ -342,6 +342,8 @@ public:
 
   static ref<Operation> Create(const llvm::APInt& iconst);
   static ref<Operation> Create(llvm::APInt&& iconst);
+  // Specialization for creating boolean constants
+  static ref<Operation> Create(bool value);
 
   static bool classof(const Operation* op);
 };
@@ -512,6 +514,10 @@ public:
   bool is_unsigned() const;
 
   static ref<Operation> CreateICmp(ICmpOpcode cmp, const ref<Operation>& lhs,
+                                   const ref<Operation>& rhs);
+  static ref<Operation> CreateICmp(ICmpOpcode cmp, const ref<Operation>& lhs,
+                                   uint64_t rhs);
+  static ref<Operation> CreateICmp(ICmpOpcode cmp, uint64_t lhs,
                                    const ref<Operation>& rhs);
 
   bool classof(const Operation* op);

--- a/src/IR/Operation.cpp
+++ b/src/IR/Operation.cpp
@@ -313,6 +313,9 @@ ref<Operation> ConstantInt::Create(const llvm::APInt& iconst) {
 ref<Operation> ConstantInt::Create(llvm::APInt&& iconst) {
   return ref<Operation>(new ConstantInt(iconst));
 }
+ref<Operation> ConstantInt::Create(bool value) {
+  return ConstantInt::Create(llvm::APInt(1, static_cast<uint64_t>(value)));
+}
 
 /***************************************************
  * ConstantFloat                                   *
@@ -513,6 +516,24 @@ ref<Operation> ICmpOp::CreateICmp(ICmpOpcode cmp, const ref<Operation>& lhs,
                   "icmp can only be created with integer operands");
 
   return ref<Operation>(new ICmpOp(cmp, lhs->type(), lhs, rhs));
+}
+ref<Operation> ICmpOp::CreateICmp(ICmpOpcode cmp, const ref<Operation>& lhs,
+                                  uint64_t rhs) {
+  CAFFEINE_ASSERT(lhs, "lhs was null");
+  CAFFEINE_ASSERT(lhs->type().is_int(),
+                  "icmp can only be created with integer operands");
+
+  return ICmpOp::CreateICmp(
+      cmp, lhs, ConstantInt::Create(llvm::APInt(lhs->type().bitwidth(), rhs)));
+}
+ref<Operation> ICmpOp::CreateICmp(ICmpOpcode cmp, uint64_t lhs,
+                                  const ref<Operation>& rhs) {
+  CAFFEINE_ASSERT(rhs, "rhs was null");
+  CAFFEINE_ASSERT(rhs->type().is_int(),
+                  "icmp can only be created with integer operands");
+
+  return ICmpOp::CreateICmp(
+      cmp, ConstantInt::Create(llvm::APInt(rhs->type().bitwidth(), lhs)), rhs);
 }
 
 /***************************************************

--- a/src/IR/Operation.cpp
+++ b/src/IR/Operation.cpp
@@ -515,7 +515,7 @@ ref<Operation> ICmpOp::CreateICmp(ICmpOpcode cmp, const ref<Operation>& lhs,
   CAFFEINE_ASSERT(lhs->type().is_int(),
                   "icmp can only be created with integer operands");
 
-  return ref<Operation>(new ICmpOp(cmp, lhs->type(), lhs, rhs));
+  return ref<Operation>(new ICmpOp(cmp, Type::int_ty(1), lhs, rhs));
 }
 ref<Operation> ICmpOp::CreateICmp(ICmpOpcode cmp, const ref<Operation>& lhs,
                                   uint64_t rhs) {


### PR DESCRIPTION
This just adds some shortcuts for creating ICmp operations involving constants