### PR TITLE
Add first pass of Z3Solver SelectOp

### DIFF
--- a/include/caffeine/Solver/Z3Solver.h
+++ b/include/caffeine/Solver/Z3Solver.h
@@ -50,6 +50,8 @@ public:
   z3::expr visitICmp(const ICmpOp& op);
   z3::expr visitFCmp(const FCmpOp& op);
 
+  z3::expr visitSelectOp(const SelectOp& op);
+
   // Unary operations
   z3::expr visitNot (const UnaryOp& op);
   z3::expr visitFNeg(const UnaryOp& op);

--- a/test/run-fail/collatz.c
+++ b/test/run-fail/collatz.c
@@ -1,0 +1,29 @@
+
+#include <limits.h>
+#include <stdbool.h>
+#include <stdint.h>
+
+#include "caffeine.h"
+
+uint32_t __attribute__((noinline)) modulo(uint32_t x, uint32_t y) {
+  return x % y;
+}
+
+uint32_t __attribute__((noinline)) collatz(uint32_t x) {
+  uint32_t cnt = 0;
+  while (x > 1) {
+    cnt += 1;
+
+    uint32_t k1 = x / 2;
+    uint32_t k2 = 3 * x + 1;
+
+    x = (modulo(x, 2) == 0) ? k1 : k2;
+    caffeine_assume(cnt < 10);
+  }
+
+  return cnt;
+}
+
+void test(uint32_t n) {
+  caffeine_assert(collatz(n) <= 2);
+}

--- a/test/run-fail/sample.c
+++ b/test/run-fail/sample.c
@@ -1,0 +1,11 @@
+
+#include "caffeine.h"
+#include <stdint.h>
+
+void test(uint32_t x) {
+  uint32_t a = x + 1020202;
+  uint32_t b = x * 555142;
+  uint32_t c = x - 1321;
+
+  caffeine_assert(x + 5 != 0);
+}

--- a/test/run-fail/sdiv-nonzero.c
+++ b/test/run-fail/sdiv-nonzero.c
@@ -1,0 +1,10 @@
+
+#include "caffeine.h"
+#include <stdint.h>
+
+// Test that signed division checks for overflow in the case
+// where x == INT_MIN and y == -1
+int32_t test(int32_t x, int32_t y) {
+  caffeine_assume(y != 0);
+  return x / y;
+}

--- a/test/run-fail/sdiv-udiv-inequal.c
+++ b/test/run-fail/sdiv-udiv-inequal.c
@@ -1,0 +1,26 @@
+
+#include "caffeine.h"
+#include <stdint.h>
+
+uint32_t sdiv(uint32_t x, uint32_t y) {
+  // Don't have or yet. Need to emulate it.
+  if (x == INT32_MIN)
+    caffeine_assume(y != -1);
+  caffeine_assume(y != 0);
+
+  return (int32_t)x / (int32_t)y;
+}
+
+uint32_t udiv(uint32_t x, uint32_t y) {
+  caffeine_assume(y != 0);
+
+  return x / y;
+}
+
+// Test that udiv and sdiv are different for certain values.
+void test(uint32_t x, uint32_t y) {
+  uint32_t a = sdiv(x, y);
+  uint32_t b = udiv(x, y);
+
+  caffeine_assert(a == b);
+}

--- a/test/run-fail/sdiv-zero.c
+++ b/test/run-fail/sdiv-zero.c
@@ -1,0 +1,12 @@
+
+#include "caffeine.h"
+#include <stdint.h>
+
+// Test that signed division checks for divide-by-zero.
+int32_t test(int32_t x, int32_t y) {
+  // Don't have or yet. Need to emulate it.
+  if (x == INT32_MIN)
+    caffeine_assume(y != -1);
+
+  return x / y;
+}


### PR DESCRIPTION
This is necessary to implement the SelectOp in the interpreter, and pass the collatz test case