### PR TITLE
Move caffeine-bin to root directory

### DIFF
--- a/src/bin/CMakeLists.txt
+++ b/src/bin/CMakeLists.txt
@@ -3,3 +3,9 @@ add_executable(caffeine-bin caffeine.cpp)
 
 target_link_libraries(caffeine-bin PRIVATE caffeine)
 target_link_libraries(caffeine-bin PRIVATE LLVMIRReader)
+
+set_target_properties(caffeine-bin
+  PROPERTIES
+  OUTPUT_NAME caffeine
+  RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}"
+)


### PR DESCRIPTION
This makes it easier to run it from the command line when needed.