### PR TITLE
Create shared byte array data structure

### DIFF
--- a/include/caffeine/ADT/SharedArray.h
+++ b/include/caffeine/ADT/SharedArray.h
@@ -159,6 +159,9 @@ public:
   char* data();
 };
 
+bool operator==(const SharedArray& lhs, const SharedArray& rhs);
+bool operator!=(const SharedArray& lhs, const SharedArray& rhs);
+
 } // namespace caffeine
 
 #endif

--- a/include/caffeine/ADT/SharedArray.h
+++ b/include/caffeine/ADT/SharedArray.h
@@ -1,0 +1,164 @@
+#ifndef CAFFEINE_ADT_SHAREDARRAY_H
+#define CAFFEINE_ADT_SHAREDARRAY_H
+
+#include <memory>
+#include <unordered_map>
+#include <variant>
+#include <vector>
+
+namespace caffeine {
+
+/**
+ * Efficiently copiable array.
+ *
+ * This class will automatically track modifications to a base array. This is
+ * meant to allow efficient cloning of the array while still allowing for
+ * modifications to be made. Note that this will get more inefficient as more
+ * levels are added to the modification chain.
+ *
+ * To avoid degenerate cases SharedArray will copy the backing data when the
+ * number of elements/modifications is low.
+ *
+ * Safety
+ * ======
+ * Due to internal implementation details it is UB to copy from a flat
+ * SharedArray concurrently from multiple threads (as it needs to convert the
+ * copied-from instance to a shared instance).
+ *
+ * TODOs
+ * =====
+ * If you happen to need these then go ahead and implement them :)
+ * - Iterators (both const and non-const). These should use load and store and
+ *   may find it easiest to take advantage of IndexAccessor.
+ */
+class SharedArray {
+  // Needed so that tests can use the internal thresholds instead of hardcoding
+  // them. Shouldn't normally be set.
+#ifdef CAFFEINE_SHAREDARRAY_TEST_EXPOSE_INTERNALS
+public:
+#else
+private:
+#endif
+  /**
+   * For sizes <= to this one we'll just copy the inner data instead of turning
+   * it into a shared reference.
+   *
+   * TODO: Tune this to see what works best at runtime.
+   */
+  static constexpr size_t min_copy_size = 64;
+  /**
+   * If the fraction of modified items is greater than this then we'll flatten
+   * the SharedArray into a single vector.
+   *
+   * TODO: Tune this to balance memory usage with performance.
+   */
+  static constexpr double flatten_threshold = 0.8;
+
+private:
+  struct Modified;
+
+  using Variant = std::variant<std::vector<char>, Modified>;
+
+  struct Modified {
+    std::shared_ptr<Variant> variant;
+    std::unordered_map<size_t, char> changes;
+
+    Modified(const std::shared_ptr<Variant>& var) : variant(var) {}
+
+    const char& operator[](size_t idx) const {
+      const Modified* current = this;
+
+      while (true) {
+        auto it = current->changes.find(idx);
+        if (it != current->changes.end())
+          return it->second;
+
+        if (const auto* data =
+                std::get_if<std::vector<char>>(current->variant.get()))
+          return data->at(idx);
+
+        current = &std::get<Modified>(*current->variant);
+      }
+    }
+  };
+
+  mutable Variant data_;
+  size_t modcnt_ = 0;
+  size_t size_ = 0;
+
+public:
+  // Proxy class for non-const element access
+  class IndexAccessor {
+  private:
+    SharedArray* array;
+    size_t idx;
+
+    IndexAccessor(SharedArray* array, size_t idx) : array(array), idx(idx) {}
+
+    friend class SharedArray;
+
+    IndexAccessor() = delete;
+    IndexAccessor(const IndexAccessor&) = delete;
+    IndexAccessor(IndexAccessor&&) = delete;
+    IndexAccessor& operator=(const IndexAccessor&) = delete;
+    IndexAccessor& operator=(IndexAccessor&&) = delete;
+
+  public:
+    operator char() const {
+      return array->load(idx);
+    }
+
+    IndexAccessor& operator=(char value) {
+      array->store(idx, value);
+      return *this;
+    }
+  };
+
+public:
+  SharedArray() = default;
+  ~SharedArray() = default;
+
+  SharedArray(const std::vector<char>& data);
+  SharedArray(std::vector<char>&& data);
+  SharedArray(const char* data, size_t size);
+
+  template <typename It>
+  SharedArray(It begin, It end) : data_(std::vector<char>(begin, end)) {}
+
+  SharedArray(const SharedArray& array);
+  SharedArray(SharedArray&& array);
+
+  SharedArray& operator=(const SharedArray& array);
+  SharedArray& operator=(SharedArray&& array);
+
+  size_t size() const {
+    return size_;
+  }
+
+  bool is_shared() const {
+    return data_.index() == 1;
+  }
+  bool is_flat() const {
+    return data_.index() == 0;
+  }
+
+  void store(size_t idx, char value);
+  char load(size_t idx) const;
+
+  char operator[](size_t idx) const;
+  IndexAccessor operator[](size_t idx);
+
+  void flatten();
+
+  /**
+   * Access the internal data as an array.
+   *
+   * Note that this will flatten the shared array. Unless you need the data as
+   * an array it is preferable to use the indexing accessors.
+   */
+  char* data();
+};
+
+} // namespace caffeine
+
+#endif

--- a/src/ADT/SharedArray.cpp
+++ b/src/ADT/SharedArray.cpp
@@ -1,0 +1,120 @@
+
+#include "caffeine/ADT/SharedArray.h"
+#include "caffeine/Support/Assert.h"
+
+namespace caffeine {
+
+SharedArray::SharedArray(const std::vector<char>& data)
+    : data_(data), size_(data.size()) {}
+SharedArray::SharedArray(std::vector<char>&& data) : data_(std::move(data)) {
+  size_ = std::get<std::vector<char>>(data_).size();
+}
+SharedArray::SharedArray(const char* data, size_t size)
+    : data_(std::vector<char>(data, data + size)), size_(size) {}
+
+SharedArray::SharedArray(const SharedArray& array) {
+  *this = array;
+}
+SharedArray::SharedArray(SharedArray&& array)
+    : data_(std::move(array.data_)), modcnt_(array.modcnt_),
+      size_(array.size_) {
+  array.data_ = std::vector<char>();
+  array.size_ = 0;
+  array.modcnt_ = 0;
+}
+
+SharedArray& SharedArray::operator=(const SharedArray& array) {
+  if (auto* data = std::get_if<std::vector<char>>(&array.data_)) {
+    if (data->size() <= min_copy_size) {
+      data_ = *data;
+    } else {
+      auto variant = std::make_shared<Variant>(std::move(array.data_));
+
+      array.data_ = Modified(variant);
+      data_ = Modified(variant);
+    }
+  } else {
+    auto& mod = std::get<Modified>(array.data_);
+
+    if (mod.changes.size() <= min_copy_size) {
+      data_ = mod;
+    } else {
+      auto variant = std::make_shared<Variant>(std::move(array.data_));
+
+      array.data_ = Modified(variant);
+      data_ = Modified(variant);
+    }
+  }
+
+  modcnt_ = array.modcnt_;
+  size_ = array.size_;
+
+  return *this;
+}
+SharedArray& SharedArray::operator=(SharedArray&& array) {
+  data_ = std::move(array.data_);
+  size_ = array.size_;
+  modcnt_ = array.modcnt_;
+
+  array.data_ = std::vector<char>();
+  array.size_ = 0;
+  array.modcnt_ = 0;
+
+  return *this;
+}
+
+void SharedArray::store(size_t idx, char value) {
+  CAFFEINE_ASSERT(idx < size(), "index out of bounds");
+
+  std::visit(
+      [=](auto& data) {
+        using type = std::decay_t<decltype(data)>;
+
+        if constexpr (std::is_same_v<type, std::vector<char>>) {
+          data.at(idx) = value;
+        } else {
+          auto it = data.changes.find(idx);
+          if (it != data.changes.end()) {
+            it->second = value;
+            return;
+          }
+
+          if (data[idx] == value)
+            return;
+
+          data.changes.insert({idx, value});
+          modcnt_ += 1;
+
+          if (modcnt_ > size() * flatten_threshold)
+            flatten();
+        }
+      },
+      data_);
+}
+char SharedArray::load(size_t idx) const {
+  CAFFEINE_ASSERT(idx < size(), "index out of bounds");
+  return std::visit([=](const auto& val) -> char { return val[idx]; }, data_);
+}
+
+void SharedArray::flatten() {
+  if (is_flat())
+    return;
+
+  std::vector<char> newdata;
+  newdata.reserve(size());
+
+  for (size_t i = 0; i < size(); ++i)
+    newdata.push_back(load(i));
+
+  data_ = std::move(newdata);
+}
+
+char SharedArray::operator[](size_t idx) const {
+  return load(idx);
+}
+SharedArray::IndexAccessor SharedArray::operator[](size_t idx) {
+  CAFFEINE_ASSERT(idx < size(), "index out of bounds");
+  return IndexAccessor(this, idx);
+}
+
+} // namespace caffeine

--- a/src/ADT/SharedArray.cpp
+++ b/src/ADT/SharedArray.cpp
@@ -108,6 +108,10 @@ void SharedArray::flatten() {
 
   data_ = std::move(newdata);
 }
+char* SharedArray::data() {
+  flatten();
+  return std::get<std::vector<char>>(data_).data();
+}
 
 char SharedArray::operator[](size_t idx) const {
   return load(idx);
@@ -115,6 +119,21 @@ char SharedArray::operator[](size_t idx) const {
 SharedArray::IndexAccessor SharedArray::operator[](size_t idx) {
   CAFFEINE_ASSERT(idx < size(), "index out of bounds");
   return IndexAccessor(this, idx);
+}
+
+bool operator==(const SharedArray& lhs, const SharedArray& rhs) {
+  if (lhs.size() != rhs.size())
+    return false;
+
+  for (size_t i = 0; i < lhs.size(); ++i) {
+    if (lhs[i] != rhs[i])
+      return false;
+  }
+
+  return true;
+}
+bool operator!=(const SharedArray& lhs, const SharedArray& rhs) {
+  return !(lhs == rhs);
 }
 
 } // namespace caffeine

--- a/test/unit/ADT/SharedArray.cpp
+++ b/test/unit/ADT/SharedArray.cpp
@@ -1,0 +1,63 @@
+#include <gtest/gtest.h>
+
+#define CAFFEINE_SHAREDARRAY_TEST_EXPOSE_INTERNALS
+#include "caffeine/ADT/SharedArray.h"
+
+using caffeine::SharedArray;
+
+static_assert(0.0 <= SharedArray::flatten_threshold &&
+                  SharedArray::flatten_threshold <= 1.0,
+              "flatten_threshold out of range");
+
+class SharedArrayTest : public ::testing::Test {
+protected:
+  std::vector<char> zeros;
+  std::vector<char> large;
+
+  void SetUp() override {
+    zeros = std::vector<char>(2 * SharedArray::min_copy_size, 0);
+
+    large.clear();
+    large.reserve(16000);
+    for (size_t i = 0; i < 16000; ++i)
+      large.push_back(i % 128);
+  }
+};
+
+TEST_F(SharedArrayTest, copy_test) {
+  SharedArray array = large;
+
+  for (size_t i = 0; i < array.size(); ++i)
+    ASSERT_EQ(array[i], large[i]);
+}
+
+TEST_F(SharedArrayTest, no_change_when_copied_array_changed) {
+  SharedArray array1 = large;
+  SharedArray array2 = array1;
+
+  for (size_t i = 0; i < 2 * SharedArray::min_copy_size; ++i) {
+    array2[i] = 0;
+  }
+
+  for (size_t i = 0; i < 2 * SharedArray::min_copy_size; ++i)
+    ASSERT_EQ(array2[i], 0);
+
+  for (size_t i = 0; i < 2 * SharedArray::min_copy_size; ++i)
+    ASSERT_EQ(array1[i], large[i]);
+}
+
+TEST_F(SharedArrayTest, flattens_when_sufficiently_modified) {
+  SharedArray array = zeros;
+  SharedArray copy = array;
+
+  ASSERT_TRUE(array.is_shared());
+  ASSERT_TRUE(copy.is_shared());
+
+  for (size_t i = 0; i < zeros.size(); ++i)
+    copy.store(i, 5);
+
+  for (size_t i = 0; i < copy.size(); ++i)
+    ASSERT_EQ(copy[i], 5);
+
+  ASSERT_TRUE(copy.is_flat());
+}


### PR DESCRIPTION
This is basically a modifiable byte array that efficiently shares it's contents between instances. It does this by storing a base value along with changes to that base array (and it does that recursively). This means that when a `SharedArray` is copied it will only copy at most a small amount of data.

I've also included a few small optimizations:
- If there's fewer than 64 elements/modifications in the copy source then we just copy the entire array. This should help avoid building a large linked list with only a single change at each level which would be inefficient.
- If the number of modified elements is greater than 80% of the total size, then just flatten the array and work with that.

These factors still need to be tuned but we can revisit that when doing performance work at a later time.

This is used as part of #94.