### PR TITLE
(Mostly) make floats work

### DIFF
--- a/cmake/formatting.cmake
+++ b/cmake/formatting.cmake
@@ -29,7 +29,6 @@ set(formatted "")
 
 foreach(source ${fmt_sources})
   get_filename_component(source_dir "${source}" DIRECTORY)
-  get_filename_component(source_name "${source}" NAME)
 
   add_custom_command(
     OUTPUT "${CMAKE_BINARY_DIR}/.fmt/${source}"
@@ -37,7 +36,7 @@ foreach(source ${fmt_sources})
     COMMAND ${CLANG_FORMAT} "${CMAKE_SOURCE_DIR}/${source}" > "${CMAKE_BINARY_DIR}/.fmt/${source}"
     COMMAND diff --color=always -u "${CMAKE_SOURCE_DIR}/${source}" "${CMAKE_BINARY_DIR}/.fmt/${source}"
     DEPENDS "${CMAKE_SOURCE_DIR}/${source}"
-    COMMENT "Checking formatting for ${source_name}"
+    COMMENT "Checking formatting for ${source}"
     WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}"
   )
 

--- a/include/caffeine/IR/Type.inl
+++ b/include/caffeine/IR/Type.inl
@@ -91,6 +91,11 @@ inline Type Type::type_of<void>() {
   return Type::void_ty();
 }
 
+template <>
+inline Type Type::type_of<bool>() {
+  return Type::int_ty(1);
+}
+
 #undef CAFFEINE_TYPE_TYPEOF_INT
 
 } // namespace caffeine

--- a/include/caffeine/Interpreter/Interpreter.h
+++ b/include/caffeine/Interpreter/Interpreter.h
@@ -48,6 +48,7 @@ public:
   ExecutionResult visitNot(llvm::BinaryOperator& op);
 
   ExecutionResult visitICmpInst(llvm::ICmpInst& icmp);
+  ExecutionResult visitFCmpInst(llvm::FCmpInst& fcmp);
 
   ExecutionResult visitTrunc(llvm::TruncInst& trunc);
 

--- a/src/IR/Operation.cpp
+++ b/src/IR/Operation.cpp
@@ -618,7 +618,7 @@ ref<Operation> FCmpOp::CreateFCmp(FCmpOpcode cmp, const ref<Operation>& lhs,
   CAFFEINE_ASSERT(lhs->type().is_float(),
                   "icmp can only be created with integer operands");
 
-  return ref<Operation>(new FCmpOp(cmp, lhs->type(), lhs, rhs));
+  return ref<Operation>(new FCmpOp(cmp, Type::type_of<bool>(), lhs, rhs));
 }
 
 /***************************************************

--- a/src/Interpreter/Interpreter.cpp
+++ b/src/Interpreter/Interpreter.cpp
@@ -246,6 +246,40 @@ ExecutionResult Interpreter::visitICmpInst(llvm::ICmpInst& icmp) {
   }
 #undef ICMP_CASE
 }
+ExecutionResult Interpreter::visitFCmpInst(llvm::FCmpInst& fcmp) {
+  using llvm::FCmpInst;
+
+  auto& frame = ctx->stack_top();
+
+  auto lhs = frame.lookup(fcmp.getOperand(0));
+  auto rhs = frame.lookup(fcmp.getOperand(1));
+
+#define FCMP_CASE(op)                                                          \
+  case FCmpInst::FCMP_##op:                                                    \
+    frame.insert(&fcmp, FCmpOp::CreateFCmp(FCmpOpcode::op, lhs, rhs));         \
+    return ExecutionResult::Continue
+
+  switch (fcmp.getPredicate()) {
+    FCMP_CASE(OEQ);
+    FCMP_CASE(OGT);
+    FCMP_CASE(OGE);
+    FCMP_CASE(OLT);
+    FCMP_CASE(OLE);
+    FCMP_CASE(ONE);
+    FCMP_CASE(ORD);
+    FCMP_CASE(UEQ);
+    FCMP_CASE(UGT);
+    FCMP_CASE(UGE);
+    FCMP_CASE(ULT);
+    FCMP_CASE(ULE);
+    FCMP_CASE(UNE);
+    FCMP_CASE(UNO);
+  default:
+    CAFFEINE_UNREACHABLE();
+  }
+
+#undef FCMP_CASE
+}
 
 ExecutionResult Interpreter::visitTrunc(llvm::TruncInst& trunc) {
   auto& frame = ctx->stack_top();

--- a/src/Interpreter/Interpreter.cpp
+++ b/src/Interpreter/Interpreter.cpp
@@ -274,6 +274,14 @@ ExecutionResult Interpreter::visitFCmpInst(llvm::FCmpInst& fcmp) {
     FCMP_CASE(ULE);
     FCMP_CASE(UNE);
     FCMP_CASE(UNO);
+
+  case FCmpInst::FCMP_TRUE:
+    frame.insert(&fcmp, ConstantInt::Create(true));
+    return ExecutionResult::Continue;
+  case FCmpInst::FCMP_FALSE:
+    frame.insert(&fcmp, ConstantInt::Create(false));
+    return ExecutionResult::Continue;
+
   default:
     CAFFEINE_UNREACHABLE();
   }

--- a/src/Interpreter/StackFrame.cpp
+++ b/src/Interpreter/StackFrame.cpp
@@ -14,6 +14,12 @@ ref<Operation> evaluate_constant(const llvm::Constant* constant) {
     return ConstantInt::Create(value);
   }
 
+  if (auto* fpconst = llvm::dyn_cast<llvm::ConstantFP>(constant)) {
+    const llvm::APFloat& value = fpconst->getValueAPF();
+
+    return ConstantFloat::Create(value);
+  }
+
   // We only implement integers at the moment
   CAFFEINE_UNIMPLEMENTED();
 }

--- a/src/Interpreter/StackFrame.cpp
+++ b/src/Interpreter/StackFrame.cpp
@@ -20,7 +20,6 @@ ref<Operation> evaluate_constant(const llvm::Constant* constant) {
     return ConstantFloat::Create(value);
   }
 
-  // We only implement integers at the moment
   CAFFEINE_UNIMPLEMENTED();
 }
 

--- a/src/Solver/Z3Solver.cpp
+++ b/src/Solver/Z3Solver.cpp
@@ -22,6 +22,61 @@ static llvm::APInt z3_to_apint(const z3::expr& expr) {
   }
 }
 
+static llvm::APFloat z3_to_apfloat(const z3::expr& expr) {
+  CAFFEINE_ASSERT(expr.is_fpa());
+
+  unsigned int sbits = expr.get_sort().fpa_sbits();
+  unsigned int ebits = expr.get_sort().fpa_ebits();
+
+  llvm::APInt mantissa;
+  uint64_t s = 0;
+  if (Z3_fpa_get_numeral_significand_uint64(expr.ctx(), expr, &s)) {
+    mantissa = llvm::APInt(sbits, s);
+  } else {
+    auto str = Z3_fpa_get_numeral_significand_string(expr.ctx(), expr);
+    mantissa = llvm::APInt(sbits, str, 10);
+  }
+
+  // Z3 doesn't exactly model NaNs well. Need to avoid the case where we get a
+  // NaN but Z3 tells us that the significand is 0 since that actually
+  // represents an infinity.
+  if (Z3_fpa_is_numeral_nan(expr.ctx(), expr) && mantissa == 0) {
+    mantissa = llvm::APInt(sbits, 1);
+  }
+
+  // Remove leading bit from mantissa to get it in IEEE-754 representation
+  mantissa = mantissa.trunc(mantissa.getBitWidth() - 1);
+
+  llvm::APInt exponent;
+  int64_t e = 0;
+  if (Z3_fpa_get_numeral_exponent_int64(expr.ctx(), expr, &e, false)) {
+    exponent = llvm::APInt(ebits, e, true);
+  } else if (Z3_fpa_is_numeral_nan(expr.ctx(), expr)) {
+    exponent = llvm::APInt::getAllOnesValue(ebits);
+  } else {
+    // Not worth implementing until we have a float implementation that supports
+    // more than 16-bit exponents.
+    CAFFEINE_UNIMPLEMENTED();
+  }
+
+  int sign = 0;
+  if (Z3_fpa_is_numeral_nan(expr.ctx(), expr)) {
+    // There's no way to extract the sign bit from Z3
+    sign = 0;
+  } else if (!Z3_fpa_get_numeral_sign(expr.ctx(), expr, &sign)) {
+    CAFFEINE_ABORT("broken fpa numeral");
+  }
+
+  llvm::APInt total = mantissa.zext(ebits + sbits) |
+                      (exponent.zext(ebits + sbits) << (sbits - 1));
+  if (sign < 0)
+    total.setSignBit();
+
+  return std::move(
+      Value::bitcast(Value(std::move(total)), Type::float_ty(ebits, sbits))
+          .apfloat());
+}
+
 static z3::expr bool_to_bv(const z3::expr& expr) {
   CAFFEINE_ASSERT(expr.is_bool());
 
@@ -114,8 +169,10 @@ Value Z3Model::lookup(const Constant& constant) const {
 
   if (evaluated.is_bv()) {
     return Value(z3_to_apint(evaluated));
+  } else if (evaluated.is_fpa()) {
+    return Value(z3_to_apfloat(evaluated));
   } else {
-    CAFFEINE_ABORT("FPA numerals are not supported right now");
+    CAFFEINE_ABORT("Unsupported numeral type");
   }
 }
 
@@ -151,7 +208,6 @@ std::unique_ptr<Model> Z3Solver::resolve(std::vector<Assertion>& assertions,
     solver.add(normalize_to_bool(exp));
   }
 
-  std::cout << solver.to_smt2() << std::endl;
   auto result = solver.check();
 
   switch (result) {
@@ -312,7 +368,9 @@ z3::expr Z3OpVisitor::visitICmp(const ICmpOp& op) {
 
 // Z3's C++ API doesn't include this so we need to use the C API
 static z3::expr is_nan(const z3::expr& e) {
-  return z3::expr(e.ctx(), Z3_mk_fpa_is_nan(e.ctx(), e));
+  auto expr = z3::expr(e.ctx(), Z3_mk_fpa_is_nan(e.ctx(), e));
+  expr.check_error();
+  return expr;
 }
 
 z3::expr Z3OpVisitor::visitFCmp(const FCmpOp& op) {

--- a/src/Solver/Z3Solver.cpp
+++ b/src/Solver/Z3Solver.cpp
@@ -61,7 +61,7 @@ static llvm::APFloat z3_to_apfloat(const z3::expr& expr) {
 
   int sign = 0;
   if (Z3_fpa_is_numeral_nan(expr.ctx(), expr)) {
-    // There's no way to extract the sign bit from Z3
+    // There's no way to extract the sign bit from Z3 for NaNs
     sign = 0;
   } else if (!Z3_fpa_get_numeral_sign(expr.ctx(), expr, &sign)) {
     CAFFEINE_ABORT("broken fpa numeral");

--- a/src/Solver/Z3Solver.cpp
+++ b/src/Solver/Z3Solver.cpp
@@ -52,6 +52,8 @@ static llvm::APFloat z3_to_apfloat(const z3::expr& expr) {
   if (Z3_fpa_get_numeral_exponent_int64(expr.ctx(), expr, &e, false)) {
     exponent = llvm::APInt(ebits, e, true);
   } else if (Z3_fpa_is_numeral_nan(expr.ctx(), expr)) {
+    // Z3 doesn't allow us to extract the exponent of NaNs. However there's only
+    // one possible exponent for a NaN so just hardcode it here.
     exponent = llvm::APInt::getAllOnesValue(ebits);
   } else {
     // Not worth implementing until we have a float implementation that supports

--- a/test/run-fail/fp/self-equality.c
+++ b/test/run-fail/fp/self-equality.c
@@ -1,0 +1,7 @@
+
+#include "caffeine.h"
+
+void test(double x) {
+  // This should fail when X is NaN
+  caffeine_assert(x == x);
+}


### PR DESCRIPTION
This makes floating point values and computations work in most cases. Here's the list of what was changed
- Implement support for LLVM `fcmp` instruction
- Use Z3's builtin `isnan` checking functions since `x == x` apparently doesn't work as expected with NaNs.
- Add support for extracting floating point values to `llvm::APFloat`
- Allow creating constants from LLVM floating point literals.
- Add a test case verifying that `x != x` fails with NaNs.

There's still some quirks of LLVM that are unsupported here but those can go in a separate PR. (I do have uncommitted test cases which fail there).