### PR TITLE
Implement inttoptr and ptrtoint

### DIFF
--- a/include/caffeine/IR/Operation.h
+++ b/include/caffeine/IR/Operation.h
@@ -519,6 +519,15 @@ public:
   static ref<Operation> CreateSIToFp(Type tgt, const ref<Operation>& operand);
   static ref<Operation> CreateBitcast(Type tgt, const ref<Operation>& operand);
 
+  /// Create a trunc operation or a zext operation as needed to convert operand
+  /// to the required bitwidth. If the bitwidths are the same then does nothing.
+  static ref<Operation> CreateTruncOrZExt(Type tgt,
+                                          const ref<Operation>& operand);
+  /// Create a trunc operation or a sext operation as needed to convert operand
+  /// to the required bitwidth. If the bitwidths are the same then does nothing.
+  static ref<Operation> CreateTruncOrSExt(Type tgt,
+                                          const ref<Operation>& operand);
+
   static bool classof(const Operation* op);
 };
 

--- a/include/caffeine/Interpreter/Interpreter.h
+++ b/include/caffeine/Interpreter/Interpreter.h
@@ -59,6 +59,8 @@ public:
 
   ExecutionResult visitSExt(llvm::SExtInst& sext);
   ExecutionResult visitZExt(llvm::ZExtInst& zext);
+  ExecutionResult visitIntToPtrInst(llvm::IntToPtrInst& inttoptr);
+  ExecutionResult visitPtrToIntInst(llvm::PtrToIntInst& ptrtoint);
 
   ExecutionResult visitBitCastInst(llvm::BitCastInst& bitcast);
 

--- a/src/IR/Operation.cpp
+++ b/src/IR/Operation.cpp
@@ -829,6 +829,29 @@ ref<Operation> UnaryOp::CreateBitcast(Type tgt, const ref<Operation>& operand) {
   return ref<Operation>(new UnaryOp(Opcode::Bitcast, tgt, operand));
 }
 
+ref<Operation> UnaryOp::CreateTruncOrZExt(Type tgt,
+                                          const ref<Operation>& operand) {
+  CAFFEINE_ASSERT(operand->type().is_int());
+  CAFFEINE_ASSERT(tgt.is_int());
+
+  if (tgt.bitwidth() < operand->type().bitwidth())
+    return CreateTrunc(tgt, operand);
+  if (tgt.bitwidth() > operand->type().bitwidth())
+    return CreateZExt(tgt, operand);
+  return operand;
+}
+ref<Operation> UnaryOp::CreateTruncOrSExt(Type tgt,
+                                          const ref<Operation>& operand) {
+  CAFFEINE_ASSERT(operand->type().is_int());
+  CAFFEINE_ASSERT(tgt.is_int());
+
+  if (tgt.bitwidth() < operand->type().bitwidth())
+    return CreateTrunc(tgt, operand);
+  if (tgt.bitwidth() > operand->type().bitwidth())
+    return CreateSExt(tgt, operand);
+  return operand;
+}
+
 /***************************************************
  * SelectOp                                        *
  ***************************************************/

--- a/test/run-fail/mem/allocations-anywhere.c
+++ b/test/run-fail/mem/allocations-anywhere.c
@@ -1,0 +1,14 @@
+
+#include "caffeine.h"
+#include <stdint.h>
+
+uint32_t array[2] = {0, 1};
+
+// Needed to force a non-constant ptrtoint instruction
+__attribute__((noinline)) uintptr_t ptrtoint(uint32_t* ptr) {
+  return (uintptr_t)ptr;
+}
+
+void test(uintptr_t x) {
+  caffeine_assert(x != ptrtoint(&array[0]));
+}


### PR DESCRIPTION
Mostly as in title. Here's the detailed list of changes:
- Added some utility operation factory functions (`CreateTruncOrZExt` and `CreateTruncOrSExt`) that behave as named
- Implement inttoptr
- Implement ptrtoint
- Fix the constant evaluation logic for both opcodes