### PR TITLE
Make everything compile with MSVC

### DIFF
--- a/cmake/setup-warnings.cmake
+++ b/cmake/setup-warnings.cmake
@@ -14,7 +14,7 @@ if (MSVC)
   )
 
   # Enable more detailed warnings (but not all of them).
-  add_compile_options(/W4)
+  add_compile_options(/W3)
 
   # Some code within LLVM triggers this. It's not something we can fix so
   # better to silence the warning than have it drown everything out.

--- a/include/caffeine/ADT/Ref.h
+++ b/include/caffeine/ADT/Ref.h
@@ -147,12 +147,10 @@ public:
     return value != r.value;
   }
 
-  ref(const ref<T>& r)
-      : Deleter(r.deleter()), value(r.value) {
+  ref(const ref<T>& r) : Deleter(r.deleter()), value(r.value) {
     increment();
   }
-  ref(ref<T>&& r) noexcept
-      : Deleter(r.deleter()), value(r.value) {
+  ref(ref<T>&& r) noexcept : Deleter(r.deleter()), value(r.value) {
     r.value = nullptr;
   }
 

--- a/include/caffeine/ADT/Ref.h
+++ b/include/caffeine/ADT/Ref.h
@@ -33,9 +33,6 @@ class ref : Deleter {
 private:
   T* value;
 
-  static const bool is_nothrow_destructible =
-      std::is_nothrow_destructible<T>::value;
-
   enum raw_t { raw };
   constexpr ref(raw_t, T* value, Deleter deleter)
       : Deleter(deleter), value(value) {}
@@ -150,25 +147,23 @@ public:
     return value != r.value;
   }
 
-  ref(const ref<T>& r) noexcept(std::is_nothrow_copy_constructible_v<Deleter>)
+  ref(const ref<T>& r)
       : Deleter(r.deleter()), value(r.value) {
     increment();
   }
-  ref(ref<T>&& r) noexcept(std::is_nothrow_move_constructible_v<Deleter>)
+  ref(ref<T>&& r) noexcept
       : Deleter(r.deleter()), value(r.value) {
     r.value = nullptr;
   }
 
-  ref<T>& operator=(const ref<T>& r) noexcept(
-      is_nothrow_destructible&& std::is_nothrow_copy_assignable_v<Deleter>) {
+  ref<T>& operator=(const ref<T>& r) {
     decrement();
     value = r.value;
     *(Deleter*)this = r.deleter();
     increment();
     return *this;
   }
-  ref<T>& operator=(ref<T>&& r) noexcept(
-      is_nothrow_destructible&& std::is_nothrow_move_assignable_v<Deleter>) {
+  ref<T>& operator=(ref<T>&& r) noexcept {
     decrement();
     value = r.value;
     r.value = nullptr;
@@ -176,13 +171,13 @@ public:
     return *this;
   }
 
-  ref<T>& operator=(std::nullptr_t) noexcept(is_nothrow_destructible) {
+  ref<T>& operator=(std::nullptr_t) noexcept {
     decrement();
     value = nullptr;
     return *this;
   }
 
-  ~ref() noexcept(is_nothrow_destructible) {
+  ~ref() noexcept {
     decrement();
   }
 

--- a/include/caffeine/ADT/SlotMap.h
+++ b/include/caffeine/ADT/SlotMap.h
@@ -5,6 +5,7 @@
 #include <climits>
 #include <deque>
 #include <optional>
+#include <stdexcept>
 #include <type_traits>
 #include <utility>
 

--- a/include/caffeine/IR/Visitor.inl
+++ b/include/caffeine/IR/Visitor.inl
@@ -6,6 +6,11 @@
 
 #include <llvm/Support/Casting.h>
 
+#ifdef _MSC_VER
+#pragma warning(push)
+#pragma warning(disable : 4002 4003)
+#endif
+
 namespace caffeine {
 
 namespace detail::visitor {
@@ -94,5 +99,9 @@ RetTy OpVisitorBase<Transform, SubClass, RetTy>::visit(
 }
 
 } // namespace caffeine
+
+#ifdef _MSC_VER
+#pragma warning(pop)
+#endif
 
 #endif

--- a/include/caffeine/Support/Macros.h
+++ b/include/caffeine/Support/Macros.h
@@ -1,6 +1,12 @@
 #ifndef CAFFEINE_SUPPORT_MACROS_H
 #define CAFFEINE_SUPPORT_MACROS_H
 
+#ifdef _MSC_VER
+#define CAFFEINE_MSVC_PRAGMA(x) __pragma(x)
+#else
+#define CAFFEINE_MSVC_PRAGMA(x)
+#endif
+
 /**
  * Support library for doing macro tricks.
  */
@@ -15,8 +21,9 @@
 #define CAFFEINE_INVOKE_NUMBERED_(x, _1, _2, _3, _4, _5, _6, _7, _8, _9, FUNC, \
                                   ...)                                         \
   FUNC
+
 /**
- *
+ * Invoke a macro with a conditional number of arguments
  *
  * Based off of https://stackoverflow.com/a/8814003/4821282
  */

--- a/src/Memory/MemHeap.cpp
+++ b/src/Memory/MemHeap.cpp
@@ -131,8 +131,8 @@ void Allocation::write(const ref<Operation>& offset,
   for (uint32_t i = 0; i < width; ++i) {
     auto byte = UnaryOp::CreateTrunc(
         Type::int_ty(8),
-        BinaryOp::CreateLShr(
-            value, ConstantInt::Create(llvm::APInt(i * 8, (uint64_t)width * 8))));
+        BinaryOp::CreateLShr(value, ConstantInt::Create(llvm::APInt(
+                                        i * 8, (uint64_t)width * 8))));
     auto index = BinaryOp::CreateAdd(
         offset, ConstantInt::Create(llvm::APInt(i, (uint64_t)width * 8)));
 

--- a/src/Memory/MemHeap.cpp
+++ b/src/Memory/MemHeap.cpp
@@ -84,7 +84,7 @@ ref<Operation> Allocation::read(const ref<Operation>& offset, const Type& t,
     // extended = zext(bytes[i], bitwidth) << (i * 8)
     auto extended = BinaryOp::CreateShl(
         UnaryOp::CreateZExt(Type::int_ty(bitwidth), bytes[i]),
-        ConstantInt::Create(llvm::APInt(bitwidth, i * 8)));
+        ConstantInt::Create(llvm::APInt(bitwidth, (uint64_t)i * 8)));
     bitresult = BinaryOp::CreateOr(bitresult, extended);
   }
 
@@ -132,9 +132,9 @@ void Allocation::write(const ref<Operation>& offset,
     auto byte = UnaryOp::CreateTrunc(
         Type::int_ty(8),
         BinaryOp::CreateLShr(
-            value, ConstantInt::Create(llvm::APInt(i * 8, width * 8))));
+            value, ConstantInt::Create(llvm::APInt(i * 8, (uint64_t)width * 8))));
     auto index = BinaryOp::CreateAdd(
-        offset, ConstantInt::Create(llvm::APInt(i, width * 8)));
+        offset, ConstantInt::Create(llvm::APInt(i, (uint64_t)width * 8)));
 
     overwrite(StoreOp::Create(data(), index, byte));
   }

--- a/src/Solver/Z3Solver.cpp
+++ b/src/Solver/Z3Solver.cpp
@@ -121,7 +121,7 @@ static z3::symbol name_to_symbol(z3::context& ctx,
     return ctx.str_symbol(ptr->c_str());
   if (auto ptr = std::get_if<uint64_t>(&name)) {
     CAFFEINE_ASSERT(*ptr <= (uint64_t)INT_MAX);
-    return ctx.int_symbol(*ptr);
+    return ctx.int_symbol(static_cast<int>(*ptr));
   }
 
   CAFFEINE_UNREACHABLE();


### PR DESCRIPTION
This fixes a few errors that aren't enforced by gcc or clang as well as resolves a number of warnings that only show up in MSVC