### PR TITLE
Elide unnecessary copy in Z3Solver

### DIFF
--- a/src/Solver/Z3Solver.cpp
+++ b/src/Solver/Z3Solver.cpp
@@ -99,8 +99,11 @@ public:
 /***************************************************
  * Z3Model                                         *
  ***************************************************/
-Z3Model::Z3Model(SolverResult result, z3::model model, const ConstMap& map)
+Z3Model::Z3Model(SolverResult result, const z3::model& model,
+                 const ConstMap& map)
     : Model(result), model(model), constants(map) {}
+Z3Model::Z3Model(SolverResult result, const z3::model& model, ConstMap&& map)
+    : Model(result), model(model), constants(std::move(map)) {}
 
 Value Z3Model::lookup(const Constant& constant) const {
   CAFFEINE_ASSERT(result() == SolverResult::SAT, "Model is not SAT");
@@ -156,7 +159,7 @@ std::unique_ptr<Model> Z3Solver::resolve(std::vector<Assertion>& assertions,
   switch (result) {
   case z3::sat:
     return std::make_unique<Z3Model>(SolverResult::SAT, solver.get_model(),
-                                     constMap);
+                                     std::move(constMap));
 
   case z3::unsat:
     return std::make_unique<EmptyModel>(SolverResult::UNSAT);

--- a/src/Solver/Z3Solver.h
+++ b/src/Solver/Z3Solver.h
@@ -26,7 +26,8 @@ private:
   ConstMap constants;
 
 public:
-  Z3Model(SolverResult result, z3::model model, const ConstMap& map);
+  Z3Model(SolverResult result, const z3::model& model, const ConstMap& map);
+  Z3Model(SolverResult result, const z3::model& model, ConstMap&& map);
 
   /**
    * Look up the value of a symbolic constant in this model. Returns an


### PR DESCRIPTION
This just fixes something I noticed when looking at the Z3Solver code.

As part of constructing Z3Model the entire constants map was copied. However, it was never used in the calling method after constructing the model so it could instead just be moved.