### PR TITLE
Implement undef operation

### DIFF
--- a/include/caffeine/IR/Operation.h
+++ b/include/caffeine/IR/Operation.h
@@ -123,7 +123,7 @@ public:
     /**
      * An unnamed symbolic constant that can have any value whenever it is
      * used. Has the same semantics as LLVM's undef.
-     * 
+     *
      * It is valid for solvers to have any value for the undef constant.
      */
     Undef = detail::opcode(1, 0, 15),
@@ -675,7 +675,7 @@ public:
 
 /**
  * Undefined value.
- * 
+ *
  * Each time this is used it can correspond to any possible bitpattern of
  * it's corresponding type. The resolved value does not have to be consistent
  * between uses of the same value.

--- a/include/caffeine/IR/Operation.h
+++ b/include/caffeine/IR/Operation.h
@@ -120,6 +120,13 @@ public:
     ConstantInt = detail::opcode(1, 0, 5),
     ConstantFloat = detail::opcode(1, 0, 6),
     ConstantArray = detail::opcode(1, 0, 7),
+    /**
+     * An unnamed symbolic constant that can have any value whenever it is
+     * used. Has the same semantics as LLVM's undef.
+     * 
+     * It is valid for solvers to have any value for the undef constant.
+     */
+    Undef = detail::opcode(1, 0, 15),
 
     /* Binary Opcodes */
     Add = detail::opcode(2, 2, 0),
@@ -268,6 +275,7 @@ protected:
             const ref<Operation>& op1, const ref<Operation>& op2);
 
   Operation();
+  Operation(Opcode op, Type t);
 
 public:
   /**
@@ -661,6 +669,23 @@ public:
   static ref<Operation> Create(const ref<Operation>& data,
                                const ref<Operation>& offset,
                                const ref<Operation>& value);
+
+  static bool classof(const Operation* op);
+};
+
+/**
+ * Undefined value.
+ * 
+ * Each time this is used it can correspond to any possible bitpattern of
+ * it's corresponding type. The resolved value does not have to be consistent
+ * between uses of the same value.
+ */
+class Undef : public Operation {
+private:
+  Undef(const Type& t);
+
+public:
+  static ref<Operation> Create(const Type& t);
 
   static bool classof(const Operation* op);
 };

--- a/include/caffeine/IR/Operation.inl
+++ b/include/caffeine/IR/Operation.inl
@@ -391,6 +391,7 @@ CAFFEINE_OP_DECL_CLASSOF(SelectOp, Select);
 CAFFEINE_OP_DECL_CLASSOF(AllocOp, Alloc);
 CAFFEINE_OP_DECL_CLASSOF(LoadOp, Load);
 CAFFEINE_OP_DECL_CLASSOF(StoreOp, Store);
+CAFFEINE_OP_DECL_CLASSOF(Undef, Undef);
 
 inline bool Constant::classof(const Operation* op) {
   return op->opcode() == ConstantNamed || op->opcode() == ConstantNumbered;

--- a/include/caffeine/IR/Visitor.h
+++ b/include/caffeine/IR/Visitor.h
@@ -91,6 +91,7 @@ public:
   RetTy visitConstant     (transform_t<Constant>     & O) { return CAFFEINE_OP_DELEGATE(Operation); }
   RetTy visitConstantInt  (transform_t<ConstantInt>  & O) { return CAFFEINE_OP_DELEGATE(Operation); }
   RetTy visitConstantFloat(transform_t<ConstantFloat>& O) { return CAFFEINE_OP_DELEGATE(Operation); }
+  RetTy visitUndef        (transform_t<Undef>        & O) { return CAFFEINE_OP_DELEGATE(Operation); }
 
   RetTy visitBinaryOp(transform_t<BinaryOp>& O) { return CAFFEINE_OP_DELEGATE(Operation); }
   RetTy visitUnaryOp (transform_t<UnaryOp> & O) { return CAFFEINE_OP_DELEGATE(Operation); }

--- a/include/caffeine/IR/Visitor.inl
+++ b/include/caffeine/IR/Visitor.inl
@@ -67,6 +67,7 @@ RetTy OpVisitorBase<Transform, SubClass, RetTy>::visit(
     DELEGATE(Select, SelectOp, SelectOp);
     DELEGATE(ConstantInt, ConstantInt);
     DELEGATE(ConstantFloat, ConstantFloat);
+    DELEGATE(Undef, Undef);
 
     DELEGATE(Trunc, UnaryOp);
     DELEGATE(SExt, UnaryOp);

--- a/src/IR/Operation.cpp
+++ b/src/IR/Operation.cpp
@@ -6,6 +6,9 @@ namespace caffeine {
 
 Operation::Operation() : opcode_(Invalid), type_(Type::void_ty()) {}
 
+Operation::Operation(Opcode op, Type t)
+    : opcode_(static_cast<uint16_t>(op)), type_(t) {}
+
 // clang-format off
 Operation::Operation(Opcode op, Type t, ref<Operation>* operands)
     : opcode_(static_cast<uint16_t>(op)),
@@ -66,6 +69,8 @@ Operation::Operation(const Operation& op) noexcept
     case ConstantNamed:
       new (&name_) std::string(op.name_);
       break;
+    case Undef:
+      break;
     default:
       CAFFEINE_UNREACHABLE();
     }
@@ -88,6 +93,8 @@ Operation::Operation(Operation&& op) noexcept
       break;
     case ConstantNamed:
       new (&name_) std::string(op.name_);
+      break;
+    case Undef:
       break;
     default:
       CAFFEINE_UNREACHABLE();
@@ -139,6 +146,8 @@ Operation& Operation::operator=(const Operation& op) noexcept {
     case ConstantNamed:
       new (&name_) std::string(op.name_);
       break;
+    case Undef:
+      break;
     default:
       CAFFEINE_UNREACHABLE();
     }
@@ -166,6 +175,8 @@ Operation& Operation::operator=(Operation&& op) noexcept {
       break;
     case ConstantNamed:
       new (&name_) std::string(std::move(op.name_));
+      break;
+    case Undef:
       break;
     default:
       CAFFEINE_UNREACHABLE();
@@ -228,6 +239,8 @@ void Operation::invalidate() noexcept {
     case ConstantNamed:
       name_.~basic_string();
       break;
+    case Undef:
+      break;
     default:
       CAFFEINE_UNREACHABLE();
     }
@@ -252,6 +265,7 @@ const char* Operation::opcode_name(Opcode op) {
   case ConstantInt:   return "ConstantInt";
   case ConstantFloat: return "ConstantFloat";
   case ConstantArray: return "ConstantArray";
+  case Undef:         return "Undef";
 
   case Add:   return "Add";
   case Sub:   return "Sub";
@@ -674,6 +688,15 @@ ref<Operation> StoreOp::Create(const ref<Operation>& data,
   CAFFEINE_ASSERT(value->type() == Type::int_ty(8), "Value must be of type i8");
 
   return ref<Operation>(new StoreOp(data, offset, value));
+}
+
+/***************************************************
+ * Undef                                           *
+ ***************************************************/
+Undef::Undef(const Type& t) : Operation(Opcode::Undef, t) {}
+
+ref<Operation> Undef::Create(const Type& t) {
+  return ref<Operation>(new Undef(t));
 }
 
 /***************************************************

--- a/src/Solver/Z3Solver.h
+++ b/src/Solver/Z3Solver.h
@@ -45,9 +45,15 @@ public:
 private:
   z3::context* ctx;
   Z3Model::ConstMap& constMap;
+  std::unordered_map<const Operation*, z3::expr> cache;
 
 public:
   Z3OpVisitor(z3::context* ctx, Z3Model::ConstMap& constMap);
+
+  z3::expr visit(const Operation& op);
+  z3::expr visit(const Operation* op) {
+    return visit(*op);
+  }
 
   z3::expr visitOperation(const Operation& op);
 
@@ -55,6 +61,7 @@ public:
   z3::expr visitConstant     (const Constant& op);
   z3::expr visitConstantInt  (const ConstantInt& op);
   z3::expr visitConstantFloat(const ConstantFloat& op);
+  z3::expr visitUndef        (const Undef& op);
 
   // Binary operations
   z3::expr visitAdd (const BinaryOp& op);


### PR DESCRIPTION
I've been trying to implement vector operations and found that I needed this. I'm pulling it out here so that it can be reviewed separately.

For the moment I've approximated the semantics of the undef opcode within Z3 by just returning a constant 0. In the future we should probably look deeper into what's needed to properly handle undefs in LLVM.