### PR TITLE
Implement more operations for the interpreter

### DIFF
--- a/include/caffeine/ADT/Ref.h
+++ b/include/caffeine/ADT/Ref.h
@@ -53,6 +53,15 @@ public:
     increment();
   }
 
+  /**
+   * Allow casting from nullptr literals implicitly.
+   *
+   * Normally we wouldn't want ref's taking ownership of pointers implicitly but
+   * with a nullptr there's nothing to take ownership of so it's fine.
+   */
+  ref(std::nullptr_t, const Deleter& deleter = Deleter())
+      : Deleter(deleter), value(nullptr) {}
+
   // References are implicitly convertable to const references.
   operator ref<const T>() const {
     return ref<const T>(get(), this->deleter());

--- a/include/caffeine/IR/Operation.h
+++ b/include/caffeine/IR/Operation.h
@@ -561,10 +561,10 @@ public:
 
   static ref<Operation> CreateICmp(ICmpOpcode cmp, const ref<Operation>& lhs,
                                    const ref<Operation>& rhs);
-  static ref<Operation> CreateICmp(ICmpOpcode cmp, const ref<Operation>& lhs,
-                                   uint64_t rhs);
-  static ref<Operation> CreateICmp(ICmpOpcode cmp, uint64_t lhs,
+  static ref<Operation> CreateICmp(ICmpOpcode cmp, int64_t lhs,
                                    const ref<Operation>& rhs);
+  static ref<Operation> CreateICmp(ICmpOpcode cmp, const ref<Operation>& lhs,
+                                   int64_t rhs);
 
   static bool classof(const Operation* op);
 };

--- a/include/caffeine/Interpreter/Context.h
+++ b/include/caffeine/Interpreter/Context.h
@@ -37,6 +37,14 @@ public:
    */
   StackFrame& stack_top();
 
+  // Utility methods for adding/removing stack frames
+  void pop();
+  void push(StackFrame&& frame);
+  void push(const StackFrame& frame);
+
+  // Does this context have any stack frames?
+  bool empty() const;
+
   std::shared_ptr<Solver> solver() const;
 
   llvm::iterator_range<std::vector<Assertion>::const_iterator>

--- a/include/caffeine/Interpreter/Interpreter.h
+++ b/include/caffeine/Interpreter/Interpreter.h
@@ -47,8 +47,9 @@ public:
   ExecutionResult visitXor(llvm::BinaryOperator& op);
   ExecutionResult visitNot(llvm::BinaryOperator& op);
 
+  ExecutionResult visitICmpInst(llvm::ICmpInst& icmp);
+
   // ExecutionResult visitTrunc(llvm::TruncInst &trunc);
-  // ExecutionResult visitICmpInst(llvm::ICmpInst &icmp);
 
   // ExecutionResult visitSExtInst(llvm::SExtInst &sext);
   // ExecutionResult visitZExtInst(llvm::ZExtInst &zext);

--- a/include/caffeine/Interpreter/Interpreter.h
+++ b/include/caffeine/Interpreter/Interpreter.h
@@ -34,7 +34,7 @@ public:
   ExecutionResult visitAdd(llvm::BinaryOperator& op);
   ExecutionResult visitSub(llvm::BinaryOperator& op);
   ExecutionResult visitMul(llvm::BinaryOperator& op);
-  // ExecutionResult visitUDiv(llvm::BinaryOperator &op);
+  ExecutionResult visitUDiv(llvm::BinaryOperator &op);
   // ExecutionResult visitSDiv(llvm::BinaryOperator &op);
   // ExecutionResult visitURem(llvm::BinaryOperator &op);
   // ExecutionResult visitSRem(llvm::BinaryOperator &op);

--- a/include/caffeine/Interpreter/Interpreter.h
+++ b/include/caffeine/Interpreter/Interpreter.h
@@ -34,8 +34,8 @@ public:
   ExecutionResult visitAdd(llvm::BinaryOperator& op);
   ExecutionResult visitSub(llvm::BinaryOperator& op);
   ExecutionResult visitMul(llvm::BinaryOperator& op);
-  ExecutionResult visitUDiv(llvm::BinaryOperator &op);
-  // ExecutionResult visitSDiv(llvm::BinaryOperator &op);
+  ExecutionResult visitUDiv(llvm::BinaryOperator& op);
+  ExecutionResult visitSDiv(llvm::BinaryOperator& op);
   // ExecutionResult visitURem(llvm::BinaryOperator &op);
   // ExecutionResult visitSRem(llvm::BinaryOperator &op);
   // ExecutionResult visitShl(llvm::BinaryOperator &op);

--- a/include/caffeine/Interpreter/Interpreter.h
+++ b/include/caffeine/Interpreter/Interpreter.h
@@ -32,8 +32,8 @@ public:
   ExecutionResult visitInstruction(llvm::Instruction& inst);
 
   ExecutionResult visitAdd(llvm::BinaryOperator& op);
-  ExecutionResult visitSub(llvm::BinaryOperator &op);
-  // ExecutionResult visitMul(llvm::BinaryOperator &op);
+  ExecutionResult visitSub(llvm::BinaryOperator& op);
+  ExecutionResult visitMul(llvm::BinaryOperator& op);
   // ExecutionResult visitUDiv(llvm::BinaryOperator &op);
   // ExecutionResult visitSDiv(llvm::BinaryOperator &op);
   // ExecutionResult visitURem(llvm::BinaryOperator &op);

--- a/include/caffeine/Interpreter/Interpreter.h
+++ b/include/caffeine/Interpreter/Interpreter.h
@@ -32,7 +32,7 @@ public:
   ExecutionResult visitInstruction(llvm::Instruction& inst);
 
   ExecutionResult visitAdd(llvm::BinaryOperator& op);
-  // ExecutionResult visitSub(llvm::BinaryOperator &op);
+  ExecutionResult visitSub(llvm::BinaryOperator &op);
   // ExecutionResult visitMul(llvm::BinaryOperator &op);
   // ExecutionResult visitUDiv(llvm::BinaryOperator &op);
   // ExecutionResult visitSDiv(llvm::BinaryOperator &op);

--- a/include/caffeine/Interpreter/Interpreter.h
+++ b/include/caffeine/Interpreter/Interpreter.h
@@ -38,13 +38,14 @@ public:
   ExecutionResult visitSDiv(llvm::BinaryOperator& op);
   ExecutionResult visitURem(llvm::BinaryOperator& op);
   ExecutionResult visitSRem(llvm::BinaryOperator& op);
-  // ExecutionResult visitShl(llvm::BinaryOperator &op);
-  // ExecutionResult visitLShr(llvm::BinaryOperator &op);
-  // ExecutionResult visitAShr(llvm::BinaryOperator &op);
-  // ExecutionResult visitAnd(llvm::BinaryOperator &op);
-  // ExecutionResult visitOr(llvm::BinaryOperator &op);
-  // ExecutionResult visitXor(llvm::BinaryOperator &op);
-  // ExecutionResult visitNot(llvm::BinaryOperator &op);
+
+  ExecutionResult visitShl(llvm::BinaryOperator& op);
+  ExecutionResult visitLShr(llvm::BinaryOperator& op);
+  ExecutionResult visitAShr(llvm::BinaryOperator& op);
+  ExecutionResult visitAnd(llvm::BinaryOperator& op);
+  ExecutionResult visitOr(llvm::BinaryOperator& op);
+  ExecutionResult visitXor(llvm::BinaryOperator& op);
+  ExecutionResult visitNot(llvm::BinaryOperator& op);
 
   // ExecutionResult visitTrunc(llvm::TruncInst &trunc);
   // ExecutionResult visitICmpInst(llvm::ICmpInst &icmp);

--- a/include/caffeine/Interpreter/Interpreter.h
+++ b/include/caffeine/Interpreter/Interpreter.h
@@ -32,17 +32,31 @@ public:
   ExecutionResult visitInstruction(llvm::Instruction& inst);
 
   ExecutionResult visitAdd(llvm::BinaryOperator& op);
+  // ExecutionResult visitSub(llvm::BinaryOperator &op);
+  // ExecutionResult visitMul(llvm::BinaryOperator &op);
+  // ExecutionResult visitUDiv(llvm::BinaryOperator &op);
+  // ExecutionResult visitSDiv(llvm::BinaryOperator &op);
+  // ExecutionResult visitURem(llvm::BinaryOperator &op);
+  // ExecutionResult visitSRem(llvm::BinaryOperator &op);
+  // ExecutionResult visitShl(llvm::BinaryOperator &op);
+  // ExecutionResult visitLShr(llvm::BinaryOperator &op);
+  // ExecutionResult visitAShr(llvm::BinaryOperator &op);
+  // ExecutionResult visitAnd(llvm::BinaryOperator &op);
+  // ExecutionResult visitOr(llvm::BinaryOperator &op);
+  // ExecutionResult visitXor(llvm::BinaryOperator &op);
+  // ExecutionResult visitNot(llvm::BinaryOperator &op);
+
+  // ExecutionResult visitTrunc(llvm::TruncInst &trunc);
+  // ExecutionResult visitICmpInst(llvm::ICmpInst &icmp);
+
+  // ExecutionResult visitSExtInst(llvm::SExtInst &sext);
+  // ExecutionResult visitZExtInst(llvm::ZExtInst &zext);
+
   ExecutionResult visitPHINode(llvm::PHINode& node);
-  ExecutionResult visitBranchInst(llvm::BranchInst&);
-  ExecutionResult visitReturnInst(llvm::ReturnInst&) {
-    CAFFEINE_UNIMPLEMENTED();
-  };
-  ExecutionResult visitCallInst(llvm::CallInst&) {
-    CAFFEINE_UNIMPLEMENTED();
-  };
-  ExecutionResult visitSelectInst(llvm::SelectInst&) {
-    CAFFEINE_UNIMPLEMENTED();
-  };
+  ExecutionResult visitBranchInst(llvm::BranchInst& inst);
+  ExecutionResult visitReturnInst(llvm::ReturnInst& inst);
+  // ExecutionResult visitCallInst(llvm::CallInst &inst);
+  // ExecutionResult visitSelectInst(llvm::SelectInst &inst);
 };
 
 } // namespace caffeine

--- a/include/caffeine/Interpreter/Interpreter.h
+++ b/include/caffeine/Interpreter/Interpreter.h
@@ -36,8 +36,8 @@ public:
   ExecutionResult visitMul(llvm::BinaryOperator& op);
   ExecutionResult visitUDiv(llvm::BinaryOperator& op);
   ExecutionResult visitSDiv(llvm::BinaryOperator& op);
-  // ExecutionResult visitURem(llvm::BinaryOperator &op);
-  // ExecutionResult visitSRem(llvm::BinaryOperator &op);
+  ExecutionResult visitURem(llvm::BinaryOperator& op);
+  ExecutionResult visitSRem(llvm::BinaryOperator& op);
   // ExecutionResult visitShl(llvm::BinaryOperator &op);
   // ExecutionResult visitLShr(llvm::BinaryOperator &op);
   // ExecutionResult visitAShr(llvm::BinaryOperator &op);

--- a/interface/caffeine.h
+++ b/interface/caffeine.h
@@ -1,0 +1,33 @@
+#ifndef CAFFEINE_INTERFACE_H
+#define CAFFEINE_INTERFACE_H
+
+#pragma once
+
+#include <stdbool.h>
+
+#ifndef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * Assert that the condition is true.
+ *
+ * In cases where the symbolic executor determines that the
+ * condition could be false, it will produce a test case with
+ * concrete inputs which reproduce the failure.
+ */
+void caffeine_assert(bool cond);
+
+/**
+ * Assume that a condition is true.
+ *
+ * This will silently remove any executions in which the condition
+ * could evaluate to false.
+ */
+void caffeine_assume(bool cond);
+
+#ifndef __cplusplus
+}
+#endif
+
+#endif

--- a/src/IR/Operation.cpp
+++ b/src/IR/Operation.cpp
@@ -577,23 +577,27 @@ ref<Operation> ICmpOp::CreateICmp(ICmpOpcode cmp, const ref<Operation>& lhs,
 
   return ref<Operation>(new ICmpOp(cmp, Type::int_ty(1), lhs, rhs));
 }
-ref<Operation> ICmpOp::CreateICmp(ICmpOpcode cmp, const ref<Operation>& lhs,
-                                  uint64_t rhs) {
-  CAFFEINE_ASSERT(lhs, "lhs was null");
-  CAFFEINE_ASSERT(lhs->type().is_int(),
-                  "icmp can only be created with integer operands");
-
-  return ICmpOp::CreateICmp(
-      cmp, lhs, ConstantInt::Create(llvm::APInt(lhs->type().bitwidth(), rhs)));
-}
-ref<Operation> ICmpOp::CreateICmp(ICmpOpcode cmp, uint64_t lhs,
+ref<Operation> ICmpOp::CreateICmp(ICmpOpcode cmp, int64_t lhs,
                                   const ref<Operation>& rhs) {
   CAFFEINE_ASSERT(rhs, "rhs was null");
   CAFFEINE_ASSERT(rhs->type().is_int(),
                   "icmp can only be created with integer operands");
 
+  auto literal = llvm::APInt(64, static_cast<uint64_t>(lhs));
   return ICmpOp::CreateICmp(
-      cmp, ConstantInt::Create(llvm::APInt(rhs->type().bitwidth(), lhs)), rhs);
+      cmp, ConstantInt::Create(literal.sextOrTrunc(rhs->type().bitwidth())),
+      rhs);
+}
+ref<Operation> ICmpOp::CreateICmp(ICmpOpcode cmp, const ref<Operation>& lhs,
+                                  int64_t rhs) {
+  CAFFEINE_ASSERT(lhs, "rhs was null");
+  CAFFEINE_ASSERT(lhs->type().is_int(),
+                  "icmp can only be created with integer operands");
+
+  auto literal = llvm::APInt(64, static_cast<uint64_t>(rhs));
+  return ICmpOp::CreateICmp(
+      cmp, lhs,
+      ConstantInt::Create(literal.sextOrTrunc(lhs->type().bitwidth())));
 }
 
 /***************************************************

--- a/src/Interpreter/Context.cpp
+++ b/src/Interpreter/Context.cpp
@@ -41,6 +41,21 @@ StackFrame& Context::stack_top() {
   return stack.back();
 }
 
+void Context::push(const StackFrame& frame) {
+  stack.push_back(frame);
+}
+void Context::push(StackFrame&& frame) {
+  stack.push_back(frame);
+}
+void Context::pop() {
+  CAFFEINE_ASSERT(!stack.empty());
+  stack.pop_back();
+}
+
+bool Context::empty() const {
+  return stack.empty();
+}
+
 std::shared_ptr<Solver> Context::solver() const {
   return solver_;
 }

--- a/src/Interpreter/Interpreter.cpp
+++ b/src/Interpreter/Interpreter.cpp
@@ -101,4 +101,26 @@ ExecutionResult Interpreter::visitBranchInst(llvm::BranchInst& inst) {
   }
 }
 
+ExecutionResult Interpreter::visitReturnInst(llvm::ReturnInst& inst) {
+  auto& frame = ctx->stack_top();
+
+  ref<Operation> result = nullptr;
+  if (inst.getNumOperands() != 0)
+    result = frame.lookup(inst.getOperand(0));
+
+  ctx->pop();
+
+  if (ctx->empty())
+    return ExecutionResult::Stop;
+
+  if (result) {
+    auto& parent = ctx->stack_top();
+    auto& caller = *std::prev(parent.current);
+
+    parent.insert(&caller, result);
+  }
+
+  return ExecutionResult::Continue;
+}
+
 } // namespace caffeine

--- a/src/Interpreter/Interpreter.cpp
+++ b/src/Interpreter/Interpreter.cpp
@@ -54,6 +54,16 @@ ExecutionResult Interpreter::visitSub(llvm::BinaryOperator& op) {
 
   return ExecutionResult::Continue;
 }
+ExecutionResult Interpreter::visitMul(llvm::BinaryOperator& op) {
+  StackFrame& frame = ctx->stack_top();
+
+  auto lhs = frame.lookup(op.getOperand(0));
+  auto rhs = frame.lookup(op.getOperand(1));
+
+  frame.insert(&op, BinaryOp::CreateMul(lhs, rhs));
+
+  return ExecutionResult::Continue;
+}
 
 ExecutionResult Interpreter::visitPHINode(llvm::PHINode& node) {
   auto& frame = ctx->stack_top();

--- a/src/Interpreter/Interpreter.cpp
+++ b/src/Interpreter/Interpreter.cpp
@@ -147,6 +147,74 @@ ExecutionResult Interpreter::visitURem(llvm::BinaryOperator& op) {
   return ExecutionResult::Continue;
 }
 
+ExecutionResult Interpreter::visitShl(llvm::BinaryOperator& op) {
+  StackFrame& frame = ctx->stack_top();
+
+  auto lhs = frame.lookup(op.getOperand(0));
+  auto rhs = frame.lookup(op.getOperand(1));
+
+  frame.insert(&op, BinaryOp::CreateShl(lhs, rhs));
+
+  return ExecutionResult::Continue;
+}
+ExecutionResult Interpreter::visitLShr(llvm::BinaryOperator& op) {
+  StackFrame& frame = ctx->stack_top();
+
+  auto lhs = frame.lookup(op.getOperand(0));
+  auto rhs = frame.lookup(op.getOperand(1));
+
+  frame.insert(&op, BinaryOp::CreateLShr(lhs, rhs));
+
+  return ExecutionResult::Continue;
+}
+ExecutionResult Interpreter::visitAShr(llvm::BinaryOperator& op) {
+  StackFrame& frame = ctx->stack_top();
+
+  auto lhs = frame.lookup(op.getOperand(0));
+  auto rhs = frame.lookup(op.getOperand(1));
+
+  frame.insert(&op, BinaryOp::CreateAShr(lhs, rhs));
+
+  return ExecutionResult::Continue;
+}
+ExecutionResult Interpreter::visitAnd(llvm::BinaryOperator& op) {
+  StackFrame& frame = ctx->stack_top();
+
+  auto lhs = frame.lookup(op.getOperand(0));
+  auto rhs = frame.lookup(op.getOperand(1));
+
+  frame.insert(&op, BinaryOp::CreateAnd(lhs, rhs));
+
+  return ExecutionResult::Continue;
+}
+ExecutionResult Interpreter::visitOr(llvm::BinaryOperator& op) {
+  StackFrame& frame = ctx->stack_top();
+
+  auto lhs = frame.lookup(op.getOperand(0));
+  auto rhs = frame.lookup(op.getOperand(1));
+
+  frame.insert(&op, BinaryOp::CreateOr(lhs, rhs));
+
+  return ExecutionResult::Continue;
+}
+ExecutionResult Interpreter::visitXor(llvm::BinaryOperator& op) {
+  StackFrame& frame = ctx->stack_top();
+
+  auto lhs = frame.lookup(op.getOperand(0));
+  auto rhs = frame.lookup(op.getOperand(1));
+
+  frame.insert(&op, BinaryOp::CreateXor(lhs, rhs));
+
+  return ExecutionResult::Continue;
+}
+ExecutionResult Interpreter::visitNot(llvm::BinaryOperator& op) {
+  StackFrame& frame = ctx->stack_top();
+
+  frame.insert(&op, UnaryOp::CreateNot(frame.lookup(op.getOperand(0))));
+
+  return ExecutionResult::Continue;
+}
+
 ExecutionResult Interpreter::visitPHINode(llvm::PHINode& node) {
   auto& frame = ctx->stack_top();
 

--- a/src/Interpreter/Interpreter.cpp
+++ b/src/Interpreter/Interpreter.cpp
@@ -44,6 +44,16 @@ ExecutionResult Interpreter::visitAdd(llvm::BinaryOperator& op) {
 
   return ExecutionResult::Continue;
 }
+ExecutionResult Interpreter::visitSub(llvm::BinaryOperator& op) {
+  StackFrame& frame = ctx->stack_top();
+
+  auto lhs = frame.lookup(op.getOperand(0));
+  auto rhs = frame.lookup(op.getOperand(1));
+
+  frame.insert(&op, BinaryOp::CreateSub(lhs, rhs));
+
+  return ExecutionResult::Continue;
+}
 
 ExecutionResult Interpreter::visitPHINode(llvm::PHINode& node) {
   auto& frame = ctx->stack_top();

--- a/src/Interpreter/Interpreter.cpp
+++ b/src/Interpreter/Interpreter.cpp
@@ -80,6 +80,31 @@ ExecutionResult Interpreter::visitUDiv(llvm::BinaryOperator& op) {
 
   return ExecutionResult::Continue;
 }
+ExecutionResult Interpreter::visitSDiv(llvm::BinaryOperator& op) {
+  StackFrame& frame = ctx->stack_top();
+
+  auto lhs = frame.lookup(op.getOperand(0));
+  auto rhs = frame.lookup(op.getOperand(1));
+
+  auto cmp1 = ICmpOp::CreateICmp(ICmpOpcode::EQ, rhs, 0);
+  auto cmp2 =
+      ICmpOp::CreateICmp(ICmpOpcode::EQ, lhs,
+                         ConstantInt::Create(llvm::APInt::getSignedMinValue(
+                             lhs->type().bitwidth())));
+  auto cmp3 = ICmpOp::CreateICmp(ICmpOpcode::EQ, rhs, -1);
+
+  // lhs == 0 || (lhs == INT_MIN && rhs == -1)
+  Assertion assertion =
+      BinaryOp::CreateOr(cmp1, BinaryOp::CreateAnd(cmp2, cmp3));
+  auto model = ctx->resolve(assertion);
+  if (model->result() == SolverResult::SAT)
+    logger->log_failure(model.get(), *ctx);
+  ctx->add(!assertion);
+
+  frame.insert(&op, BinaryOp::CreateSDiv(lhs, rhs));
+
+  return ExecutionResult::Continue;
+}
 
 ExecutionResult Interpreter::visitPHINode(llvm::PHINode& node) {
   auto& frame = ctx->stack_top();


### PR DESCRIPTION
This commit implements most of the non-controlflow opcodes we'll need for the demo although there's still a number left.

If we implement call and the builtins then we should be able to reuse the test suite from last time.