### PR TITLE
Cleanup Operation constructors

### DIFF
--- a/include/caffeine/IR/Operation.h
+++ b/include/caffeine/IR/Operation.h
@@ -416,6 +416,20 @@ public:
 };
 
 /**
+ *
+ */
+class ConstantArray : public Operation {
+private:
+
+public:
+  llvm::ArrayRef<char> data() const;
+
+  static ref<Operation> Create(const char* data, size_t size);
+
+  static bool classof(const Operation* op);
+};
+
+/**
  * Floating point constant.
  *
  * This represents a constant floating point value in an expression.

--- a/include/caffeine/IR/Operation.h
+++ b/include/caffeine/IR/Operation.h
@@ -416,20 +416,6 @@ public:
 };
 
 /**
- *
- */
-class ConstantArray : public Operation {
-private:
-
-public:
-  llvm::ArrayRef<char> data() const;
-
-  static ref<Operation> Create(const char* data, size_t size);
-
-  static bool classof(const Operation* op);
-};
-
-/**
  * Floating point constant.
  *
  * This represents a constant floating point value in an expression.

--- a/include/caffeine/IR/Operation.h
+++ b/include/caffeine/IR/Operation.h
@@ -257,20 +257,7 @@ protected:
   Operation(Opcode op, Type t, const Inner& inner);
   Operation(Opcode op, Type t, Inner&& inner);
 
-  // Specialization that provides some sanity checking when
-  // the caller is using a fixed-size array.
-  template <size_t N>
-  Operation(Opcode op, Type t, ref<Operation> (&operands)[N]);
   Operation(Opcode op, Type t, ref<Operation>* operands);
-
-  Operation(Opcode op, const llvm::APInt& iconst);
-  Operation(Opcode op, llvm::APInt&& iconst);
-
-  Operation(Opcode op, const llvm::APFloat& fconst);
-  Operation(Opcode op, llvm::APFloat&& fconst);
-
-  Operation(Opcode op, Type t, const std::string& name);
-  Operation(Opcode op, Type t, uint64_t number);
 
   Operation(Opcode op, Type t, const ref<Operation>& op0);
   Operation(Opcode op, Type t, const ref<Operation>& op0,
@@ -336,12 +323,12 @@ public:
     return llvm::isa<T>(*this);
   }
 
-  // Need to manually define these since we have an internal union.
-  Operation(const Operation& op) = default;
-  Operation(Operation&& op) noexcept = default;
+  // Need to define this since refcount shouldn't be copied/moved.
+  Operation(const Operation& op);
+  Operation(Operation&& op) noexcept;
 
-  Operation& operator=(const Operation& op) = default;
-  Operation& operator=(Operation&& op) noexcept = default;
+  Operation& operator=(const Operation& op);
+  Operation& operator=(Operation&& op) noexcept;
 
   ~Operation() = default;
 

--- a/include/caffeine/IR/Operation.inl
+++ b/include/caffeine/IR/Operation.inl
@@ -132,16 +132,6 @@ namespace detail {
   }
 } // namespace detail
 
-template <size_t N>
-Operation::Operation(Opcode op, Type t, ref<Operation> (&operands)[N])
-    : Operation(([&] {
-                  // Need the lambda so that this is evaluated before the
-                  // delegated constructor runs.
-                  CAFFEINE_ASSERT(((uint16_t)op & 0x3) <= N);
-                  return op;
-                })(),
-                t, (ref<Opcode>*)operands) {}
-
 inline bool Operation::valid() const {
   return opcode_ != 0;
 }


### PR DESCRIPTION
Some of the changes made in #84 mean that we can actually delete a bunch of `Operation` constructors without modifying the dependent code. This PR does that.

Currently depends on #84 and so includes it's code. I'll rebase to remove that once #84 merges.