### PR TITLE
Give failure logger required context to see all assertions

### DIFF
--- a/include/caffeine/Interpreter/FailureLogger.h
+++ b/include/caffeine/Interpreter/FailureLogger.h
@@ -8,12 +8,22 @@
 
 namespace caffeine {
 
+struct Failure {
+  Assertion check;
+  std::string_view message;
+
+  explicit Failure(const Assertion& check) : check(check), message("") {}
+  Failure(const Assertion& check, std::string_view msg)
+      : check(check), message(msg) {}
+};
+
 class FailureLogger {
 public:
   FailureLogger() = default;
   virtual ~FailureLogger() = default;
 
-  virtual void log_failure(const Model* model, const Context& context) = 0;
+  virtual void log_failure(const Model& model, const Context& context,
+                           const Failure& failure) = 0;
 
 protected:
   FailureLogger(const FailureLogger&) = default;
@@ -30,7 +40,8 @@ private:
 public:
   PrintingFailureLogger(std::ostream& os);
 
-  void log_failure(const Model* model, const Context& context) override;
+  void log_failure(const Model& model, const Context& context,
+                   const Failure& failure) override;
 };
 
 } // namespace caffeine

--- a/src/Interpreter/Interpreter.cpp
+++ b/src/Interpreter/Interpreter.cpp
@@ -75,7 +75,7 @@ ExecutionResult Interpreter::visitUDiv(llvm::BinaryOperator& op) {
   Assertion assertion = ICmpOp::CreateICmp(ICmpOpcode::NE, rhs, 0);
   auto model = ctx->resolve(!assertion);
   if (model->result() == SolverResult::SAT)
-    logger->log_failure(model.get(), *ctx);
+    logger->log_failure(*model, *ctx, Failure(!assertion));
   ctx->add(assertion);
 
   frame.insert(&op, BinaryOp::CreateUDiv(lhs, rhs));
@@ -100,7 +100,7 @@ ExecutionResult Interpreter::visitSDiv(llvm::BinaryOperator& op) {
       BinaryOp::CreateOr(cmp1, BinaryOp::CreateAnd(cmp2, cmp3));
   auto model = ctx->resolve(assertion);
   if (model->result() == SolverResult::SAT)
-    logger->log_failure(model.get(), *ctx);
+    logger->log_failure(*model, *ctx, Failure(!assertion));
   ctx->add(!assertion);
 
   frame.insert(&op, BinaryOp::CreateSDiv(lhs, rhs));
@@ -125,7 +125,7 @@ ExecutionResult Interpreter::visitSRem(llvm::BinaryOperator& op) {
       BinaryOp::CreateOr(cmp1, BinaryOp::CreateAnd(cmp2, cmp3));
   auto model = ctx->resolve(assertion);
   if (model->result() == SolverResult::SAT)
-    logger->log_failure(model.get(), *ctx);
+    logger->log_failure(*model, *ctx, Failure(assertion));
   ctx->add(!assertion);
 
   frame.insert(&op, BinaryOp::CreateSRem(lhs, rhs));
@@ -141,7 +141,7 @@ ExecutionResult Interpreter::visitURem(llvm::BinaryOperator& op) {
   Assertion assertion = ICmpOp::CreateICmp(ICmpOpcode::NE, rhs, 0);
   auto model = ctx->resolve(!assertion);
   if (model->result() == SolverResult::SAT)
-    logger->log_failure(model.get(), *ctx);
+    logger->log_failure(*model, *ctx, Failure(!assertion));
   ctx->add(assertion);
 
   frame.insert(&op, BinaryOp::CreateURem(lhs, rhs));
@@ -427,7 +427,7 @@ ExecutionResult Interpreter::visitAssert(llvm::CallInst& call) {
 
   auto model = ctx->resolve(!assertion);
   if (model->result() == SolverResult::SAT)
-    logger->log_failure(model.get(), *ctx);
+    logger->log_failure(*model, *ctx, Failure(!assertion));
 
   ctx->add(assertion);
 

--- a/src/Interpreter/PrintingFailureLogger.cpp
+++ b/src/Interpreter/PrintingFailureLogger.cpp
@@ -45,17 +45,18 @@ public:
 
 PrintingFailureLogger::PrintingFailureLogger(std::ostream& os) : os(&os) {}
 
-void PrintingFailureLogger::log_failure(const Model* model,
-                                        const Context& ctx) {
-  CAFFEINE_ASSERT(model->result() == SolverResult::SAT);
+void PrintingFailureLogger::log_failure(const Model& model, const Context& ctx,
+                                        const Failure& failure) {
+  CAFFEINE_ASSERT(model.result() == SolverResult::SAT);
 
-  ConstantPrinter printer{*os, model};
+  ConstantPrinter printer{*os, &model};
 
   *os << "Found assertion failure:\n";
 
   for (const auto& assertion : ctx.assertions()) {
     printer.visit(*assertion.value());
   }
+  printer.visit(*failure.check.value());
 
   *os << std::flush;
 }

--- a/src/bin/caffeine.cpp
+++ b/src/bin/caffeine.cpp
@@ -28,10 +28,11 @@ public:
 
   using caffeine::PrintingFailureLogger::PrintingFailureLogger;
 
-  void log_failure(const caffeine::Model* model,
-                   const caffeine::Context& ctx) override {
+  void log_failure(const caffeine::Model& model,
+                   const caffeine::Context& ctx,
+                   const caffeine::Failure& failure) override {
     num_failures += 1;
-    caffeine::PrintingFailureLogger::log_failure(model, ctx);
+    caffeine::PrintingFailureLogger::log_failure(model, ctx, failure);
   }
 };
 

--- a/src/bin/caffeine.cpp
+++ b/src/bin/caffeine.cpp
@@ -28,8 +28,7 @@ public:
 
   using caffeine::PrintingFailureLogger::PrintingFailureLogger;
 
-  void log_failure(const caffeine::Model& model,
-                   const caffeine::Context& ctx,
+  void log_failure(const caffeine::Model& model, const caffeine::Context& ctx,
                    const caffeine::Failure& failure) override {
     num_failures += 1;
     caffeine::PrintingFailureLogger::log_failure(model, ctx, failure);

--- a/test/run-fail/collatz.c
+++ b/test/run-fail/collatz.c
@@ -5,11 +5,7 @@
 
 #include "caffeine.h"
 
-uint32_t __attribute__((noinline)) modulo(uint32_t x, uint32_t y) {
-  return x % y;
-}
-
-uint32_t __attribute__((noinline)) collatz(uint32_t x) {
+uint32_t collatz(uint32_t x) {
   uint32_t cnt = 0;
   while (x > 1) {
     cnt += 1;
@@ -17,7 +13,7 @@ uint32_t __attribute__((noinline)) collatz(uint32_t x) {
     uint32_t k1 = x / 2;
     uint32_t k2 = 3 * x + 1;
 
-    x = (modulo(x, 2) == 0) ? k1 : k2;
+    x = (x % 2 == 0) ? k1 : k2;
     caffeine_assume(cnt < 10);
   }
 

--- a/test/run-fail/murmurhash3.c
+++ b/test/run-fail/murmurhash3.c
@@ -1,0 +1,18 @@
+
+#include "caffeine.h"
+#include <stdint.h>
+
+// Murmurhash3 finalizer
+uint64_t murmurhash3_f(uint64_t i) {
+  i += 1ULL;
+  i ^= i >> 33ULL;
+  i *= 0xff51afd7ed558ccdULL;
+  i ^= i >> 33ULL;
+  i *= 0xc4ceb9fe1a85ec53ULL;
+  i ^= i >> 33ULL;
+  return i;
+}
+
+void test(uint64_t a) {
+  caffeine_assert(murmurhash3_f(a) != 16);
+}

--- a/test/run-fail/sdiv-udiv-inequal.c
+++ b/test/run-fail/sdiv-udiv-inequal.c
@@ -4,6 +4,7 @@
 
 uint32_t sdiv(uint32_t x, uint32_t y) {
   caffeine_assume(x != INT32_MIN || y != -1);
+  caffeine_assume(y != 0);
 
   return (int32_t)x / (int32_t)y;
 }


### PR DESCRIPTION
The failure logger wasn't able to see the assertion used as an argument to `check`. This lead to not printing values that should have been asserted when running the fnv.c test case.

I also went through and cleaned up a few test cases that were coded to restrictions in decaf that no longer apply.