### PR TITLE
Add ContextValue

### DIFF
--- a/include/caffeine/Interpreter/Value.h
+++ b/include/caffeine/Interpreter/Value.h
@@ -1,0 +1,60 @@
+#ifndef CAFFEINE_INTERP_VALUE_H
+#define CAFFEINE_INTERP_VALUE_H
+
+#include "caffeine/IR/Operation.h"
+
+#include <llvm/ADT/ArrayRef.h>
+#include <llvm/IR/Constant.h>
+
+#include <variant>
+#include <vector>
+
+namespace caffeine {
+
+/**
+ * An LLVM value as represented within a stack frame.
+ */
+class ContextValue {
+private:
+  struct slice {
+    const ContextValue* data;
+    size_t size;
+
+    constexpr slice() : data(nullptr), size(0) {}
+    constexpr slice(const ContextValue* data, size_t size)
+        : data(data), size(size) {}
+  };
+
+  std::variant<ref<Operation>, std::vector<ContextValue>, slice> inner_;
+
+public:
+  explicit ContextValue(llvm::Constant* constant);
+  explicit ContextValue(const ref<Operation>& op);
+  explicit ContextValue(const std::vector<ContextValue>& data);
+  explicit ContextValue(std::vector<ContextValue>&& data);
+  ContextValue(const ContextValue* data, size_t size);
+
+  ContextValue(const ContextValue&) = default;
+  ContextValue(ContextValue&&) = default;
+
+  ContextValue& operator=(const ContextValue&) = default;
+  ContextValue& operator=(ContextValue&&) = default;
+
+  ContextValue to_ref() const;
+  ContextValue into_owned() &&;
+
+  bool is_vector() const;
+  bool is_scalar() const;
+
+  const ref<Operation>& scalar() const;
+  llvm::ArrayRef<ContextValue> vector() const;
+};
+
+template<typename F, typename... Vs>
+inline ContextValue transform(F&& func, const Vs&... values);
+
+} // namespace caffeine
+
+#include "caffeine/Interpreter/Value.inl"
+
+#endif

--- a/include/caffeine/Interpreter/Value.h
+++ b/include/caffeine/Interpreter/Value.h
@@ -6,9 +6,9 @@
 #include <llvm/ADT/ArrayRef.h>
 #include <llvm/IR/Constant.h>
 
+#include <iosfwd>
 #include <variant>
 #include <vector>
-#include <iosfwd>
 
 namespace caffeine {
 
@@ -75,7 +75,6 @@ template <typename F, typename... Vs>
 ContextValue transform(F&& func, const Vs&... values);
 
 std::ostream& operator<<(std::ostream& os, const ContextValue& value);
-
 
 } // namespace caffeine
 

--- a/include/caffeine/Interpreter/Value.inl
+++ b/include/caffeine/Interpreter/Value.inl
@@ -1,0 +1,106 @@
+#ifndef CAFFEINE_INTERP_VALUE_INL
+#define CAFFEINE_INTERP_VALUE_INL
+
+#include "caffeine/Interpreter/Value.h"
+
+#include <tuple>
+
+namespace caffeine {
+
+inline bool ContextValue::is_vector() const {
+  switch (inner_.index()) {
+  case 0:
+    return false;
+  case 1:
+  case 2:
+    return true;
+  default:
+    CAFFEINE_UNREACHABLE();
+  }
+}
+inline bool ContextValue::is_scalar() const {
+  return !is_vector();
+}
+
+namespace detail {
+  template <typename F, typename... Ts, size_t... Idxs>
+  auto tuple_foreach_(F&& func, std::tuple<Ts...>& tuple,
+                      std::index_sequence<Idxs...>) {
+    static_assert(sizeof...(Idxs) == sizeof...(Ts));
+
+    return std::make_tuple(func(std::get<Idxs>(tuple))...);
+  }
+
+  template <typename F, typename... Ts>
+  auto tuple_foreach(F&& func, std::tuple<Ts...>& tuple) {
+    return tuple_foreach_(func, tuple, std::index_sequence_for<Ts...>());
+  }
+
+  template <typename F, typename... T1s, typename... T2s, size_t... Idxs>
+  auto tuple_combine_(F&& func, std::tuple<T1s...>& t1, std::tuple<T2s...>& t2,
+                      std::index_sequence<Idxs...>) {
+    static_assert(sizeof...(T1s) == sizeof...(Idxs));
+    static_assert(sizeof...(T2s) == sizeof...(Idxs));
+
+    return std::make_tuple(func(std::get<Idxs>(t1), std::get<Idxs>(t2))...);
+  }
+
+  template <typename F, typename... T1s, typename... T2s>
+  auto tuple_combine(F&& func, std::tuple<T1s...>& t1, std::tuple<T2s...>& t2) {
+    return tuple_combine_(func, t1, t2, std::index_sequence_for<T1s...>());
+  }
+
+  template <typename... Ts>
+  bool all(Ts... values) {
+    return (... && values);
+  }
+
+  template <typename T, typename... Ts>
+  const T& first(const T& first, const Ts&...) {
+    return first;
+  }
+} // namespace detail
+
+template <typename F, typename... Vs>
+inline ContextValue transform(F&& func, const Vs&... values) {
+  static_assert((... && std::is_same_v<Vs, ContextValue>),
+                "Transform may only be called with ContextValues");
+
+  const ContextValue& v1 = detail::first(values...);
+
+  CAFFEINE_ASSERT((... && (v1.is_scalar() == values.is_scalar())));
+
+  if (v1.is_scalar())
+    return ContextValue(func(values.scalar()...));
+
+  auto vecs = std::make_tuple(values.vector()...);
+  auto its =
+      detail::tuple_foreach([](const auto& v) { return std::begin(v); }, vecs);
+  auto ends =
+      detail::tuple_foreach([](const auto& v) { return std::end(v); }, vecs);
+
+  std::vector<ContextValue> result;
+  result.reserve(std::get<0>(vecs).size());
+
+  while (!std::apply(
+      [](auto... v) { return (... && v); },
+      detail::tuple_combine([](const auto& a, const auto& b) { return a != b; },
+                            its, ends))) {
+    result.push_back(std::apply(
+        [&](const auto&... values) { return transform(func, values...); },
+        detail::tuple_foreach([](const auto& it) { return *it; }, its)));
+
+    detail::tuple_foreach(
+        [](auto& it) {
+          ++it;
+          return 0;
+        },
+        its);
+  }
+
+  return ContextValue(std::move(result));
+}
+
+} // namespace caffeine
+
+#endif

--- a/src/Interpreter/Value.cpp
+++ b/src/Interpreter/Value.cpp
@@ -1,0 +1,109 @@
+#include "caffeine/Interpreter/Value.h"
+
+#include <llvm/IR/Constants.h>
+
+#include <type_traits>
+
+namespace caffeine {
+
+static ContextValue evaluate_constant(llvm::Constant* constant) {
+  if (auto* cnst = llvm::dyn_cast<llvm::ConstantInt>(constant))
+    return ContextValue(ConstantInt::Create(cnst->getValue()));
+
+  if (auto* cnst = llvm::dyn_cast<llvm::ConstantFP>(constant))
+    return ContextValue(ConstantFloat::Create(cnst->getValueAPF()));
+
+  if (auto* undef = llvm::dyn_cast<llvm::UndefValue>(constant)) {
+    auto type = undef->getType();
+
+    if (type->isVectorTy()) {
+      CAFFEINE_ASSERT(!type->getVectorIsScalable(),
+                      "scalable vectors are not supported");
+      size_t count = type->getVectorNumElements();
+
+      std::vector<ContextValue> result;
+      result.reserve(count);
+
+      auto inner = llvm::UndefValue::get(type->getVectorElementType());
+
+      for (size_t i = 0; i < count; ++i)
+        result.push_back(evaluate_constant(inner));
+
+      return ContextValue(std::move(result));
+    } else {
+      return ContextValue(Undef::Create(Type::from_llvm(type)));
+    }
+  }
+
+  if (auto* vec = llvm::dyn_cast<llvm::ConstantDataVector>(constant)) {
+    CAFFEINE_ASSERT(!vec->getType()->getVectorIsScalable(),
+                    "scalable vectors are not supported");
+
+    auto type = vec->getType();
+    auto count = type->getVectorNumElements();
+
+    std::vector<ContextValue> result;
+    result.reserve(count);
+
+    // TODO: This is inefficient, should be directly converting for known
+    //       element types.
+    for (size_t i = 0; i < count; ++i)
+      result.push_back(evaluate_constant(vec->getElementAsConstant(i)));
+
+    return ContextValue(std::move(result));
+  }
+
+  CAFFEINE_UNIMPLEMENTED();
+}
+
+ContextValue::ContextValue(llvm::Constant* constant)
+    : ContextValue(evaluate_constant(constant)) {}
+
+ContextValue::ContextValue(const ref<Operation>& op) : inner_(op) {}
+
+ContextValue::ContextValue(const std::vector<ContextValue>& data)
+    : inner_(data) {}
+ContextValue::ContextValue(std::vector<ContextValue>&& data)
+    : inner_(std::move(data)) {}
+
+ContextValue::ContextValue(const ContextValue* data, size_t size)
+    : inner_(slice(data, size)) {}
+
+ContextValue ContextValue::to_ref() const {
+  if (const auto* vec = std::get_if<std::vector<ContextValue>>(&inner_))
+    return ContextValue(vec->data(), vec->size());
+
+  return *this;
+}
+ContextValue ContextValue::into_owned() && {
+  if (const auto* val = std::get_if<slice>(&inner_))
+    return ContextValue(
+        std::vector<ContextValue>(val->data, val->data + val->size));
+  return *this;
+}
+
+const ref<Operation>& ContextValue::scalar() const {
+  const auto* val = std::get_if<ref<Operation>>(&inner_);
+  CAFFEINE_ASSERT(val, "ContextValue was not a scalar");
+  return *val;
+}
+llvm::ArrayRef<ContextValue> ContextValue::vector() const {
+  auto [data, size] = std::visit(
+      [&](const auto& val) {
+        using type =
+            std::remove_reference_t<std::remove_const_t<decltype(val)>>;
+
+        if constexpr (std::is_same_v<type, slice>) {
+          return std::make_pair(val.data, val.size);
+        } else if constexpr (std::is_same_v<type, std::vector<ContextValue>>) {
+          return std::make_pair(val.data(), val.size());
+        } else {
+          return std::make_pair<const ContextValue*, size_t>(this, 1);
+        }
+      },
+      inner_);
+
+  return llvm::ArrayRef<ContextValue>(data, size);
+}
+
+} // namespace caffeine

--- a/src/Interpreter/Value.cpp
+++ b/src/Interpreter/Value.cpp
@@ -4,8 +4,8 @@
 #include <llvm/IR/Constants.h>
 #include <llvm/Support/raw_ostream.h>
 
-#include <type_traits>
 #include <iostream>
+#include <type_traits>
 
 namespace caffeine {
 


### PR DESCRIPTION
This is an attempt to break apart bits of #76 into more reviewable chunks.

This part adds a new value representation for program values (which can be vectors or scalars at the moment). It isn't currently used anywhere within the program but will get used in the next PR. It also adds a method to map over these new values which is meant to make it easier to implement the visitor method. For examples of how it's used see the other PR.