### PR TITLE
Add support for floating-point opcodes

### DIFF
--- a/include/caffeine/Interpreter/Interpreter.h
+++ b/include/caffeine/Interpreter/Interpreter.h
@@ -47,6 +47,11 @@ public:
   ExecutionResult visitXor(llvm::BinaryOperator& op);
   ExecutionResult visitNot(llvm::BinaryOperator& op);
 
+  ExecutionResult visitFAdd(llvm::BinaryOperator& op);
+  ExecutionResult visitFSub(llvm::BinaryOperator& op);
+  ExecutionResult visitFMul(llvm::BinaryOperator& op);
+  ExecutionResult visitFDiv(llvm::BinaryOperator& op);
+
   ExecutionResult visitICmpInst(llvm::ICmpInst& icmp);
   ExecutionResult visitFCmpInst(llvm::FCmpInst& fcmp);
 

--- a/src/Interpreter/Interpreter.cpp
+++ b/src/Interpreter/Interpreter.cpp
@@ -217,6 +217,47 @@ ExecutionResult Interpreter::visitNot(llvm::BinaryOperator& op) {
   return ExecutionResult::Continue;
 }
 
+ExecutionResult Interpreter::visitFAdd(llvm::BinaryOperator& op) {
+  StackFrame& frame = ctx->stack_top();
+
+  auto lhs = frame.lookup(op.getOperand(0));
+  auto rhs = frame.lookup(op.getOperand(1));
+
+  frame.insert(&op, BinaryOp::CreateFAdd(lhs, rhs));
+
+  return ExecutionResult::Continue;
+}
+ExecutionResult Interpreter::visitFSub(llvm::BinaryOperator& op) {
+  StackFrame& frame = ctx->stack_top();
+
+  auto lhs = frame.lookup(op.getOperand(0));
+  auto rhs = frame.lookup(op.getOperand(1));
+
+  frame.insert(&op, BinaryOp::CreateFAdd(lhs, rhs));
+
+  return ExecutionResult::Continue;
+}
+ExecutionResult Interpreter::visitFMul(llvm::BinaryOperator& op) {
+  StackFrame& frame = ctx->stack_top();
+
+  auto lhs = frame.lookup(op.getOperand(0));
+  auto rhs = frame.lookup(op.getOperand(1));
+
+  frame.insert(&op, BinaryOp::CreateFAdd(lhs, rhs));
+
+  return ExecutionResult::Continue;
+}
+ExecutionResult Interpreter::visitFDiv(llvm::BinaryOperator& op) {
+  StackFrame& frame = ctx->stack_top();
+
+  auto lhs = frame.lookup(op.getOperand(0));
+  auto rhs = frame.lookup(op.getOperand(1));
+
+  frame.insert(&op, BinaryOp::CreateFAdd(lhs, rhs));
+
+  return ExecutionResult::Continue;
+}
+
 ExecutionResult Interpreter::visitICmpInst(llvm::ICmpInst& icmp) {
   using llvm::ICmpInst;
 

--- a/src/Solver/Z3Solver.cpp
+++ b/src/Solver/Z3Solver.cpp
@@ -399,7 +399,7 @@ static z3::expr fpa_geq(const z3::expr& a, const z3::expr& b) {
   return val;
 }
 static z3::expr fpa_gt(const z3::expr& a, const z3::expr& b) {
-  auto val = z3::expr(a.ctx(), Z3_mk_fpa_leq(a.ctx(), a, b));
+  auto val = z3::expr(a.ctx(), Z3_mk_fpa_gt(a.ctx(), a, b));
   val.check_error();
   return val;
 }

--- a/src/Solver/Z3Solver.h
+++ b/src/Solver/Z3Solver.h
@@ -92,4 +92,10 @@ public:
   // clang-format on
 };
 
+// Convert a Z3 expression to an APInt
+llvm::APInt z3_to_apint(const z3::expr& expr);
+
+// Convert a Z3 expression to an APFloat
+llvm::APFloat z3_to_apfloat(const z3::expr& expr);
+
 } // namespace caffeine

--- a/test/run-fail/fp/approx-sqrt.c
+++ b/test/run-fail/fp/approx-sqrt.c
@@ -1,0 +1,24 @@
+
+#include "caffeine.h"
+#include <stdlib.h>
+
+double approx_sqrt(double x) {
+  double r = 1.0;
+
+  for (size_t i = 0; i < 5; ++i) {
+    r -= (r * r - x) / (2.0 * r);
+  }
+
+  return r;
+}
+
+void test(double x) {
+  // No NaNs
+  caffeine_assume(x == x);
+  caffeine_assume(x > 0.0);
+  caffeine_assume(x < 1.0);
+
+  double v = approx_sqrt(x);
+
+  caffeine_assert(v * v <= x * 2.0);
+}

--- a/test/run-fail/fp/greater-than-all.c
+++ b/test/run-fail/fp/greater-than-all.c
@@ -1,0 +1,10 @@
+
+#include "caffeine.h"
+#include <float.h>
+
+void test(double x) {
+  // TODO: Support isnan
+  caffeine_assume(x == x);
+
+  caffeine_assert(x <= DBL_MAX);
+}

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -15,6 +15,7 @@ target_link_libraries(caffeine-unittest PRIVATE caffeine)
 target_link_libraries(caffeine-unittest PRIVATE GTest::GTest)
 target_include_directories(caffeine-unittest PRIVATE "${CMAKE_SOURCE_DIR}/include")
 target_include_directories(caffeine-unittest PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}")
+target_include_directories(caffeine-unittest PRIVATE "${CMAKE_SOURCE_DIR}")
 
 if (${CMAKE_VERSION} VERSION_LESS "3.10.0")
   add_test(NAME unit-tests COMMAND caffeine-unittest)

--- a/test/unit/Solver/Z3Solver.cpp
+++ b/test/unit/Solver/Z3Solver.cpp
@@ -1,0 +1,70 @@
+
+#include "src/Solver/Z3Solver.h"
+
+#include <gtest/gtest.h>
+
+using caffeine::z3_to_apfloat;
+using caffeine::z3_to_apint;
+
+class Z3ConversionTests : public ::testing::Test {
+public:
+  z3::context ctx;
+};
+
+TEST_F(Z3ConversionTests, pos_inf_to_apfloat) {
+  auto pos_z = z3::expr(ctx, Z3_mk_fpa_inf(ctx, ctx.fpa_sort(11, 53), false));
+  auto pos_v = z3_to_apfloat(pos_z);
+
+  EXPECT_TRUE(pos_v.isInfinity());
+
+  ASSERT_EQ(pos_v.convertToDouble(), INFINITY);
+}
+
+TEST_F(Z3ConversionTests, neg_inf_to_apfloat) {
+  auto neg_z = z3::expr(ctx, Z3_mk_fpa_inf(ctx, ctx.fpa_sort(11, 53), true));
+  auto neg_v = z3_to_apfloat(neg_z);
+
+  EXPECT_TRUE(neg_v.isInfinity());
+  ASSERT_EQ(neg_v.convertToDouble(), -INFINITY);
+}
+
+TEST_F(Z3ConversionTests, nan_to_apfloat) {
+  auto nan = z3::expr(ctx, Z3_mk_fpa_nan(ctx, ctx.fpa_sort(11, 53)));
+  auto val = z3_to_apfloat(nan);
+
+  ASSERT_TRUE(val.isNaN());
+}
+
+TEST_F(Z3ConversionTests, zero_to_apfloat) {
+  auto zero = z3::expr(ctx, Z3_mk_fpa_zero(ctx, ctx.fpa_sort(11, 53), false));
+  auto val = z3_to_apfloat(zero);
+
+  ASSERT_TRUE(val.isZero());
+}
+
+TEST_F(Z3ConversionTests, five_to_apfloat) {
+  auto fpa =
+      z3::expr(ctx, Z3_mk_fpa_numeral_double(ctx, 5.0, ctx.fpa_sort(11, 53)));
+  auto val = z3_to_apfloat(fpa);
+
+  ASSERT_TRUE(val.isFiniteNonZero());
+  ASSERT_EQ(val.convertToDouble(), 5.0);
+}
+
+TEST_F(Z3ConversionTests, neg1_to_apfloat) {
+  auto fpa =
+      z3::expr(ctx, Z3_mk_fpa_numeral_double(ctx, -1.0, ctx.fpa_sort(11, 53)));
+  auto val = z3_to_apfloat(fpa);
+
+  ASSERT_TRUE(val.isFiniteNonZero());
+  ASSERT_EQ(val.convertToDouble(), -1.0);
+}
+
+TEST_F(Z3ConversionTests, dbl_max_to_apfloat) {
+  auto fpa = z3::expr(
+      ctx, Z3_mk_fpa_numeral_double(ctx, DBL_MAX, ctx.fpa_sort(11, 53)));
+  auto val = z3_to_apfloat(fpa);
+
+  ASSERT_TRUE(val.isFiniteNonZero());
+  ASSERT_EQ(val.convertToDouble(), DBL_MAX);
+}


### PR DESCRIPTION
This adds support for floating point arithmetic opcodes and also uses the Z3 C interface for floating point operations that are not supported by the C++ interface.

Note: Conversion from Z3 values to APFloat is currently broken when the Z3 fpa is an infinity. Will hold off merging until I fix that.