### PR TITLE
Implement support for Trunc, ZExt, SExt, and Bitcast within Value and Model::evaluate

### DIFF
--- a/include/caffeine/IR/Type.h
+++ b/include/caffeine/IR/Type.h
@@ -94,6 +94,9 @@ public:
   static Type type_of(const llvm::APInt& apint);
   static Type type_of(const llvm::APFloat& apfloat);
 
+  template <typename T>
+  static Type type_of();
+
   bool operator==(const Type& b) const;
   bool operator!=(const Type& b) const;
 

--- a/include/caffeine/IR/Type.inl
+++ b/include/caffeine/IR/Type.inl
@@ -4,6 +4,8 @@
 #include "caffeine/IR/Type.h"
 #include "caffeine/Support/Assert.h"
 
+#include <climits>
+
 namespace caffeine {
 
 inline Type::Kind Type::kind() const {
@@ -52,6 +54,44 @@ inline bool Type::operator!=(const Type& b) const {
 inline llvm::hash_code hash_value(const Type& type) {
   return llvm::hash_combine(type.llvm_, type.kind_, type.desc_);
 }
+
+#define CAFFEINE_TYPE_TYPEOF_INT(ty)                                           \
+  template <>                                                                  \
+  inline Type Type::type_of<ty>() {                                            \
+    return Type::int_ty(sizeof(ty) * CHAR_BIT);                                \
+  }                                                                            \
+  static_assert(true)
+
+CAFFEINE_TYPE_TYPEOF_INT(unsigned char);
+CAFFEINE_TYPE_TYPEOF_INT(unsigned short);
+CAFFEINE_TYPE_TYPEOF_INT(unsigned int);
+CAFFEINE_TYPE_TYPEOF_INT(unsigned long);
+CAFFEINE_TYPE_TYPEOF_INT(unsigned long long);
+
+CAFFEINE_TYPE_TYPEOF_INT(signed char);
+CAFFEINE_TYPE_TYPEOF_INT(signed short);
+CAFFEINE_TYPE_TYPEOF_INT(signed int);
+CAFFEINE_TYPE_TYPEOF_INT(signed long);
+CAFFEINE_TYPE_TYPEOF_INT(signed long long);
+
+CAFFEINE_TYPE_TYPEOF_INT(char);
+
+template <>
+inline Type Type::type_of<double>() {
+  return Type::float_ty(11, 53);
+}
+
+template <>
+inline Type Type::type_of<float>() {
+  return Type::float_ty(8, 24);
+}
+
+template <>
+inline Type Type::type_of<void>() {
+  return Type::void_ty();
+}
+
+#undef CAFFEINE_TYPE_TYPEOF_INT
 
 } // namespace caffeine
 

--- a/include/caffeine/IR/Value.h
+++ b/include/caffeine/IR/Value.h
@@ -98,6 +98,11 @@ public:
 
   static Value select(const Value& cond, const Value& t, const Value& f);
 
+  static Value trunc(const Value& v, uint32_t bitwidth);
+  static Value sext(const Value& v, uint32_t bitwidth);
+  static Value zext(const Value& v, uint32_t bitwidth);
+  static Value bitcast(const Value& v, const Type& tgt);
+
   // These need to be defined since Value has an internal union
   Value(const Value&);
   Value(Value&&);

--- a/src/Solver/Solver.cpp
+++ b/src/Solver/Solver.cpp
@@ -16,7 +16,9 @@ public:
   }
 
   Value visitConstant(const Constant& op) {
-    return model_->lookup(op);
+    auto value = model_->lookup(op);
+    CAFFEINE_ASSERT(value.type() != Type::void_ty());
+    return value;
   }
   Value visitConstantInt(const ConstantInt& op) {
     return op.value();
@@ -59,6 +61,20 @@ public:
 
   Value visitSelectOp(const SelectOp& select) {
     return Value::select(visit(select[0]), visit(select[1]), visit(select[2]));
+  }
+
+  Value visitTrunc(const UnaryOp& op) {
+    return Value::trunc(visit(op[0]), op.type().bitwidth());
+  }
+  Value visitZExt(const UnaryOp& op) {
+    return Value::zext(visit(op[0]), op.type().bitwidth());
+  }
+  Value visitSExt(const UnaryOp& op) {
+    return Value::sext(visit(op[0]), op.type().bitwidth());
+  }
+
+  Value visitBitcast(const UnaryOp& op) {
+    return Value::bitcast(visit(op[0]), op.type());
   }
 
 private:

--- a/test/unit/IR/Value.cpp
+++ b/test/unit/IR/Value.cpp
@@ -1,4 +1,5 @@
 #include "caffeine/IR/Value.h"
+#include "caffeine/IR/Type.h"
 
 #include <gtest/gtest.h>
 
@@ -22,3 +23,13 @@ DECL_TEST(bvand, &, 0xFF0, 0x0FF);
 DECL_TEST(bvor, |, 0xFF0, 0x0FF);
 DECL_TEST(bvxor, ^, 0xFF0, 0x0FF);
 DECL_TEST(bvshl, <<, 0xFF, 3);
+
+// This should really be a property-based test
+// Ideally we'd use caffeine itself to perform these tests
+TEST(ir_value, bitcast_roundtrip) {
+  Value a{llvm::APInt(64, ~UINT64_C(0))};
+  Value b =
+      Value::bitcast(Value::bitcast(a, Type::type_of<double>()), a.type());
+
+  ASSERT_EQ(a, b);
+}


### PR DESCRIPTION
As in title. I have added 1 test case to ensure everything works but I can add more if we think they're needed.

Closes #62.