### PR TITLE
Make everything compile and add main executable

### DIFF
--- a/cmake/formatting.cmake
+++ b/cmake/formatting.cmake
@@ -35,7 +35,7 @@ foreach(source ${fmt_sources})
     OUTPUT "${CMAKE_BINARY_DIR}/.fmt/${source}"
     COMMAND ${CMAKE_COMMAND} -E make_directory "${CMAKE_BINARY_DIR}/.fmt/${source_dir}"
     COMMAND ${CLANG_FORMAT} "${CMAKE_SOURCE_DIR}/${source}" > "${CMAKE_BINARY_DIR}/.fmt/${source}"
-    COMMAND diff -u "${CMAKE_SOURCE_DIR}/${source}" "${CMAKE_BINARY_DIR}/.fmt/${source}"
+    COMMAND diff --color=always -u "${CMAKE_SOURCE_DIR}/${source}" "${CMAKE_BINARY_DIR}/.fmt/${source}"
     DEPENDS "${CMAKE_SOURCE_DIR}/${source}"
     COMMENT "Checking formatting for ${source_name}"
     WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}"

--- a/include/caffeine/IR/Operation.h
+++ b/include/caffeine/IR/Operation.h
@@ -259,6 +259,7 @@ protected:
   Operation(Opcode op, llvm::APFloat&& fconst);
 
   Operation(Opcode op, Type t, const std::string& name);
+  Operation(Opcode op, Type t, uint64_t number);
 
   Operation(Opcode op, Type t, const ref<Operation>& op0);
   Operation(Opcode op, Type t, const ref<Operation>& op0,
@@ -353,6 +354,7 @@ class Constant : public Operation {
 private:
   Constant(Type t, const std::string& name);
   Constant(Type t, std::string&& name);
+  Constant(Type t, uint64_t number);
 
 public:
   std::string_view name() const;
@@ -529,7 +531,7 @@ public:
                                const ref<Operation>& true_value,
                                const ref<Operation>& false_value);
 
-  bool classof(const Operation* op);
+  static bool classof(const Operation* op);
 };
 
 /**
@@ -564,7 +566,7 @@ public:
   static ref<Operation> CreateICmp(ICmpOpcode cmp, uint64_t lhs,
                                    const ref<Operation>& rhs);
 
-  bool classof(const Operation* op);
+  static bool classof(const Operation* op);
 };
 
 /**
@@ -586,7 +588,7 @@ public:
   static ref<Operation> CreateFCmp(FCmpOpcode cmp, const ref<Operation>& lhs,
                                    const ref<Operation>& rhs);
 
-  bool classof(const Operation* op);
+  static bool classof(const Operation* op);
 };
 
 /**
@@ -610,7 +612,7 @@ public:
   static ref<Operation> Create(const ref<Operation>& size,
                                const ref<Operation>& defaultval);
 
-  bool classof(const Operation* op);
+  static bool classof(const Operation* op);
 };
 
 /**
@@ -632,7 +634,7 @@ public:
   static ref<Operation> Create(const ref<Operation>& data,
                                const ref<Operation>& offset);
 
-  bool classof(const Operation* op);
+  static bool classof(const Operation* op);
 };
 
 /**
@@ -660,7 +662,7 @@ public:
                                const ref<Operation>& offset,
                                const ref<Operation>& value);
 
-  bool classof(const Operation* op);
+  static bool classof(const Operation* op);
 };
 
 } // namespace caffeine

--- a/include/caffeine/IR/Value.h
+++ b/include/caffeine/IR/Value.h
@@ -4,6 +4,8 @@
 #include <llvm/ADT/APFloat.h>
 #include <llvm/ADT/APInt.h>
 
+#include <iosfwd>
+
 namespace caffeine {
 
 class Type;
@@ -106,7 +108,11 @@ public:
 
 private:
   void invalidate();
+
+  friend std::ostream& operator<<(std::ostream& os, const Value& v);
 };
+
+std::ostream& operator<<(std::ostream& os, const Value& v);
 
 } // namespace caffeine
 

--- a/include/caffeine/IR/Visitor.h
+++ b/include/caffeine/IR/Visitor.h
@@ -4,6 +4,7 @@
 #include "caffeine/IR/Operation.h"
 
 #include <llvm/IR/InstVisitor.h>
+#include <llvm/Support/Casting.h>
 
 namespace caffeine {
 
@@ -19,9 +20,9 @@ namespace detail {
   };
 } // namespace detail
 
-#define CAFFEINE_OP_DELEGATE(class)                                            \
-  static_cast<SubClass*>(this)->visit##class(                                  \
-      static_cast<transform_t<class>&>(O))
+#define CAFFEINE_OP_DELEGATE(class_)                                           \
+  static_cast<SubClass*>(this)->visit##class_(                                 \
+      static_cast<transform_t<class_>&>(O))
 
 /**
  * Base class for operation visitors.
@@ -84,9 +85,6 @@ private:
   using transform_t = typename Transform<T>::type;
 
 public:
-  RetTy visit(transform_t<Operation>& O);
-  RetTy visit(transform_t<Operation>* O);
-
   void visitOperation(transform_t<Operation>&) {}
 
   // clang-format off
@@ -140,6 +138,9 @@ public:
   RetTy visitSIToFp (transform_t<UnaryOp>& O) { return CAFFEINE_OP_DELEGATE(UnaryOp); }
   RetTy visitBitcast(transform_t<UnaryOp>& O) { return CAFFEINE_OP_DELEGATE(UnaryOp); }
   // clang-format on
+
+  RetTy visit(transform_t<Operation>* O);
+  RetTy visit(transform_t<Operation>& O);
 };
 
 /**
@@ -161,5 +162,7 @@ using ConstOpVisitor = OpVisitorBase<detail::as_const, SubClass, RetTy>;
 #undef CAFFEINE_OP_DELEGATE
 
 } // namespace caffeine
+
+#include "Visitor.inl"
 
 #endif

--- a/include/caffeine/Interpreter/Context.h
+++ b/include/caffeine/Interpreter/Context.h
@@ -39,6 +39,9 @@ public:
 
   std::shared_ptr<Solver> solver() const;
 
+  llvm::iterator_range<std::vector<Assertion>::const_iterator>
+  assertions() const;
+
   /**
    * Get a unique constant number among all of the ones in this context.
    *

--- a/include/caffeine/Interpreter/FailureLogger.h
+++ b/include/caffeine/Interpreter/FailureLogger.h
@@ -1,0 +1,38 @@
+#ifndef CAFFEINE_INTERPRETER_FAILURELOGGER_H
+#define CAFFEINE_INTERPRETER_FAILURELOGGER_H
+
+#include "caffeine/Interpreter/Context.h"
+#include "caffeine/Solver/Solver.h"
+
+#include <iosfwd>
+
+namespace caffeine {
+
+class FailureLogger {
+public:
+  FailureLogger() = default;
+  virtual ~FailureLogger() = default;
+
+  virtual void log_failure(const Model* model, const Context& context) = 0;
+
+protected:
+  FailureLogger(const FailureLogger&) = default;
+  FailureLogger(FailureLogger&&) = default;
+
+  FailureLogger& operator=(const FailureLogger&) = default;
+  FailureLogger& operator=(FailureLogger&&) = default;
+};
+
+class PrintingFailureLogger : public FailureLogger {
+private:
+  std::ostream* os;
+
+public:
+  PrintingFailureLogger(std::ostream& os);
+
+  void log_failure(const Model* model, const Context& context) override;
+};
+
+} // namespace caffeine
+
+#endif

--- a/include/caffeine/Interpreter/Interpreter.h
+++ b/include/caffeine/Interpreter/Interpreter.h
@@ -5,6 +5,7 @@
 
 #include "caffeine/IR/Assertion.h"
 #include "caffeine/Interpreter/Executor.h"
+#include "caffeine/Interpreter/FailureLogger.h"
 #include "caffeine/Support/Assert.h"
 
 #include <llvm/IR/InstVisitor.h>
@@ -17,14 +18,14 @@ class Interpreter : public llvm::InstVisitor<Interpreter, ExecutionResult> {
 private:
   Context* ctx;
   Executor* queue;
+  FailureLogger* logger;
 
 public:
   /**
-   * The interpreter constructor needs an executor and context
-   *
-   * TODO: Add failure tracker
+   * The interpreter constructor needs an executor and context as well as a way
+   * to log assertion failures.
    */
-  Interpreter(Executor* queue, Context* ct);
+  Interpreter(Executor* queue, Context* ctx, FailureLogger* logger);
 
   void execute();
 

--- a/include/caffeine/Solver/Z3Solver.h
+++ b/include/caffeine/Solver/Z3Solver.h
@@ -20,6 +20,8 @@ public:
   Z3OpVisitor(z3::context* ctx,
               std::unordered_map<std::string, z3::expr>& constMap);
 
+  z3::expr visitOperation(const Operation& op);
+
   // clang-format off
   z3::expr visitConstant     (const Constant& op);
   z3::expr visitConstantInt  (const ConstantInt& op);
@@ -83,36 +85,6 @@ public:
 
   /**
    * Validate whether the set of assertions combined with the extra assertion,
-   * if it isn't empty, is satisfiable.
-   *
-   * Solvers are free to perform any modifications to the assertions vector
-   * provided as long as they
-   * 1. don't change the satisfiability of the end result or the space of valid
-   *    models, and
-   * 2. don't incorporate any information from `extra`. As an example, if the
-   *    assertion vector contains `x < 5` and `x = 2` then it would be valid to
-   *    simplify that to `true` and `x = 2`. But if extra is `x = 2` then it
-   *    wouldn't be valid to perform that simplification. Note, however, that
-   *    the final SAT/UNSAT result should take extra into account.
-   *
-   * This includes modifying the backing expression trees and so on. Note that
-   * care must be taken not to modify expressions that have multiple references
-   * (refcount > 1) as that could modify unrelated expressions.
-   *
-   * Default Implementation
-   * ======================
-   * By default this is implemented by calling resolve and then throwing away
-   * the model.
-   *
-   * Solver adapters should forward this method (after performing any applicable
-   * modifications to the assertions) as it may be more efficient for some
-   * solvers.
-   */
-  SolverResult check(std::vector<Assertion>& assertions,
-                     const Assertion& extra);
-
-  /**
-   * Validate whether the set of assertions combined with the extra assertion,
    * if it isn't empty, is satisfiable and return a model.
    *
    * Solvers are free to perform any modifications to the assertions vector
@@ -130,7 +102,7 @@ public:
    * (refcount > 1) as that could modify unrelated expressions.
    */
   std::unique_ptr<Model> resolve(std::vector<Assertion>& assertions,
-                                 const Assertion& extra);
+                                 const Assertion& extra) override;
 };
 
 } // namespace caffeine

--- a/include/caffeine/Support/Macros.h
+++ b/include/caffeine/Support/Macros.h
@@ -1,0 +1,37 @@
+#ifndef CAFFEINE_SUPPORT_MACROS_H
+#define CAFFEINE_SUPPORT_MACROS_H
+
+/**
+ * Support library for doing macro tricks.
+ */
+
+#define CAFFEINE_CONCAT_(x, y) x##y
+#define CAFFEINE_CONCAT(x, y) CAFFEINE_CONCAT_(x, y)
+
+#define CAFFEINE_EXPAND(x) x
+
+#define CAFFEINE_FIRST(x, ...) x
+
+#define CAFFEINE_INVOKE_NUMBERED_(x, _1, _2, _3, _4, _5, _6, _7, _8, _9, FUNC, \
+                                  ...)                                         \
+  FUNC
+/**
+ *
+ *
+ * Based off of https://stackoverflow.com/a/8814003/4821282
+ */
+#define CAFFEINE_INVOKE_NUMBERED(macro, ...)                                   \
+  CAFFEINE_EXPAND(CAFFEINE_INVOKE_NUMBERED_(                                   \
+      , ##__VA_ARGS__ /* this comment makes the autoformatter work better */,  \
+      CAFFEINE_CONCAT(macro, 9)(__VA_ARGS__),                                  \
+      CAFFEINE_CONCAT(macro, 8)(__VA_ARGS__),                                  \
+      CAFFEINE_CONCAT(macro, 7)(__VA_ARGS__),                                  \
+      CAFFEINE_CONCAT(macro, 6)(__VA_ARGS__),                                  \
+      CAFFEINE_CONCAT(macro, 5)(__VA_ARGS__),                                  \
+      CAFFEINE_CONCAT(macro, 4)(__VA_ARGS__),                                  \
+      CAFFEINE_CONCAT(macro, 3)(__VA_ARGS__),                                  \
+      CAFFEINE_CONCAT(macro, 2)(__VA_ARGS__),                                  \
+      CAFFEINE_CONCAT(macro, 1)(__VA_ARGS__),                                  \
+      CAFFEINE_CONCAT(macro, 0)(__VA_ARGS__)))
+
+#endif

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,5 +1,5 @@
 
-add_subdirectory(Bin)
+add_subdirectory(bin)
 
 file(
   GLOB subdirs

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,11 +1,31 @@
 
+add_subdirectory(Bin)
+
 file(
-  GLOB_RECURSE sources
+  GLOB subdirs
   CONFIGURE_DEPENDS
-  *.cpp
-  *.hpp
-  *.h
+  RELATIVE "${CMAKE_CURRENT_SOURCE_DIR}"
+  "${CMAKE_CURRENT_SOURCE_DIR}/*"
 )
+
+set(sources "")
+
+foreach(subdir ${subdirs})
+  if (
+    IS_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/${subdir}"
+    AND NOT "${subdir}" STREQUAL "bin")
+
+    file(
+      GLOB_RECURSE dir_sources
+      CONFIGURE_DEPENDS
+      "${subdir}/*.cpp"
+      "${subdir}/*.hpp"
+      "${subdir}/*.h"
+    )
+
+    list(APPEND sources ${dir_sources})
+  endif()
+endforeach()
 
 file(
   GLOB_RECURSE headers

--- a/src/IR/Operation.cpp
+++ b/src/IR/Operation.cpp
@@ -31,7 +31,7 @@ Operation::Operation(Opcode op, const llvm::APInt& iconst)
 Operation::Operation(Opcode op, llvm::APInt&& iconst)
     : opcode_(op), type_(Type::type_of(iconst)), iconst_(iconst) {
   // Currently only ConstantInt is valid here
-  CAFFEINE_ASSERT(op == ConstantInt || op == ConstantNumbered);
+  CAFFEINE_ASSERT(op == ConstantInt);
 }
 
 Operation::Operation(Opcode op, const llvm::APFloat& fconst)
@@ -46,6 +46,10 @@ Operation::Operation(Opcode op, llvm::APFloat&& fconst)
 Operation::Operation(Opcode op, Type t, const std::string& name)
     : opcode_(op), type_(t), name_(name) {
   CAFFEINE_ASSERT(op == ConstantNamed);
+}
+Operation::Operation(Opcode op, Type t, uint64_t number)
+    : opcode_(op), type_(t), iconst_(64, number) {
+  CAFFEINE_ASSERT(op == ConstantNumbered);
 }
 
 Operation::Operation(const Operation& op) noexcept
@@ -323,6 +327,30 @@ const char* Operation::opcode_name(Opcode op) {
   }
   // clang-format on
   return "Unknown";
+}
+
+/***************************************************
+ * Constant                                        *
+ ***************************************************/
+Constant::Constant(Type t, const std::string& name)
+    : Operation(ConstantNamed, t, name) {}
+Constant::Constant(Type t, std::string&& name)
+    : Operation(ConstantNamed, t, std::move(name)) {}
+Constant::Constant(Type t, uint64_t number)
+    : Operation(ConstantNumbered, t, number) {}
+
+ref<Operation> Constant::Create(Type t, const std::string& name) {
+  CAFFEINE_ASSERT(!name.empty(), "cannot create constant with empty name");
+
+  return ref<Operation>(new Constant(t, name));
+}
+ref<Operation> Constant::Create(Type t, std::string&& name) {
+  CAFFEINE_ASSERT(!name.empty(), "cannot create constant with empty name");
+
+  return ref<Operation>(new Constant(t, std::move(name)));
+}
+ref<Operation> Constant::Create(Type t, uint64_t number) {
+  return ref<Operation>(new Constant(t, number));
 }
 
 /***************************************************

--- a/src/Interpreter/Context.cpp
+++ b/src/Interpreter/Context.cpp
@@ -36,8 +36,18 @@ Context Context::fork() const {
   return Context{*this};
 }
 
+StackFrame& Context::stack_top() {
+  CAFFEINE_ASSERT(!stack.empty());
+  return stack.back();
+}
+
 std::shared_ptr<Solver> Context::solver() const {
   return solver_;
+}
+
+llvm::iterator_range<std::vector<Assertion>::const_iterator>
+Context::assertions() const {
+  return {std::begin(assertions_), std::end(assertions_)};
 }
 
 void Context::add(const Assertion& assertion) {

--- a/src/Interpreter/Executor.cpp
+++ b/src/Interpreter/Executor.cpp
@@ -1,0 +1,21 @@
+#include "caffeine/Interpreter/Executor.h"
+
+namespace caffeine {
+
+void Executor::add_context(Context&& ctx) {
+  contexts.push_back(ctx);
+}
+
+Context Executor::next_context() {
+  CAFFEINE_ASSERT(!contexts.empty());
+
+  auto ctx = std::move(contexts.back());
+  contexts.pop_back();
+  return ctx;
+}
+
+bool Executor::has_next() const {
+  return !contexts.empty();
+}
+
+} // namespace caffeine

--- a/src/Interpreter/Interpreter.cpp
+++ b/src/Interpreter/Interpreter.cpp
@@ -6,8 +6,8 @@
 
 namespace caffeine {
 
-Interpreter::Interpreter(Executor* queue, Context* ctx)
-    : ctx{ctx}, queue{queue} {}
+Interpreter::Interpreter(Executor* queue, Context* ctx, FailureLogger* logger)
+    : ctx{ctx}, queue{queue}, logger{logger} {}
 
 void Interpreter::execute() {
   ExecutionResult exec;

--- a/src/Interpreter/PrintingFailureLogger.cpp
+++ b/src/Interpreter/PrintingFailureLogger.cpp
@@ -1,0 +1,63 @@
+#include "caffeine/Interpreter/FailureLogger.h"
+
+#include "caffeine/IR/Visitor.h"
+
+#include <iostream>
+#include <unordered_set>
+
+namespace caffeine {
+
+class ConstantPrinter : public ConstOpVisitor<ConstantPrinter> {
+private:
+  std::ostream& os;
+  const Model* model;
+  std::unordered_set<std::string_view> seen;
+
+public:
+  ConstantPrinter(std::ostream& os, const Model* model)
+      : os(os), model(model) {}
+
+  void visitOperation(const Operation& op) {
+    for (const auto& operand : op.operands()) {
+      visit(operand);
+    }
+  }
+
+  void visitConstant(const Constant& c) {
+    // TODO: Figure out how to print numbered constants and whether we'd want
+    //       to.
+    if (!c.is_named())
+      return;
+
+    // We've already printed this constant.
+    if (!seen.insert(c.name()).second)
+      return;
+
+    auto value = model->lookup(c);
+
+    os << "  " << c.name() << " = " << value << "\n";
+  }
+};
+
+/***************************************************
+ * PrintingFailureLogger                           *
+ ***************************************************/
+
+PrintingFailureLogger::PrintingFailureLogger(std::ostream& os) : os(&os) {}
+
+void PrintingFailureLogger::log_failure(const Model* model,
+                                        const Context& ctx) {
+  CAFFEINE_ASSERT(model->result() == SolverResult::SAT);
+
+  ConstantPrinter printer{*os, model};
+
+  *os << "Found assertion failure:\n";
+
+  for (const auto& assertion : ctx.assertions()) {
+    printer.visit(*assertion.value());
+  }
+
+  *os << std::flush;
+}
+
+} // namespace caffeine

--- a/src/Solver/Z3Solver.cpp
+++ b/src/Solver/Z3Solver.cpp
@@ -2,8 +2,13 @@
 #include "caffeine/IR/Type.h"
 #include "caffeine/Support/Assert.h"
 
+#include <fmt/format.h>
+
 namespace caffeine {
 
+/***************************************************
+ * Z3Model                                         *
+ ***************************************************/
 Z3Model::Z3Model(SolverResult result, z3::context* ctx, z3::model model,
                  const std::unordered_map<std::string, z3::expr>& map)
     : Model(result), ctx(ctx), model(model), constants(map) {}
@@ -24,6 +29,9 @@ Value Z3Model::lookup(const Constant& constant) const {
   }
 }
 
+/***************************************************
+ * Z3Solver                                        *
+ ***************************************************/
 Z3Solver::Z3Solver() {
   // We want z3 to generate models
   ctx.set("model", true);
@@ -65,11 +73,17 @@ std::unique_ptr<Model> Z3Solver::resolve(std::vector<Assertion>& assertions,
   }
 }
 
-// #########################################################
-
+/***************************************************
+ * Z3OpVisitor                                     *
+ ***************************************************/
 Z3OpVisitor::Z3OpVisitor(z3::context* ctx,
                          std::unordered_map<std::string, z3::expr>& constMap)
     : ctx(ctx), constMap(constMap) {}
+
+z3::expr Z3OpVisitor::visitOperation(const Operation& op) {
+  CAFFEINE_ABORT(fmt::format("Z3Solver does not have support for opcode {}",
+                             op.opcode_name()));
+}
 
 z3::expr Z3OpVisitor::visitConstant(const Constant& op) {
   auto type = op.type();
@@ -157,6 +171,7 @@ CAFFEINE_BINOP_IMPL(LShr, z3::lshr(lhs, rhs))
 CAFFEINE_BINOP_IMPL(AShr, z3::ashr(lhs, rhs))
 CAFFEINE_BINOP_IMPL(FAdd, lhs + rhs)
 CAFFEINE_BINOP_IMPL(FSub, lhs - rhs)
+CAFFEINE_BINOP_IMPL(FMul, lhs * rhs)
 CAFFEINE_BINOP_IMPL(FDiv, lhs / rhs)
 CAFFEINE_BINOP_IMPL(FRem, lhs % rhs)
 #undef CAFFEINE_BINOP_IMPL

--- a/src/bin/CMakeLists.txt
+++ b/src/bin/CMakeLists.txt
@@ -1,0 +1,5 @@
+
+add_executable(caffeine-bin caffeine.cpp)
+
+target_link_libraries(caffeine-bin PRIVATE caffeine)
+target_link_libraries(caffeine-bin PRIVATE LLVMIRReader)

--- a/src/bin/caffeine.cpp
+++ b/src/bin/caffeine.cpp
@@ -1,0 +1,110 @@
+
+#include "caffeine/Interpreter/Interpreter.h"
+#include "caffeine/Solver/Z3Solver.h"
+
+#include <llvm/IR/DiagnosticInfo.h>
+#include <llvm/IR/DiagnosticPrinter.h>
+#include <llvm/IR/Module.h>
+#include <llvm/IRReader/IRReader.h>
+#include <llvm/Support/CommandLine.h>
+#include <llvm/Support/InitLLVM.h>
+#include <llvm/Support/WithColor.h>
+
+#include <iostream>
+#include <memory>
+
+using namespace llvm;
+
+using caffeine::Context;
+using caffeine::Executor;
+using caffeine::Interpreter;
+
+cl::opt<std::string> input_filename{cl::Positional};
+cl::opt<std::string> target_method{cl::Positional};
+
+static ExitOnError exit_on_err;
+
+namespace {
+struct DecafDiagnosticHandler : public DiagnosticHandler {
+  bool handleDiagnostics(const DiagnosticInfo& di) override {
+    unsigned severity = di.getSeverity();
+    switch (severity) {
+    case DS_Error:
+      WithColor::error();
+      break;
+    case DS_Warning:
+      WithColor::warning();
+      break;
+    case DS_Remark:
+      WithColor::remark();
+      break;
+    case DS_Note:
+      WithColor::note();
+      break;
+    default:
+      llvm_unreachable("DiagnosticInfo had unknown severity level");
+    }
+
+    DiagnosticPrinterRawOStream dp(errs());
+    di.print(dp);
+    errs() << '\n';
+
+    return true;
+  }
+};
+} // namespace
+
+static std::unique_ptr<Module>
+loadFile(const char* argv0, const std::string& filename, LLVMContext& context) {
+  llvm::SMDiagnostic error;
+  auto module = llvm::parseIRFile(filename, error, context);
+
+  if (!module) {
+    error.print(argv0, llvm::errs());
+    return nullptr;
+  }
+
+  return module;
+}
+
+int main(int argc, char** argv) {
+  InitLLVM X(argc, argv);
+  exit_on_err.setBanner(std::string(argv[0]) + ":");
+
+  LLVMContext context;
+  context.setDiagnosticHandler(std::make_unique<DecafDiagnosticHandler>(),
+                               true);
+
+  cl::ParseCommandLineOptions(argc, argv, "symbolic executor for LLVM IR");
+
+  auto module = loadFile(argv[0], input_filename.getValue(), context);
+  if (!module) {
+    errs() << argv[0] << ": ";
+    WithColor::error() << " loading file '" << input_filename.getValue()
+                       << "'\n";
+    return 1;
+  }
+
+  auto function = module->getFunction(target_method.getValue());
+  if (!function) {
+    errs() << argv[0] << ": ";
+    WithColor::error() << " no method '" << target_method.getValue() << "'";
+    return 1;
+  }
+
+  std::shared_ptr<caffeine::Solver> solver =
+      std::make_shared<caffeine::Z3Solver>();
+  auto logger = caffeine::PrintingFailureLogger{std::cout};
+
+  Executor exec;
+  exec.add_context(Context{function, solver});
+
+  while (exec.has_next()) {
+    auto ctx = exec.next_context();
+    Interpreter interp{&exec, &ctx, &logger};
+
+    interp.execute();
+  }
+
+  return 0;
+}


### PR DESCRIPTION
This PR has the following changes
- Add all the methods that were used be we forgot to implement
- Add a interface for logging failures
- Implement that interface to print out the constants in the model when executed
- More or less copy over the main binary

I have no idea if this runs because we haven't implemented enough of an interpreter to actually test anything.