### PR TITLE
Implement basic constant folding

### DIFF
--- a/include/caffeine/IR/Operation.h
+++ b/include/caffeine/IR/Operation.h
@@ -327,6 +327,11 @@ public:
 
   bool is_constant() const;
 
+  template <typename T>
+  bool is() const {
+    return llvm::isa<T>(*this);
+  }
+
   // Need to manually define these since we have an internal union.
   Operation(const Operation& op) noexcept;
   Operation(Operation&& op) noexcept;

--- a/src/IR/Operation.cpp
+++ b/src/IR/Operation.cpp
@@ -727,6 +727,9 @@ ref<Operation> UnaryOp::CreateTrunc(Type tgt, const ref<Operation>& operand) {
   CAFFEINE_ASSERT(operand->type().is_int());
   CAFFEINE_ASSERT(tgt.bitwidth() < operand->type().bitwidth());
 
+  if (const auto* undef = llvm::dyn_cast<caffeine::Undef>(operand.get()))
+    return Undef::Create(tgt);
+
   if (const auto* op = llvm::dyn_cast<caffeine::ConstantInt>(operand.get()))
     return ConstantInt::Create(op->value().trunc(tgt.bitwidth()));
 
@@ -746,6 +749,9 @@ ref<Operation> UnaryOp::CreateSExt(Type tgt, const ref<Operation>& operand) {
   CAFFEINE_ASSERT(tgt.is_int());
   CAFFEINE_ASSERT(operand->type().is_int());
   CAFFEINE_ASSERT(tgt.bitwidth() > operand->type().bitwidth());
+
+  if (const auto* undef = llvm::dyn_cast<caffeine::Undef>(operand.get()))
+    return Undef::Create(tgt);
 
   if (const auto* op = llvm::dyn_cast<caffeine::ConstantInt>(operand.get()))
     return ConstantInt::Create(op->value().sext(tgt.bitwidth()));

--- a/src/IR/Operation.h
+++ b/src/IR/Operation.h
@@ -14,4 +14,31 @@ inline bool is_constant_int(const Operation& op, uint64_t value) {
   return false;
 }
 
+inline bool constant_int_compare(ICmpOpcode cmp, const llvm::APInt& lhs,
+                                 const llvm::APInt& rhs) {
+  switch (cmp) {
+  case ICmpOpcode::EQ:
+    return lhs == rhs;
+  case ICmpOpcode::NE:
+    return lhs != rhs;
+  case ICmpOpcode::SGE:
+    return lhs.sge(rhs);
+  case ICmpOpcode::SGT:
+    return lhs.sgt(rhs);
+  case ICmpOpcode::SLE:
+    return lhs.sle(rhs);
+  case ICmpOpcode::SLT:
+    return lhs.slt(rhs);
+  case ICmpOpcode::UGE:
+    return lhs.uge(rhs);
+  case ICmpOpcode::UGT:
+    return lhs.ugt(rhs);
+  case ICmpOpcode::ULE:
+    return lhs.ule(rhs);
+  case ICmpOpcode::ULT:
+    return lhs.ult(rhs);
+  }
+  CAFFEINE_UNREACHABLE("unknown ICmpOpcode");
+}
+
 } // namespace caffeine

--- a/src/IR/Operation.h
+++ b/src/IR/Operation.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include "caffeine/IR/Operation.h"
+
+/**
+ * This header has a bunch of utility methods for constant folding.
+ */
+
+namespace caffeine {
+
+inline bool is_constant_int(const Operation& op, uint64_t value) {
+  if (const auto* constant = llvm::dyn_cast<ConstantInt>(&op))
+    return constant->value() == value;
+  return false;
+}
+
+} // namespace caffeine


### PR DESCRIPTION
This implements constant folding as part of expression construction. That is, when you call the corresponding `CreateXXX` method with constant operands it'll automatically do the proper constant folding. This means that no other code needs to be changed to take advantage of this.

This PR is dependant on #73 and includes its commits as well.