### PR TITLE
Add assertions for accessing Constant identifiers

### DIFF
--- a/include/caffeine/IR/Operation.inl
+++ b/include/caffeine/IR/Operation.inl
@@ -203,9 +203,11 @@ inline const Operation& Operation::operator[](size_t idx) const {
  * Constant                                        *
  ***************************************************/
 inline std::string_view Constant::name() const {
+  CAFFEINE_ASSERT(is_named(), "tried to access name of unnamed constant");
   return name_;
 }
 inline uint64_t Constant::number() const {
+  CAFFEINE_ASSERT(is_numbered(), "tried to access number of named constant");
   return iconst_.getLimitedValue();
 }
 

--- a/include/caffeine/IR/Type.inl
+++ b/include/caffeine/IR/Type.inl
@@ -25,6 +25,9 @@ inline bool Type::is_void() const {
 inline bool Type::is_function_pointer() const {
   return kind() == FunctionPointer;
 }
+inline bool Type::is_array() const {
+  return kind() == Array;
+}
 
 inline uint32_t Type::bitwidth() const {
   CAFFEINE_ASSERT(is_int());

--- a/include/caffeine/Memory/MemHeap.h
+++ b/include/caffeine/Memory/MemHeap.h
@@ -225,4 +225,6 @@ public:
 
 } // namespace caffeine
 
+#include "MemHeap.inl"
+
 #endif

--- a/include/caffeine/Memory/MemHeap.inl
+++ b/include/caffeine/Memory/MemHeap.inl
@@ -48,7 +48,7 @@ inline bool Pointer::is_resolved() const {
   // TODO: This depends on some internal parts of slot_map which aren't really
   //       meant to be exposed. It should be fine but if slotmap ever starts
   //       using a different key type then it'll be necessary to rework this.
-  return alloc_.second == SIZE_MAX;
+  return alloc_.second != SIZE_MAX;
 }
 
 } // namespace caffeine


### PR DESCRIPTION
Calling `Constant::name` when the constant was numbered would previously just reinterpret the data there as a std::string. Now it just nicely explodes with a nice error message.

This also includes a few small unrelated fixes for missing includes/method implementations.