### PR TITLE
Update MemHeap to be usable as part of memory support

### DIFF
--- a/include/caffeine/IR/Type.inl
+++ b/include/caffeine/IR/Type.inl
@@ -32,7 +32,7 @@ inline bool Type::is_array() const {
 }
 
 inline uint32_t Type::bitwidth() const {
-  CAFFEINE_ASSERT(is_int());
+  CAFFEINE_ASSERT(is_int() || is_array());
   return desc_;
 }
 inline uint32_t Type::mantissa_bits() const {

--- a/include/caffeine/Memory/MemHeap.h
+++ b/include/caffeine/Memory/MemHeap.h
@@ -175,7 +175,7 @@ public:
    * This will add the corresponding assertions to the context as well.
    */
   AllocId allocate(const ref<Operation>& size, const ref<Operation>& alignment,
-                   Context& ctx);
+                   const ref<Operation>& data, Context& ctx);
 
   /**
    * Deallocate an existing allocation.

--- a/src/Memory/MemHeap.cpp
+++ b/src/Memory/MemHeap.cpp
@@ -46,7 +46,7 @@ Assertion Allocation::check_inbounds(const ref<Operation>& offset,
   auto upper = ICmpOp::CreateICmp(
       ICmpOpcode::ULT,
       BinaryOp::CreateAdd(offset, ConstantInt::Create(llvm::APInt(
-                                      width, Type::pointer_ty().bitwidth()))),
+                                      width, offset->type().bitwidth()))),
       size());
 
   return Assertion(BinaryOp::CreateAnd(std::move(upper), std::move(lower)));
@@ -246,7 +246,9 @@ Assertion MemHeap::check_valid(const Pointer& ptr) {
     result = BinaryOp::CreateOr(result, BinaryOp::CreateAnd(cmp1, cmp2));
   }
 
-  return result;
+  // Note: NULL pointers are never valid.
+  return BinaryOp::CreateAnd(ICmpOp::CreateICmp(ICmpOpcode::NE, value, 0),
+                             result);
 }
 
 llvm::SmallVector<Pointer, 1> MemHeap::resolve(const Pointer& ptr,

--- a/src/Memory/MemHeap.cpp
+++ b/src/Memory/MemHeap.cpp
@@ -171,13 +171,15 @@ const Allocation& MemHeap::operator[](const AllocId& alloc) const {
 }
 
 AllocId MemHeap::allocate(const ref<Operation>& size,
-                          const ref<Operation>& alignment, Context& ctx) {
+                          const ref<Operation>& alignment,
+                          const ref<Operation>& data, Context& ctx) {
   CAFFEINE_ASSERT(size->type() == alignment->type());
   CAFFEINE_ASSERT(size->type().is_int());
+  CAFFEINE_ASSERT(data->type().is_array());
+  CAFFEINE_ASSERT(data->type().bitwidth() == size->type().bitwidth());
 
   auto allocation = Allocation(
-      Constant::Create(size->type(), ctx.next_constant()), size,
-      AllocOp::Create(size, ConstantInt::Create(llvm::APInt(8, 0xDC))));
+      Constant::Create(size->type(), ctx.next_constant()), size, data);
 
   // Ensure that the allocation is properly aligned
   ctx.add(ICmpOp::CreateICmp(

--- a/test/unit/Memory/MemHeap.cpp
+++ b/test/unit/Memory/MemHeap.cpp
@@ -47,7 +47,10 @@ TEST_F(MemHeapTests, resolve_pointer_single) {
   unsigned index_size = layout.getIndexSizeInBits(0);
   auto align = MakeInt(16);
   auto size = Constant::Create(Type::int_ty(index_size), "size");
-  auto alloc = heap.allocate(size, align, context);
+  auto alloc = heap.allocate(
+      size, align,
+      AllocOp::Create(size, ConstantInt::Create(llvm::APInt(8, 0xDD))),
+      context);
   auto offset = Constant::Create(Type::int_ty(index_size), "offset");
 
   context.add(ICmpOp::CreateICmp(ICmpOpcode::ULT, offset, size));


### PR DESCRIPTION
Here's the things that got updated as part of this:
- Explicitly check that the pointer is not null when performing a validity check
- When allocating a new heap allocation the caller now needs to pass in the data

The second one is needed to create allocations with preexisting data (e.g. global arrays).