### PR TITLE
Add cmake code to allow skipping tests

### DIFF
--- a/cmake/testutils.cmake
+++ b/cmake/testutils.cmake
@@ -1,0 +1,24 @@
+
+# Extract the first line of the file into OUTVAR
+function(extract_first_line RESULT FILE)
+  file(READ "${FILE}" contents)
+
+  # Convert file contents into a CMake list (where each element in the list
+  # is one line of the file)
+  #
+  STRING(REGEX REPLACE ";" "\\\\;" contents "${contents}")
+  STRING(REGEX REPLACE "\n" ";" contents "${contents}")
+
+  list(POP_FRONT contents first_line)
+  set(${RESULT} "${first_line}" PARENT_SCOPE)
+endfunction()
+
+function(should_skip_test RESULT testfile)
+  extract_first_line(first_line "${testfile}")
+
+  if ("${first_line}" MATCHES ".*SKIP TEST.*")
+    set(${RESULT} TRUE PARENT_SCOPE)
+  else()
+    set(${RESULT} FALSE PARENT_SCOPE)
+  endif()
+endfunction()

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -14,3 +14,5 @@ if ("${CLANGXX}" STREQUAL "CLANGXX-NOTFOUND")
 add_subdirectory(unit)
 add_subdirectory(run-pass)
 add_subdirectory(run-fail)
+
+add_executable(skip-test skip-test.cpp)

--- a/test/run-fail/CMakeLists.txt
+++ b/test/run-fail/CMakeLists.txt
@@ -5,18 +5,30 @@ file(GLOB ir_tests  CONFIGURE_DEPENDS *.ll)
 
 set(CLANG_FLAGS -S -emit-llvm -O3 -fcolor-diagnostics)
 
+include(testutils)
+
+
 foreach(test ${ir_tests})
   file(RELATIVE_PATH test_file "${CMAKE_CURRENT_SOURCE_DIR}" "${test}")
+  should_skip_test(should_skip "${test}")
 
-  add_test(
-    NAME "run-pass/${test_file}"
-    COMMAND caffeine-bin "${test}" test
-  )
+  if (should_skip)
+    add_test(
+      NAME "run-fail/${test_file}"
+      COMMAND skip-test "${test}" test
+    )
+  else()
+    add_test(
+      NAME "run-fail/${test_file}"
+      COMMAND caffeine-bin "${test}" test
+    )
+  endif()
   
   set_tests_properties(
     "run-fail/${test_file}"
     PROPERTIES
-    WILL_FAIL TRUE  
+    WILL_FAIL TRUE
+    SKIP_RETURN_CODE 77
   )
 endforeach()
 
@@ -24,6 +36,7 @@ if (NOT "${CLANG}" STREQUAL "CLANG-NOTFOUND")
   foreach(test ${c_tests})
     file(RELATIVE_PATH test_file "${CMAKE_CURRENT_SOURCE_DIR}" "${test}")
     set(TEST_OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/${test_file}.ll")
+    should_skip_test(should_skip "${test}")
 
     add_custom_command(
       OUTPUT "${TEST_OUTPUT}"
@@ -31,15 +44,23 @@ if (NOT "${CLANG}" STREQUAL "CLANG-NOTFOUND")
       MAIN_DEPENDENCY "${test}"
     )
 
-    add_test(
-      NAME "run-fail/${test_file}"
-      COMMAND caffeine-bin "${TEST_OUTPUT}" test
-    )
+    if (should_skip)
+      add_test(
+        NAME "run-fail/${test_file}"
+        COMMAND skip-test "${test}" test
+      )
+    else()
+      add_test(
+        NAME "run-fail/${test_file}"
+        COMMAND caffeine-bin "${TEST_OUTPUT}" test
+      )
+    endif()
 
     set_tests_properties(
       "run-fail/${test_file}"
       PROPERTIES
-      WILL_FAIL TRUE  
+      WILL_FAIL TRUE
+      SKIP_RETURN_CODE 77
     )
 
     list(APPEND test_files "${TEST_OUTPUT}")
@@ -50,6 +71,7 @@ if (NOT "${CLANGXX}" STREQUAL "CLANGXX-NOTFOUND")
   foreach(test ${cpp_tests})
     file(RELATIVE_PATH test_file "${CMAKE_CURRENT_SOURCE_DIR}" "${test}")
     set(TEST_OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/${test_file}.ll")
+    should_skip_test(should_skip "${test}")
 
     add_custom_command(
       OUTPUT "${TEST_OUTPUT}"
@@ -57,15 +79,23 @@ if (NOT "${CLANGXX}" STREQUAL "CLANGXX-NOTFOUND")
       MAIN_DEPENDENCY "${test}"
     )
 
-    add_test(
-      NAME "run-fail/${test_file}"
-      COMMAND caffeine-bin "${TEST_OUTPUT}" test
-    )
+    if (should_skip)
+      add_test(
+        NAME "run-fail/${test_file}"
+        COMMAND skip-test "${test}" test
+      )
+    else()
+      add_test(
+        NAME "run-fail/${test_file}"
+        COMMAND caffeine-bin "${TEST_OUTPUT}" test
+      )
+    endif()
 
     set_tests_properties(
       "run-fail/${test_file}"
       PROPERTIES
-      WILL_FAIL TRUE  
+      WILL_FAIL TRUE
+      SKIP_RETURN_CODE 77
     )
 
     list(APPEND test_files "${TEST_OUTPUT}")

--- a/test/run-fail/collatz.c
+++ b/test/run-fail/collatz.c
@@ -25,8 +25,5 @@ uint32_t __attribute__((noinline)) collatz(uint32_t x) {
 }
 
 void test(uint32_t n) {
-  // Select not implemented yet; skip
-  return;
-
   caffeine_assert(collatz(n) <= 2);
 }

--- a/test/run-pass/CMakeLists.txt
+++ b/test/run-pass/CMakeLists.txt
@@ -5,12 +5,28 @@ file(GLOB ir_tests  CONFIGURE_DEPENDS *.ll)
 
 set(CLANG_FLAGS -S -emit-llvm -O3 -fcolor-diagnostics)
 
+include(testutils)
+
 foreach(test ${ir_tests})
   file(RELATIVE_PATH test_file "${CMAKE_CURRENT_SOURCE_DIR}" "${test}")
+  should_skip_test(should_skip "${test}")
 
-  add_test(
-    NAME "run-pass/${test_file}"
-    COMMAND caffeine-bin "${test}" test
+  if (should_skip)
+    add_test(
+      NAME "run-pass/${test_file}"
+      COMMAND skip-test "${test}" test
+    )
+  else()
+    add_test(
+      NAME "run-pass/${test_file}"
+      COMMAND caffeine-bin "${test}" test
+    )
+  endif()
+  
+  set_tests_properties(
+    "run-pass/${test_file}"
+    PROPERTIES
+    SKIP_RETURN_CODE 77
   )
 endforeach()
 
@@ -18,16 +34,30 @@ if (NOT "${CLANG}" STREQUAL "CLANG-NOTFOUND")
   foreach(test ${c_tests})
     file(RELATIVE_PATH test_file "${CMAKE_CURRENT_SOURCE_DIR}" "${test}")
     set(TEST_OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/${test_file}.ll")
+    should_skip_test(should_skip "${test}")
 
     add_custom_command(
       OUTPUT "${TEST_OUTPUT}"
-      COMMAND "${CLANG}" "${test}" -o "${TEST_OUTPUT}" -std=c11 ${CLANG_FLAGS}
+      COMMAND "${CLANG}" -std=c11 ${CLANG_FLAGS} "${test}" -o "${TEST_OUTPUT}"
       MAIN_DEPENDENCY "${test}"
     )
 
-    add_test(
-      NAME "run-fail/${test_file}"
-      COMMAND caffeine-bin "${TEST_OUTPUT}" test
+    if (should_skip)
+      add_test(
+        NAME "run-pass/${test_file}"
+        COMMAND skip-test "${test}" test
+      )
+    else()
+      add_test(
+        NAME "run-pass/${test_file}"
+        COMMAND caffeine-bin "${TEST_OUTPUT}" test
+      )
+    endif()
+
+    set_tests_properties(
+      "run-pass/${test_file}"
+      PROPERTIES
+      SKIP_RETURN_CODE 77
     )
 
     list(APPEND test_files "${TEST_OUTPUT}")
@@ -38,16 +68,30 @@ if (NOT "${CLANGXX}" STREQUAL "CLANGXX-NOTFOUND")
   foreach(test ${cpp_tests})
     file(RELATIVE_PATH test_file "${CMAKE_CURRENT_SOURCE_DIR}" "${test}")
     set(TEST_OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/${test_file}.ll")
+    should_skip_test(should_skip "${test}")
 
     add_custom_command(
       OUTPUT "${TEST_OUTPUT}"
-      COMMAND "${CLANGXX}" "${test}" -o "${TEST_OUTPUT}" -std=c++17 ${CLANG_FLAGS}
+      COMMAND "${CLANGXX}" -std=c++17 ${CLANG_FLAGS} "${test}" -o "${TEST_OUTPUT}"
       MAIN_DEPENDENCY "${test}"
     )
 
-    add_test(
-      NAME "run-fail/${test_file}"
-      COMMAND caffeine-bin "${TEST_OUTPUT}" test
+    if (should_skip)
+      add_test(
+        NAME "run-pass/${test_file}"
+        COMMAND skip-test "${test}" test
+      )
+    else()
+      add_test(
+        NAME "run-pass/${test_file}"
+        COMMAND caffeine-bin "${TEST_OUTPUT}" test
+      )
+    endif()
+
+    set_tests_properties(
+      "run-pass/${test_file}"
+      PROPERTIES
+      SKIP_RETURN_CODE 77
     )
 
     list(APPEND test_files "${TEST_OUTPUT}")

--- a/test/skip-test.cpp
+++ b/test/skip-test.cpp
@@ -1,0 +1,4 @@
+
+int main(int, char**) {
+  return 77;
+}


### PR DESCRIPTION
`select` isn't implemented so collatz cannot run. This adds cmake code to allow us to skip tests by putting `SKIP TEST` somewhere on the first line and then uses that to skip `collatz.c`.