### PR TITLE
Implement support for LLVM expression constants

### DIFF
--- a/src/Interpreter/CtxConstEval.cpp
+++ b/src/Interpreter/CtxConstEval.cpp
@@ -1,14 +1,19 @@
 #include "caffeine/Interpreter/Context.h"
 
+#include "caffeine/IR/Operation.h"
 #include "caffeine/Support/Assert.h"
 
 #include <llvm/IR/Constant.h>
 #include <llvm/IR/Constants.h>
 #include <llvm/IR/DataLayout.h>
+#include <llvm/IR/GetElementPtrTypeIterator.h>
 #include <llvm/IR/GlobalValue.h>
 #include <llvm/IR/GlobalVariable.h>
+#include <llvm/IR/Instruction.h>
 #include <llvm/IR/Module.h>
 #include <llvm/Support/raw_ostream.h>
+
+using llvm::Instruction;
 
 namespace caffeine {
 
@@ -53,6 +58,140 @@ static ContextValue evaluate_const_vector(Context* ctx,
     result.push_back(evaluate(ctx, vec->getOperand(i)));
 
   return ContextValue(std::move(result));
+}
+
+static ContextValue evaluate_expr(Context* ctx, llvm::ConstantExpr* expr) {
+#define OPERAND(expr, num)                                                     \
+  evaluate(ctx, llvm::cast<llvm::Constant>((expr)->getOperand(num)))
+#define UNARY_OP(expr_) transform((expr_), OPERAND(expr, 0))
+#define BINARY_OP(expr_) transform((expr_), OPERAND(expr, 0), OPERAND(expr, 1))
+#define CAST_OP(expr_)                                                         \
+  transform(                                                                   \
+      [=, type = Type::from_llvm(expr->getType())](                            \
+          const ref<Operation>& value) -> ref<Operation> { return (expr_); },  \
+      OPERAND(expr, 0))
+
+  switch (expr->getOpcode()) {
+  // clang-format off
+  // Unary Operations
+  case Instruction::FNeg: return UNARY_OP(UnaryOp::CreateFNeg);
+
+  // Binary Operations
+  case Instruction::Add:  return BINARY_OP(BinaryOp::CreateAdd);
+  case Instruction::Sub:  return BINARY_OP(BinaryOp::CreateSub);
+  case Instruction::Mul:  return BINARY_OP(BinaryOp::CreateMul);
+  case Instruction::UDiv: return BINARY_OP(BinaryOp::CreateUDiv);
+  case Instruction::SDiv: return BINARY_OP(BinaryOp::CreateSDiv);
+  case Instruction::URem: return BINARY_OP(BinaryOp::CreateURem);
+  case Instruction::SRem: return BINARY_OP(BinaryOp::CreateSRem);
+
+  case Instruction::And:  return BINARY_OP(BinaryOp::CreateAnd);
+  case Instruction::Or:   return BINARY_OP(BinaryOp::CreateOr);
+  case Instruction::Xor:  return BINARY_OP(BinaryOp::CreateXor);
+  case Instruction::Shl:  return BINARY_OP(BinaryOp::CreateShl);
+  case Instruction::LShr: return BINARY_OP(BinaryOp::CreateLShr);
+  case Instruction::AShr: return BINARY_OP(BinaryOp::CreateAShr);
+
+  case Instruction::FAdd: return BINARY_OP(BinaryOp::CreateFAdd);
+  case Instruction::FSub: return BINARY_OP(BinaryOp::CreateFSub);
+  case Instruction::FMul: return BINARY_OP(BinaryOp::CreateFMul);
+  case Instruction::FDiv: return BINARY_OP(BinaryOp::CreateFDiv);
+  case Instruction::FRem: return BINARY_OP(BinaryOp::CreateFRem);
+
+  // Conversion operations
+  case Instruction::Trunc:    return CAST_OP(UnaryOp::CreateTrunc(type, value));
+  case Instruction::SExt:     return CAST_OP(UnaryOp::CreateSExt(type, value));
+  case Instruction::ZExt:     return CAST_OP(UnaryOp::CreateZExt(type, value));
+  case Instruction::FPTrunc:  return CAST_OP(UnaryOp::CreateFpTrunc(type, value));
+  case Instruction::FPExt:    return CAST_OP(UnaryOp::CreateFpExt(type, value));
+  case Instruction::UIToFP:   return CAST_OP(UnaryOp::CreateUIToFp(type, value));
+  case Instruction::SIToFP:   return CAST_OP(UnaryOp::CreateSIToFp(type, value));
+  case Instruction::FPToUI:   return CAST_OP(UnaryOp::CreateFpToUI(type, value));
+  case Instruction::FPToSI:   return CAST_OP(UnaryOp::CreateFpToSI(type, value));
+    // clang-format on
+
+  case Instruction::IntToPtr:
+    return transform_value(
+        [=](const auto& value) {
+          return ContextValue(Pointer(value.scalar()));
+        },
+        OPERAND(expr, 0));
+
+  case Instruction::PtrToInt:
+    return transform_value(
+        [=](const auto& value) {
+          return ContextValue(value.pointer().value(ctx->heap()));
+        },
+        OPERAND(expr, 0));
+
+  case Instruction::BitCast:
+    return OPERAND(expr, 0);
+
+  case Instruction::Select:
+    return transform(SelectOp::Create, OPERAND(expr, 0), OPERAND(expr, 1),
+                     OPERAND(expr, 2));
+
+  case Instruction::GetElementPtr: {
+    const llvm::DataLayout& layout = ctx->llvm_module()->getDataLayout();
+
+    ContextValue ptr = OPERAND(expr, 0);
+    llvm::Type* ptr_ty = expr->getOperand(0)->getType();
+    while (ptr_ty->isVectorTy())
+      ptr_ty = ptr_ty->getVectorElementType();
+
+    auto offset_width =
+        layout.getPointerSizeInBits(ptr_ty->getPointerAddressSpace());
+    auto offset = ConstantInt::Create(llvm::APInt(offset_width, 0));
+
+    auto end = llvm::gep_type_end(expr);
+    for (auto it = llvm::gep_type_begin(expr); it != end; ++it) {
+      if (llvm::StructType* sty = it.getStructTypeOrNull()) {
+        auto slo = layout.getStructLayout(sty);
+        unsigned index =
+            llvm::cast<llvm::ConstantInt>(it.getOperand())->getZExtValue();
+
+        offset = BinaryOp::CreateAdd(
+            offset,
+            ConstantInt::Create(llvm::APInt(offset->type().bitwidth(),
+                                            slo->getElementOffset(index))));
+      } else {
+        auto value =
+            evaluate(ctx, llvm::cast<llvm::Constant>(it.getOperand())).scalar();
+        unsigned bitwidth = value->type().bitwidth();
+
+        if (bitwidth < offset_width)
+          value = UnaryOp::CreateSExt(Type::int_ty(offset_width), value);
+        else if (bitwidth > offset_width)
+          value = UnaryOp::CreateTrunc(Type::int_ty(offset_width), value);
+
+        auto itemoffset = BinaryOp::CreateMul(
+            value,
+            ConstantInt::Create(llvm::APInt(
+                bitwidth, layout.getTypeAllocSize(it.getIndexedType()))));
+
+        offset = BinaryOp::CreateAdd(offset, itemoffset);
+      }
+    }
+
+    auto func = [&](const ContextValue& value) {
+      const auto& ptr = value.pointer();
+
+      return ContextValue(
+          Pointer(BinaryOp::CreateAdd(ptr.value(ctx->heap()), offset)));
+    };
+    return transform_value(func, ptr);
+  }
+
+  default:
+    break;
+  }
+
+  std::string s = "Unsupported constant expression: ";
+  llvm::raw_string_ostream os(s);
+  expr->print(os, true);
+  os.flush();
+
+  CAFFEINE_UNIMPLEMENTED(s);
 }
 
 // Note: This method should always return a pointer. (At least I think that's
@@ -123,6 +262,9 @@ static ContextValue evaluate(Context* ctx, llvm::Constant* constant) {
 
   if (auto* global = llvm::dyn_cast<llvm::GlobalVariable>(constant))
     return evaluate_global(ctx, global);
+
+  if (auto* expr = llvm::dyn_cast<llvm::ConstantExpr>(constant))
+    return evaluate_expr(ctx, expr);
 
   if (auto* vec = llvm::dyn_cast<llvm::ConstantDataVector>(constant)) {
     CAFFEINE_ASSERT(!vec->getType()->getVectorIsScalable(),

--- a/src/Memory/MemHeap.cpp
+++ b/src/Memory/MemHeap.cpp
@@ -145,9 +145,13 @@ void Allocation::write(const ref<Operation>& offset,
  ***************************************************/
 
 Pointer::Pointer(const ref<Operation>& value)
-    : Pointer({SIZE_MAX, SIZE_MAX}, value) {}
+    : Pointer({SIZE_MAX, SIZE_MAX}, value) {
+  CAFFEINE_ASSERT(value->type().is_int());
+}
 Pointer::Pointer(const AllocId& alloc, const ref<Operation>& offset)
-    : alloc_(alloc), offset_(offset) {}
+    : alloc_(alloc), offset_(offset) {
+  CAFFEINE_ASSERT(offset->type().is_int());
+}
 
 ref<Operation> Pointer::value(const MemHeap& heap) const {
   if (is_resolved())

--- a/test/run-pass/mem/const-getelementptr.c
+++ b/test/run-pass/mem/const-getelementptr.c
@@ -1,0 +1,15 @@
+
+#include "caffeine.h"
+#include <stdint.h>
+
+uint32_t array[4] = {1, 2, 3, 4};
+
+__attribute__((noinline)) uint32_t* offset(uint32_t* ptr, uint32_t x) {
+  return ptr + x;
+}
+
+void test(uint32_t x) {
+  caffeine_assume(x < 4);
+
+  caffeine_assert(offset(array, x) == array + x);
+}


### PR DESCRIPTION
Turns out that you can apparently just shove any old set of LLVM operations into a constant expression. This is annoying since it means that I have to duplicate a whole bunch of code from the interpreted but make it different enough that they can't share.

Anyway, this implements it by just building the corresponding set of expression trees and letting constant folding take care of the rest. 

Here's the detailed set of changes in this PR:
- Refactor the constant handling code out into it's own source file. It was getting rather big and seemed like it would be better off as a somewhat independent module.
- Allow `icmp` to work with pointer operands.
- Add a test case that involves both of the above.

Edit: The refactor has been split out into #111 