### PR TITLE
Add vector support

### DIFF
--- a/include/caffeine/Interpreter/Context.h
+++ b/include/caffeine/Interpreter/Context.h
@@ -1,13 +1,13 @@
 #ifndef CAFFEINE_INTERP_CONTEXT_H
 #define CAFFEINE_INTERP_CONTEXT_H
 
-#include <memory>
-
-#include <llvm/IR/Function.h>
-
 #include "caffeine/IR/Assertion.h"
 #include "caffeine/Interpreter/StackFrame.h"
 #include "caffeine/Solver/Solver.h"
+
+#include <llvm/IR/Function.h>
+
+#include <memory>
 
 namespace caffeine {
 

--- a/include/caffeine/Interpreter/Interpreter.h
+++ b/include/caffeine/Interpreter/Interpreter.h
@@ -66,6 +66,10 @@ public:
   ExecutionResult visitCallInst(llvm::CallInst& inst);
   ExecutionResult visitSelectInst(llvm::SelectInst& inst);
 
+  // ExecutionResult visitInsertElementInst(llvm::InsertElementInst& inst);
+  // ExecutionResult visitExtractElementInst(llvm::ExtractElementInst& inst);
+  // ExecutionResult visitShuffleVectorInst(llvm::ShuffleVectorInst& inst);
+
 private:
   ExecutionResult visitExternFunc(llvm::CallInst& inst);
 

--- a/include/caffeine/Interpreter/Interpreter.h
+++ b/include/caffeine/Interpreter/Interpreter.h
@@ -67,8 +67,8 @@ public:
   ExecutionResult visitSelectInst(llvm::SelectInst& inst);
 
   ExecutionResult visitInsertElementInst(llvm::InsertElementInst& inst);
-  // ExecutionResult visitExtractElementInst(llvm::ExtractElementInst& inst);
-  // ExecutionResult visitShuffleVectorInst(llvm::ShuffleVectorInst& inst);
+  ExecutionResult visitExtractElementInst(llvm::ExtractElementInst& inst);
+  ExecutionResult visitShuffleVectorInst(llvm::ShuffleVectorInst& inst);
 
 private:
   ExecutionResult visitExternFunc(llvm::CallInst& inst);

--- a/include/caffeine/Interpreter/Interpreter.h
+++ b/include/caffeine/Interpreter/Interpreter.h
@@ -66,7 +66,7 @@ public:
   ExecutionResult visitCallInst(llvm::CallInst& inst);
   ExecutionResult visitSelectInst(llvm::SelectInst& inst);
 
-  // ExecutionResult visitInsertElementInst(llvm::InsertElementInst& inst);
+  ExecutionResult visitInsertElementInst(llvm::InsertElementInst& inst);
   // ExecutionResult visitExtractElementInst(llvm::ExtractElementInst& inst);
   // ExecutionResult visitShuffleVectorInst(llvm::ShuffleVectorInst& inst);
 

--- a/include/caffeine/Interpreter/StackFrame.h
+++ b/include/caffeine/Interpreter/StackFrame.h
@@ -14,9 +14,6 @@ namespace caffeine {
 class Context;
 
 class StackFrame {
-public:
-  using VarType = ContextValue;
-
 private:
   llvm::Function* function;
   std::unordered_map<llvm::Value*, ContextValue> variables;
@@ -44,8 +41,7 @@ public:
    * is already in the current stack frame then it overwrites it.
    */
   void insert(llvm::Value* value, const ref<Operation>& expr);
-
-  void insert(llvm::Value* value, const VarType& exprs);
+  void insert(llvm::Value* value, const ContextValue& exprs);
 
   /**
    * Lookup a value within the current stack frame.
@@ -61,7 +57,7 @@ public:
    * This method should be preferred over directly interacting with
    * `variables` as it correctly handles constants.
    */
-  VarType lookup(llvm::Value* value) const;
+  ContextValue lookup(llvm::Value* value) const;
 };
 
 } // namespace caffeine

--- a/include/caffeine/Interpreter/StackFrame.h
+++ b/include/caffeine/Interpreter/StackFrame.h
@@ -1,6 +1,7 @@
 #ifndef CAFFEINE_INTERP_STACKFRAME_H
 #define CAFFEINE_INTERP_STACKFRAME_H
 
+#include <llvm/ADT/SmallVector.h>
 #include <llvm/IR/BasicBlock.h>
 
 #include <unordered_map>
@@ -12,9 +13,12 @@ namespace caffeine {
 class Context;
 
 class StackFrame {
+public:
+  using VarType = llvm::SmallVector<ref<Operation>, 1>;
+
 private:
   llvm::Function* function;
-  std::unordered_map<llvm::Value*, ref<Operation>> variables;
+  std::unordered_map<llvm::Value*, VarType> variables;
 
 public:
   /**
@@ -39,6 +43,9 @@ public:
    * is already in the current stack frame then it overwrites it.
    */
   void insert(llvm::Value* value, const ref<Operation>& expr);
+
+  void insert(llvm::Value* value, const VarType& exprs);
+
   /**
    * Lookup a value within the current stack frame.
    *
@@ -53,7 +60,7 @@ public:
    * This method should be preferred over directly interacting with
    * `variables` as it correctly handles constants.
    */
-  ref<Operation> lookup(llvm::Value* value) const;
+  VarType lookup(llvm::Value* value) const;
 };
 
 } // namespace caffeine

--- a/include/caffeine/Interpreter/StackFrame.h
+++ b/include/caffeine/Interpreter/StackFrame.h
@@ -7,6 +7,7 @@
 #include <unordered_map>
 
 #include "caffeine/IR/Operation.h"
+#include "caffeine/Interpreter/Value.h"
 
 namespace caffeine {
 
@@ -14,11 +15,11 @@ class Context;
 
 class StackFrame {
 public:
-  using VarType = llvm::SmallVector<ref<Operation>, 1>;
+  using VarType = ContextValue;
 
 private:
   llvm::Function* function;
-  std::unordered_map<llvm::Value*, VarType> variables;
+  std::unordered_map<llvm::Value*, ContextValue> variables;
 
 public:
   /**

--- a/src/Interpreter/Context.cpp
+++ b/src/Interpreter/Context.cpp
@@ -1,6 +1,7 @@
 #include "caffeine/Interpreter/Context.h"
 #include "caffeine/IR/Operation.h"
 #include "caffeine/IR/Type.h"
+#include "caffeine/Interpreter/StackFrame.h"
 
 #include <fmt/format.h>
 #include <llvm/Support/raw_ostream.h>

--- a/src/Interpreter/Executor.cpp
+++ b/src/Interpreter/Executor.cpp
@@ -3,7 +3,7 @@
 namespace caffeine {
 
 void Executor::add_context(Context&& ctx) {
-  contexts.push_back(ctx);
+  contexts.push_back(std::move(ctx));
 }
 
 Context Executor::next_context() {

--- a/src/Interpreter/Interpreter.cpp
+++ b/src/Interpreter/Interpreter.cpp
@@ -428,8 +428,8 @@ ExecutionResult Interpreter::visitPHINode(llvm::PHINode& node) {
   // PHI nodes in the entry block is invalid.
   CAFFEINE_ASSERT(frame.prev_block != nullptr);
 
-  frame.insert(&node,
-               frame.lookup(node.getIncomingValueForBlock(frame.prev_block)));
+  auto value = frame.lookup(node.getIncomingValueForBlock(frame.prev_block));
+  frame.insert(&node, value);
 
   return ExecutionResult::Continue;
 }

--- a/src/Interpreter/Interpreter.cpp
+++ b/src/Interpreter/Interpreter.cpp
@@ -14,19 +14,17 @@
 
 namespace caffeine {
 
-namespace detail {
-  template <typename T, typename U>
-  std::pair<T, U> tuple_to_pair(const boost::tuple<T, U>& tuple) {
-    return std::make_pair(tuple.template get<0>(), tuple.template get<1>());
-  }
-} // namespace detail
-
+/**
+ * Combine the two provided iterators into a single one which
+ * yields std::pair.
+ */
 template <typename R1, typename R2>
 auto zip(R1& range1, R2& range2) {
   return boost::combine(range1, range2) |
-         boost::adaptors::transformed(
-             detail::tuple_to_pair<std::decay_t<decltype(*range1.begin())>,
-                                   std::decay_t<decltype(*range2.begin())>>);
+         boost::adaptors::transformed([](const auto& tuple) {
+           return std::make_pair(tuple.template get<0>(),
+                                 tuple.template get<1>());
+         });
 }
 
 Interpreter::Interpreter(Executor* queue, Context* ctx, FailureLogger* logger)

--- a/src/Interpreter/Interpreter.cpp
+++ b/src/Interpreter/Interpreter.cpp
@@ -14,8 +14,6 @@
 
 namespace caffeine {
 
-using VarType = StackFrame::VarType;
-
 namespace detail {
   template <typename T, typename U>
   std::pair<T, U> tuple_to_pair(const boost::tuple<T, U>& tuple) {

--- a/src/Interpreter/StackFrame.cpp
+++ b/src/Interpreter/StackFrame.cpp
@@ -6,8 +6,6 @@
 #include <llvm/IR/Constants.h>
 #include <llvm/IR/Function.h>
 
-#include <iostream>
-
 namespace caffeine {
 
 StackFrame::StackFrame(llvm::Function* function)

--- a/src/Interpreter/StackFrame.cpp
+++ b/src/Interpreter/StackFrame.cpp
@@ -6,6 +6,8 @@
 #include <llvm/IR/Constants.h>
 #include <llvm/IR/Function.h>
 
+#include <iostream>
+
 namespace caffeine {
 
 StackFrame::StackFrame(llvm::Function* function)
@@ -19,7 +21,7 @@ void StackFrame::jump_to(llvm::BasicBlock* block) {
 }
 
 void StackFrame::insert(llvm::Value* value, const ref<Operation>& expr) {
-  variables.insert_or_assign(value, VarType{expr});
+  insert(value, VarType{expr});
 }
 void StackFrame::insert(llvm::Value* value, const VarType& exprs) {
   variables.insert_or_assign(value, exprs);

--- a/src/Interpreter/StackFrame.cpp
+++ b/src/Interpreter/StackFrame.cpp
@@ -1,29 +1,12 @@
 #include "caffeine/Interpreter/StackFrame.h"
 #include "caffeine/IR/Operation.h"
+#include "caffeine/Interpreter/Context.h"
 #include "caffeine/Support/Assert.h"
 
 #include <llvm/IR/Constants.h>
 #include <llvm/IR/Function.h>
 
 namespace caffeine {
-
-ref<Operation> evaluate_constant(const llvm::Constant* constant) {
-  CAFFEINE_ASSERT(!constant->getType()->isVectorTy());
-
-  if (auto* intconst = llvm::dyn_cast<llvm::ConstantInt>(constant)) {
-    const llvm::APInt& value = intconst->getValue();
-
-    return ConstantInt::Create(value);
-  }
-
-  if (auto* fpconst = llvm::dyn_cast<llvm::ConstantFP>(constant)) {
-    const llvm::APFloat& value = fpconst->getValueAPF();
-
-    return ConstantFloat::Create(value);
-  }
-
-  CAFFEINE_UNIMPLEMENTED();
-}
 
 StackFrame::StackFrame(llvm::Function* function)
     : function(function), current_block(&function->getEntryBlock()),
@@ -44,7 +27,7 @@ void StackFrame::insert(llvm::Value* value, const VarType& exprs) {
 
 StackFrame::VarType StackFrame::lookup(llvm::Value* value) const {
   if (auto* constant = llvm::dyn_cast_or_null<llvm::Constant>(value))
-    return VarType{evaluate_constant(constant)};
+    return ContextValue(constant);
 
   auto it = variables.find(value);
   CAFFEINE_ASSERT(it != variables.end(), "Tried to access unknown variable");

--- a/src/Interpreter/StackFrame.cpp
+++ b/src/Interpreter/StackFrame.cpp
@@ -21,13 +21,13 @@ void StackFrame::jump_to(llvm::BasicBlock* block) {
 }
 
 void StackFrame::insert(llvm::Value* value, const ref<Operation>& expr) {
-  insert(value, VarType{expr});
+  insert(value, ContextValue{expr});
 }
-void StackFrame::insert(llvm::Value* value, const VarType& exprs) {
+void StackFrame::insert(llvm::Value* value, const ContextValue& exprs) {
   variables.insert_or_assign(value, exprs);
 }
 
-StackFrame::VarType StackFrame::lookup(llvm::Value* value) const {
+ContextValue StackFrame::lookup(llvm::Value* value) const {
   if (auto* constant = llvm::dyn_cast_or_null<llvm::Constant>(value))
     return ContextValue(constant);
 

--- a/test/run-fail/interleave.c
+++ b/test/run-fail/interleave.c
@@ -1,0 +1,22 @@
+
+#include <stdint.h>
+#include <limits.h>
+
+#include "caffeine.h"
+
+uint32_t interleave(uint16_t x, uint16_t y) {
+  uint32_t z = 0;
+
+  for (unsigned i = 0; i < CHAR_BIT * sizeof(x); ++i) {
+    uint32_t xb = (x >> i) & 1;
+    uint32_t yb = (y >> i) & 1;
+
+    z |= xb << (2 * i) | yb << (2 * i + 1);
+  }
+
+  return z;
+}
+
+void test(uint16_t x) {
+  caffeine_assert(interleave(x, x) != 0xFFFFFFFF);
+}

--- a/test/run-fail/interleave.c
+++ b/test/run-fail/interleave.c
@@ -1,6 +1,6 @@
 
-#include <stdint.h>
 #include <limits.h>
+#include <stdint.h>
 
 #include "caffeine.h"
 

--- a/test/run-fail/vector/extractelement1.ll
+++ b/test/run-fail/vector/extractelement1.ll
@@ -1,0 +1,30 @@
+; ModuleID = '/mnt/d/Projects/Projects/UWaterloo/caffeine/test/run-fail/interleave.c'
+source_filename = "/mnt/d/Projects/Projects/UWaterloo/caffeine/test/run-fail/interleave.c"
+target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128"
+target triple = "x86_64-pc-linux-gnu"
+
+; Function Attrs: nounwind uwtable
+define dso_local void @test(i32 zeroext %0) local_unnamed_addr #1 {
+  %2 = add <8 x i32> zeroinitializer, <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7>
+  %3 = insertelement <8 x i32> %2, i32 8, i32 0
+  %4 = icmp ult i32 %0, 8
+  tail call void @caffeine_assume(i1 zeroext %4)
+  %5 = extractelement <8 x i32> %3, i32 %0
+  %6 = icmp ne i32 %5, 8
+  tail call void @caffeine_assert(i1 zeroext %6)
+  ret void
+}
+
+declare dso_local void @caffeine_assert(i1 zeroext) local_unnamed_addr #2
+declare dso_local void @caffeine_assume(i1 zeroext) local_unnamed_addr #2
+
+attributes #0 = { norecurse nounwind readnone uwtable "correctly-rounded-divide-sqrt-fp-math"="false" "disable-tail-calls"="false" "frame-pointer"="none" "less-precise-fpmad"="false" "min-legal-vector-width"="0" "no-infs-fp-math"="false" "no-jump-tables"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="false" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
+attributes #1 = { nounwind uwtable "correctly-rounded-divide-sqrt-fp-math"="false" "disable-tail-calls"="false" "frame-pointer"="none" "less-precise-fpmad"="false" "min-legal-vector-width"="0" "no-infs-fp-math"="false" "no-jump-tables"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="false" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
+attributes #2 = { "correctly-rounded-divide-sqrt-fp-math"="false" "disable-tail-calls"="false" "frame-pointer"="none" "less-precise-fpmad"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="false" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
+attributes #3 = { nounwind }
+
+!llvm.module.flags = !{!0}
+!llvm.ident = !{!1}
+
+!0 = !{i32 1, !"wchar_size", i32 4}
+!1 = !{!"clang version 10.0.0-4ubuntu1 "}

--- a/test/run-fail/vector/shufflevector1.ll
+++ b/test/run-fail/vector/shufflevector1.ll
@@ -1,0 +1,39 @@
+; ModuleID = '/mnt/d/Projects/Projects/UWaterloo/caffeine/test/run-fail/interleave.c'
+source_filename = "/mnt/d/Projects/Projects/UWaterloo/caffeine/test/run-fail/interleave.c"
+target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128"
+target triple = "x86_64-pc-linux-gnu"
+
+; Function Attrs: nounwind uwtable
+define dso_local void @test(i32 zeroext %0, i32 zeroext %1, i32 zeroext %x) local_unnamed_addr #1 {
+  ; Create vector with alternating %0 and %1 elements
+  %v1 = insertelement <4 x i32> undef, i32 %0, i32 0
+  %v2 = insertelement <4 x i32> undef, i32 %1, i32 1
+  %v = shufflevector <4 x i32> %v1, <4 x i32> %v2, <4 x i32> <i32 0, i32 5, i32 0, i32 5>
+  
+  ; Cases where %0 == %1 aren't interesting
+  %cmp1 = icmp ne i32 %0, %1
+  call void @caffeine_assume(i1 zeroext %cmp1)  
+
+  ; Need the select index to be within the vector
+  %cmp2 = icmp ult i32 %x, 4
+  call void @caffeine_assume(i1 zeroext %cmp2)
+
+  %3 = extractelement <4 x i32> %v, i32 %x
+  %4 = icmp ne i32 %3, %1
+  call void @caffeine_assert(i1 zeroext %4)
+  ret void
+}
+
+declare dso_local void @caffeine_assert(i1 zeroext) local_unnamed_addr #2
+declare dso_local void @caffeine_assume(i1 zeroext) local_unnamed_addr #2
+
+attributes #0 = { norecurse nounwind readnone uwtable "correctly-rounded-divide-sqrt-fp-math"="false" "disable-tail-calls"="false" "frame-pointer"="none" "less-precise-fpmad"="false" "min-legal-vector-width"="0" "no-infs-fp-math"="false" "no-jump-tables"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="false" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
+attributes #1 = { nounwind uwtable "correctly-rounded-divide-sqrt-fp-math"="false" "disable-tail-calls"="false" "frame-pointer"="none" "less-precise-fpmad"="false" "min-legal-vector-width"="0" "no-infs-fp-math"="false" "no-jump-tables"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="false" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
+attributes #2 = { "correctly-rounded-divide-sqrt-fp-math"="false" "disable-tail-calls"="false" "frame-pointer"="none" "less-precise-fpmad"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="false" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
+attributes #3 = { nounwind }
+
+!llvm.module.flags = !{!0}
+!llvm.ident = !{!1}
+
+!0 = !{i32 1, !"wchar_size", i32 4}
+!1 = !{!"clang version 10.0.0-4ubuntu1 "}

--- a/test/run-pass/vector/shufflevector2.ll
+++ b/test/run-pass/vector/shufflevector2.ll
@@ -1,0 +1,35 @@
+; ModuleID = '/mnt/d/Projects/Projects/UWaterloo/caffeine/test/run-fail/interleave.c'
+source_filename = "/mnt/d/Projects/Projects/UWaterloo/caffeine/test/run-fail/interleave.c"
+target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128"
+target triple = "x86_64-pc-linux-gnu"
+
+; Note: This test is designed to check that the shufflevector implementation
+;       grabs the right elements from the source vectors.
+
+; Function Attrs: nounwind uwtable
+define dso_local void @test(i32 zeroext %x) local_unnamed_addr #1 {
+  %v = shufflevector <4 x i32> <i32 0, i32 1, i32 2, i32 3>, <4 x i32> <i32 4, i32 5, i32 6, i32 7>, <4 x i32> zeroinitializer
+
+  ; Need the select index to be within the vector
+  %cmp1 = icmp ult i32 %x, 4
+  call void @caffeine_assume(i1 zeroext %cmp1)
+
+  %elem = extractelement <4 x i32> %v, i32 %x
+  %cmp2 = icmp eq i32 %elem, 0
+  call void @caffeine_assert(i1 zeroext %cmp2)
+  ret void
+}
+
+declare dso_local void @caffeine_assert(i1 zeroext) local_unnamed_addr #2
+declare dso_local void @caffeine_assume(i1 zeroext) local_unnamed_addr #2
+
+attributes #0 = { norecurse nounwind readnone uwtable "correctly-rounded-divide-sqrt-fp-math"="false" "disable-tail-calls"="false" "frame-pointer"="none" "less-precise-fpmad"="false" "min-legal-vector-width"="0" "no-infs-fp-math"="false" "no-jump-tables"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="false" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
+attributes #1 = { nounwind uwtable "correctly-rounded-divide-sqrt-fp-math"="false" "disable-tail-calls"="false" "frame-pointer"="none" "less-precise-fpmad"="false" "min-legal-vector-width"="0" "no-infs-fp-math"="false" "no-jump-tables"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="false" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
+attributes #2 = { "correctly-rounded-divide-sqrt-fp-math"="false" "disable-tail-calls"="false" "frame-pointer"="none" "less-precise-fpmad"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="false" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
+attributes #3 = { nounwind }
+
+!llvm.module.flags = !{!0}
+!llvm.ident = !{!1}
+
+!0 = !{i32 1, !"wchar_size", i32 4}
+!1 = !{!"clang version 10.0.0-4ubuntu1 "}


### PR DESCRIPTION
Does a few things:
- Change the representation of values within `Context` to support having vectors
- Change all existing LLVM opcode implementations to work with this
- Implement the new vector opcodes required to run the added test cases (`insertelement`, `extractelement`, and `shufflevector`)