### PR TITLE
Add ConstantArray operation

### DIFF
--- a/include/caffeine/IR/Operation.h
+++ b/include/caffeine/IR/Operation.h
@@ -229,7 +229,9 @@ public:
   };
 
 protected:
-  using opvec = boost::container::static_vector<ref<Operation>, 3>;
+  using OpVec = boost::container::static_vector<ref<Operation>, 3>;
+  using Inner = std::variant<std::monostate, OpVec, llvm::APInt, llvm::APFloat,
+                             uint64_t, std::string>;
 
   uint16_t opcode_;
   uint16_t dummy_ = 0; // Unused, used for padding
@@ -238,10 +240,7 @@ protected:
   // Needs to be mutable so that const refs (ref<const Operation>) work.
   mutable uint32_t refcount = 0;
   Type type_;
-
-  std::variant<std::monostate, opvec, llvm::APInt, llvm::APFloat, uint64_t,
-               std::string>
-      inner_;
+  Inner inner_;
 
   // So ref can get at the refcount field.
   //
@@ -255,6 +254,9 @@ protected:
   friend llvm::hash_code hash_value(const Operation& op);
 
 protected:
+  Operation(Opcode op, Type t, const Inner& inner);
+  Operation(Opcode op, Type t, Inner&& inner);
+
   // Specialization that provides some sanity checking when
   // the caller is using a fixed-size array.
   template <size_t N>
@@ -414,20 +416,6 @@ public:
 };
 
 /**
- *
- */
-class ConstantArray : public Operation {
-private:
-
-public:
-  llvm::ArrayRef<char> data() const;
-
-  static ref<Operation> Create(const char* data, size_t size);
-
-  static bool classof(const Operation* op);
-};
-
-/**
  * Floating point constant.
  *
  * This represents a constant floating point value in an expression.
@@ -444,6 +432,21 @@ public:
 
   static ref<Operation> Create(const llvm::APFloat& fconst);
   static ref<Operation> Create(llvm::APFloat&& fconst);
+
+  static bool classof(const Operation* op);
+};
+
+/**
+ * Constant byte array.
+ */
+class ConstantArray : public Operation {
+private:
+  ConstantArray(Type t, const char* data, size_t size);
+
+public:
+  llvm::ArrayRef<char> data() const;
+
+  static ref<Operation> Create(Type index_ty, const char* data, size_t size);
 
   static bool classof(const Operation* op);
 };

--- a/include/caffeine/IR/Operation.h
+++ b/include/caffeine/IR/Operation.h
@@ -414,6 +414,20 @@ public:
 };
 
 /**
+ *
+ */
+class ConstantArray : public Operation {
+private:
+
+public:
+  llvm::ArrayRef<char> data() const;
+
+  static ref<Operation> Create(const char* data, size_t size);
+
+  static bool classof(const Operation* op);
+};
+
+/**
  * Floating point constant.
  *
  * This represents a constant floating point value in an expression.

--- a/include/caffeine/IR/Type.h
+++ b/include/caffeine/IR/Type.h
@@ -34,7 +34,8 @@ namespace caffeine {
  * - Pointer: An untyped pointer. This is effectively an integer with a
  *   target-defined width.
  * - Function Pointer.
- * - Byte array. This is the raw type of a memory allocation.
+ * - Byte array. This is the raw type of a memory allocation. It has a bitwidth
+ *   which is the width of the integer used to index into the array.
  */
 class Type {
 public:
@@ -88,7 +89,9 @@ public:
   static Type bool_ty();
   // TODO: Address spaces? Not sure if we want to model them
   static Type pointer_ty();
-  static Type array_ty();
+  // Note: Bitwidth is the bitwidth of the integer used to
+  //       index into the byte array.
+  static Type array_ty(uint32_t bitwidth);
 
   static Type from_llvm(llvm::Type* type);
 

--- a/include/caffeine/IR/Visitor.h
+++ b/include/caffeine/IR/Visitor.h
@@ -91,6 +91,7 @@ public:
   RetTy visitConstant     (transform_t<Constant>     & O) { return CAFFEINE_OP_DELEGATE(Operation); }
   RetTy visitConstantInt  (transform_t<ConstantInt>  & O) { return CAFFEINE_OP_DELEGATE(Operation); }
   RetTy visitConstantFloat(transform_t<ConstantFloat>& O) { return CAFFEINE_OP_DELEGATE(Operation); }
+  RetTy visitConstantArray(transform_t<ConstantArray>& O) { return CAFFEINE_OP_DELEGATE(Operation); }
   RetTy visitUndef        (transform_t<Undef>        & O) { return CAFFEINE_OP_DELEGATE(Operation); }
 
   RetTy visitBinaryOp(transform_t<BinaryOp>& O) { return CAFFEINE_OP_DELEGATE(Operation); }

--- a/include/caffeine/IR/Visitor.inl
+++ b/include/caffeine/IR/Visitor.inl
@@ -67,6 +67,7 @@ RetTy OpVisitorBase<Transform, SubClass, RetTy>::visit(
     DELEGATE(Select, SelectOp, SelectOp);
     DELEGATE(ConstantInt, ConstantInt);
     DELEGATE(ConstantFloat, ConstantFloat);
+    DELEGATE(ConstantArray, ConstantArray);
     DELEGATE(Undef, Undef);
 
     DELEGATE(Trunc, UnaryOp);

--- a/src/IR/Operation.cpp
+++ b/src/IR/Operation.cpp
@@ -2,10 +2,10 @@
 #include "Operation.h"
 
 #include <boost/container_hash/hash.hpp>
+#include <fmt/format.h>
+#include <fmt/ostream.h>
 #include <llvm/ADT/Hashing.h>
 #include <llvm/Support/raw_ostream.h>
-
-#include <iostream>
 
 namespace caffeine {
 
@@ -360,8 +360,12 @@ ref<Operation> BinaryOp::Create(Opcode op, const ref<Operation>& lhs,
   CAFFEINE_ASSERT((op & 0x3) == 2, "Opcode doesn't have 2 operands");
   CAFFEINE_ASSERT(lhs, "lhs was null");
   CAFFEINE_ASSERT(rhs, "rhs was null");
-  CAFFEINE_ASSERT(lhs->type() == rhs->type(),
-                  "BinaryOp created from operands with different types");
+  CAFFEINE_ASSERT(
+      lhs->type() == rhs->type(),
+      fmt::format(
+          FMT_STRING(
+              "BinaryOp created from operands with different types: {} != {}"),
+          lhs->type(), rhs->type()));
 
   return ref<Operation>(new BinaryOp(op, lhs->type(), lhs, rhs));
 }

--- a/src/IR/Operation.h
+++ b/src/IR/Operation.h
@@ -2,6 +2,8 @@
 
 #include "caffeine/IR/Operation.h"
 
+#include <llvm/Support/MathExtras.h>
+
 /**
  * This header has a bunch of utility methods for constant folding.
  */
@@ -39,6 +41,11 @@ inline bool constant_int_compare(ICmpOpcode cmp, const llvm::APInt& lhs,
     return lhs.ult(rhs);
   }
   CAFFEINE_UNREACHABLE("unknown ICmpOpcode");
+}
+
+inline uint64_t ilog2(uint64_t x) {
+  bool ispow2 = (x & (x - 1)) == 0;
+  return sizeof(x) * CHAR_BIT - llvm::countLeadingZeros(x) - (ispow2 ? 1 : 0);
 }
 
 } // namespace caffeine

--- a/src/IR/Type.cpp
+++ b/src/IR/Type.cpp
@@ -49,8 +49,8 @@ Type Type::pointer_ty() {
   return Type(Pointer, 0);
 }
 
-Type Type::array_ty() {
-  return Type(Array, 0);
+Type Type::array_ty(uint32_t bitwidth) {
+  return Type(Array, bitwidth);
 }
 
 llvm::FunctionType* Type::signature() const {


### PR DESCRIPTION
This is a prerequisite for supporting just about any other memory operations. I've also modified the array type so that it stores the bitwidth of the integer type used to index into the array.

This is a first step towards closing #82.