### PR TITLE
Remove unused private field from StackFrame

### DIFF
--- a/include/caffeine/Interpreter/StackFrame.h
+++ b/include/caffeine/Interpreter/StackFrame.h
@@ -15,7 +15,6 @@ class Context;
 
 class StackFrame {
 private:
-  llvm::Function* function;
   std::unordered_map<llvm::Value*, ContextValue> variables;
 
 public:

--- a/src/Interpreter/StackFrame.cpp
+++ b/src/Interpreter/StackFrame.cpp
@@ -9,8 +9,8 @@
 namespace caffeine {
 
 StackFrame::StackFrame(llvm::Function* function)
-    : function(function), current_block(&function->getEntryBlock()),
-      prev_block(nullptr), current(current_block->begin()) {}
+    : current_block(&function->getEntryBlock()), prev_block(nullptr),
+      current(current_block->begin()) {}
 
 void StackFrame::jump_to(llvm::BasicBlock* block) {
   prev_block = current_block;


### PR DESCRIPTION
This silences the one warning we have in the project under clang.