### PR TITLE
Rewrite cmake build steps for LLVM IR makefiles

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,11 +24,15 @@ if (NOT CAFFEINE_FMTONLY)
   # C++17 has a bunch of nice stuff, seems like a good level to target.
   set(CMAKE_CXX_STANDARD 17)
   set(CMAKE_CXX_STANDARD_REQUIRED TRUE)
+  set(CMAKE_C_STANDARD 99)
+  set(CMAKE_C_STANDARD_REQUIRED TRUE)
 
   include(setup-warnings)
+  include(LLVMIRUtils)
 
   add_subdirectory(src)
   add_subdirectory(test)
+  add_subdirectory(interface)
 
 else()
   if (CLANG_FORMAT STREQUAL "CLANG_FORMAT-NOTFOUND")

--- a/cmake/LLVMIRUtils.cmake
+++ b/cmake/LLVMIRUtils.cmake
@@ -1,0 +1,128 @@
+
+# Commands to define LLVM bitcode libraries.
+#
+# add_llvm_ir_library(<target-name> <sources>...)
+#   Creates a new bitcode library using the provided source files.
+#   C and C++ source files will be compiled to bitcode while IR and
+#   bitcode files will just be linked in directly.
+#
+#   The generated target is a real library target so all the commands
+#   that you would normally use for a library target will work here as
+#   well.
+
+if (NOT DEFINED LLVM_FOUND)
+  find_package(LLVM REQUIRED)
+endif()
+
+function(set_if_unset FLAGNAME)
+  if (NOT DEFINED ${FLAGNAME})
+    set(${FLAGNAME} "${ARGN}" PARENT_SCOPE)
+  endif()
+endfunction()
+
+set(CLANG_BUILD_SCRIPT "${CMAKE_SOURCE_DIR}/cmake/clang-build.cmake")
+set(CLANG_LINK_SCRIPT "${CMAKE_SOURCE_DIR}/cmake/clang-link.cmake")
+
+set_if_unset(CLANG     "${LLVM_TOOLS_BINARY_DIR}/clang")
+set_if_unset(CLANGXX   "${LLVM_TOOLS_BINARY_DIR}/clang++")
+set_if_unset(LLVM_LINK "${LLVM_TOOLS_BINARY_DIR}/llvm-link")
+
+# Here we define 3 new languages:
+# - LLVM_C: Compile a C source file to a bitcode file
+# - LLVM_CXX: Compile a C++ source file to a bitcode file
+# - BITCODE: A linker language that we use to link all the bitcode files together.
+#
+# Note that since these languages are no longer C and C++ cmake won't
+# set up the arguments as expected (includes will just be bare paths,
+# etc.) so we use a cmake script to preprocess the arguments beforehand.
+#
+# NOTE: The output extension of the object file is the same as the output
+#       extension of the input file. I don't know how to change this 
+#       within cmake so instead the linker is a script that copies them
+#       to have the right extension before linking.
+
+set_if_unset(CMAKE_LLVM_C_DEFINES             "${CMAKE_C_DEFINES}")
+set_if_unset(CMAKE_LLVM_C_FLAGS               "${CMAKE_C_FLAGS}")
+set(CMAKE_LLVM_C_COMPILE_OBJECT
+  "${CMAKE_COMMAND} \"-DCOMPILER=${CLANG}\" \"-DOBJECT=<OBJECT>\" \"-DSOURCE=<SOURCE>\" \"-DDEFINES=<DEFINES>\" \"-DFLAGS=-S -emit-llvm <FLAGS>\" \"-DINCLUDES=<INCLUDES>\" -P \"${CLANG_BUILD_SCRIPT}\""
+)
+
+set_if_unset(CMAKE_LLVM_CXX_DEFINES           "${CMAKE_CXX_DEFINES}")
+set_if_unset(CMAKE_LLVM_CXX_FLAGS             "${CMAKE_CXX_FLAGS}")
+set(CMAKE_LLVM_CXX_COMPILE_OBJECT
+  "${CMAKE_COMMAND} \"-DCOMPILER=${CLANGXX}\" \"-DOBJECT=<OBJECT>\" \"-DSOURCE=<SOURCE>\" \"-DDEFINES=<DEFINES>\" \"-DFLAGS=-S -emit-llvm <FLAGS>\" \"-DINCLUDES=<INCLUDES>\" -P \"${CLANG_BUILD_SCRIPT}\""
+)
+
+set(
+  CMAKE_BITCODE_CREATE_SHARED_LIBRARY
+  "${CMAKE_COMMAND} \"-DLINKER=${LLVM_LINK}\" \"-DFLAGS=<LINK_FLAGS> -S\" \"-DTARGET=<TARGET>\" \"-DLINK_LIBRARIES=<LINK_LIBRARIES>\" \"-DOBJECTS=<OBJECTS>\" -P \"${CLANG_LINK_SCRIPT}\""
+)
+
+set(CMAKE_SHARED_LIBRARY_PREFIX_BITCODE "")
+set(CMAKE_SHARED_LIBRARY_SUFFIX_BITCODE .ll)
+
+function(add_llvm_ir_library TARGET_NAME)
+  set(TARGET_SOURCES "${ARGN}")
+
+  # NOTE: Has to be a shared library so that the link libraries are properly passed along
+  add_library(${TARGET_NAME} SHARED "${TARGET_SOURCES}")
+
+  foreach(source "${TARGET_SOURCES}")
+    get_property(source_language SOURCE "${source}" PROPERTY LANGUAGE)
+    get_filename_component(source_ext "${source}" LAST_EXT)
+
+    if(source_language STREQUAL "C")
+      set_property(
+        SOURCE "${source}"
+        PROPERTY
+        LANGUAGE LLVM_C
+      )
+
+      # If the script gets modified then we want to rebuild
+      set_property(
+        SOURCE "${source}"
+        PROPERTY
+        OBJECT_DEPENDS "${CLANG_BUILD_SCRIPT}"
+      )
+    elseif(source_language STREQUAL "CXX")
+      set_property(
+        SOURCE "${source}"
+        PROPERTY
+        LANGUAGE LLVM_CXX
+      )
+
+      # If the script gets modified then we want to rebuild
+      set_property(
+        SOURCE "${source}"
+        PROPERTY
+        OBJECT_DEPENDS "${CLANG_BUILD_SCRIPT}"
+      )
+    elseif(source_ext STREQUAL .ll OR source_ext STREQUAL .bc)
+      set_property(
+        SOURCE "${source}"
+        PROPERTY
+        LANGUAGE BITCODE
+      )
+      set_property(
+        SOURCE "${source}"
+        PROPERTY
+        EXTERNAL_OBJECT TRUE
+      )
+    endif()
+  endforeach()
+
+  set_property(
+    TARGET ${TARGET_NAME}
+    PROPERTY
+    LINKER_LANGUAGE BITCODE
+  )
+
+  # We want to re-run the link step if the linker script changes.
+  set_property(
+    TARGET ${TARGET_NAME}
+    PROPERTY
+    LINK_DEPENDS "${CLANG_LINK_SCRIPT}"
+  )
+endfunction()
+
+

--- a/cmake/LLVMIRUtils.cmake
+++ b/cmake/LLVMIRUtils.cmake
@@ -72,42 +72,18 @@ function(add_llvm_ir_library TARGET_NAME)
     get_filename_component(source_ext "${source}" LAST_EXT)
 
     if(source_language STREQUAL "C")
-      set_property(
-        SOURCE "${source}"
-        PROPERTY
-        LANGUAGE LLVM_C
-      )
+      set_property(SOURCE "${source}" PROPERTY LANGUAGE LLVM_C)
 
       # If the script gets modified then we want to rebuild
-      set_property(
-        SOURCE "${source}"
-        PROPERTY
-        OBJECT_DEPENDS "${CLANG_BUILD_SCRIPT}"
-      )
+      set_property(SOURCE "${source}" PROPERTY OBJECT_DEPENDS "${CLANG_BUILD_SCRIPT}")
     elseif(source_language STREQUAL "CXX")
-      set_property(
-        SOURCE "${source}"
-        PROPERTY
-        LANGUAGE LLVM_CXX
-      )
+      set_property(SOURCE "${source}" PROPERTY LANGUAGE LLVM_CXX)
 
       # If the script gets modified then we want to rebuild
-      set_property(
-        SOURCE "${source}"
-        PROPERTY
-        OBJECT_DEPENDS "${CLANG_BUILD_SCRIPT}"
-      )
+      set_property(SOURCE "${source}" PROPERTY OBJECT_DEPENDS "${CLANG_BUILD_SCRIPT}")
     elseif(source_ext STREQUAL .ll OR source_ext STREQUAL .bc)
-      set_property(
-        SOURCE "${source}"
-        PROPERTY
-        LANGUAGE BITCODE
-      )
-      set_property(
-        SOURCE "${source}"
-        PROPERTY
-        EXTERNAL_OBJECT TRUE
-      )
+      set_property(SOURCE "${source}" PROPERTY LANGUAGE BITCODE)
+      set_property(SOURCE "${source}" PROPERTY EXTERNAL_OBJECT TRUE)
     endif()
   endforeach()
 

--- a/cmake/clang-build.cmake
+++ b/cmake/clang-build.cmake
@@ -1,0 +1,32 @@
+
+function(separate_and_strip RETURN_VAR INPUT)
+  separate_arguments(PARSED NATIVE_COMMAND "${INPUT}")
+
+  set(STRIPPED "")
+  foreach(ARG "${PARSED}")
+    if(NOT "${ARG}" STREQUAL "")
+      list(APPEND STRIPPED "${ARG}")
+    endif()
+  endforeach()
+
+  set("${RETURN_VAR}" "${STRIPPED}" PARENT_SCOPE)
+endfunction()
+
+separate_and_strip(PROC_DEFINES "${DEFINES}")
+separate_and_strip(PROC_FLAGS   "${FLAGS}")
+
+set(PROC_INCLUDES "")
+foreach(INC "${INCLUDES}")
+  if (NOT "${INC}" STREQUAL "")
+    list(APPEND PROC_INCLUDES "-I${INC}")
+  endif()
+endforeach()
+
+execute_process(
+  COMMAND "${COMPILER}" ${PROC_DEFINES} ${PROC_INCLUDES} ${PROC_FLAGS} -o "${OBJECT}" -c "${SOURCE}"
+  RESULT_VARIABLE EXITVAL
+)
+
+if (NOT "${EXITVAL}" EQUAL 0)
+  message(FATAL_ERROR "Compilation failed!")
+endif()

--- a/cmake/clang-link.cmake
+++ b/cmake/clang-link.cmake
@@ -1,0 +1,50 @@
+
+function(separate_and_strip RETURN_VAR INPUT)
+  separate_arguments(PARSED NATIVE_COMMAND "${INPUT}")
+
+  set(STRIPPED "")
+  foreach(ARG "${PARSED}")
+    if(NOT "${ARG}" STREQUAL "")
+      list(APPEND STRIPPED "${ARG}")
+    endif()
+  endforeach()
+
+  set("${RETURN_VAR}" "${STRIPPED}" PARENT_SCOPE)
+endfunction()
+
+separate_and_strip(FLAGS "${FLAGS}")
+separate_and_strip(LINK_LIBRARIES "${LINK_LIBRARIES}")
+separate_and_strip(PROC_OBJECTS "${OBJECTS}")
+
+set(OBJECTS "")
+foreach(OBJ "${PROC_OBJECTS}")
+  if("${OBJ}" STREQUAL "")
+    continue()
+  endif()
+  
+  get_filename_component(ext "${OBJ}" LAST_EXT)
+
+  if("${ext}" STREQUAL ".ll" OR "${ext}" STREQUAL ".bc")
+    list(APPEND OBJECTS "${OBJ}")
+  else()
+    list(APPEND OBJECTS "${OBJ}.ll")
+
+    execute_process(
+      COMMAND "${CMAKE_COMMAND}" -E copy_if_different "${OBJ}" "${OBJ}.ll"
+      RESULT_VARIABLE EXITVAL
+    )
+
+    if(NOT "${EXITVAL}" EQUAL 0)
+      message(FATAL_ERROR "Pre-link copying step failed!")
+    endif()
+  endif()
+endforeach()
+
+execute_process(
+  COMMAND "${LINKER}" ${FLAGS} -o "${TARGET}" ${OBJECTS} ${LINK_LIBRARIES}
+  RESULT_VARIABLE EXITVAL
+)
+
+if(NOT "${EXITVAL}" EQUAL 0)
+  message(FATAL_ERROR "Link step failed! ${EXITVAL}")
+endif()

--- a/interface/CMakeLists.txt
+++ b/interface/CMakeLists.txt
@@ -1,0 +1,5 @@
+
+add_llvm_ir_library(caffeine-builtins caffeine-builtins.c)
+
+target_compile_options(caffeine-builtins PRIVATE -O3)
+target_include_directories(caffeine-builtins PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}")

--- a/test/run-fail/CMakeLists.txt
+++ b/test/run-fail/CMakeLists.txt
@@ -1,16 +1,25 @@
 
-file(GLOB_RECURSE c_tests   CONFIGURE_DEPENDS *.c)
-file(GLOB_RECURSE cpp_tests CONFIGURE_DEPENDS *.cpp *.cc)
-file(GLOB_RECURSE ir_tests  CONFIGURE_DEPENDS *.ll)
-
-set(CLANG_FLAGS -S -emit-llvm -O3 -fcolor-diagnostics "-I${CMAKE_SOURCE_DIR}/interface")
+file(GLOB_RECURSE tests CONFIGURE_DEPENDS *.c *.cpp *.cc *.ll *.bc)
 
 include(testutils)
 
-
-foreach(test ${ir_tests})
+foreach(test ${tests})
   file(RELATIVE_PATH test_file "${CMAKE_CURRENT_SOURCE_DIR}" "${test}")
   should_skip_test(should_skip "${test}")
+  
+  string(REGEX REPLACE "\\\\|/" "_" TEST_TARGET "run-fail/${test_file}")
+  set(TEST_OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/${test_file}")
+
+  get_filename_component(output_dir "${TEST_OUTPUT}" DIRECTORY)
+  get_filename_component(basename "${TEST_OUTPUT}" NAME)
+  file(MAKE_DIRECTORY "${output_dir}")
+
+  add_llvm_ir_library("${TEST_TARGET}" "${test}")
+
+  add_dependencies("${TEST_TARGET}" caffeine-builtins)
+  target_link_libraries("${TEST_TARGET}" PRIVATE caffeine-builtins)
+  target_include_directories("${TEST_TARGET}" PRIVATE "${CMAKE_SOURCE_DIR}/interface")
+  target_compile_options("${TEST_TARGET}" PRIVATE -O3)
 
   if (should_skip)
     add_test(
@@ -20,10 +29,10 @@ foreach(test ${ir_tests})
   else()
     add_test(
       NAME "run-fail/${test_file}"
-      COMMAND caffeine-bin "${test}" test
+      COMMAND caffeine-bin "$<TARGET_FILE:${TEST_TARGET}>" test
     )
   endif()
-  
+
   set_tests_properties(
     "run-fail/${test_file}"
     PROPERTIES
@@ -31,87 +40,3 @@ foreach(test ${ir_tests})
     SKIP_RETURN_CODE 77
   )
 endforeach()
-
-if (NOT "${CLANG}" STREQUAL "CLANG-NOTFOUND")
-  foreach(test ${c_tests})
-    file(RELATIVE_PATH test_file "${CMAKE_CURRENT_SOURCE_DIR}" "${test}")
-    set(TEST_OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/${test_file}.ll")
-    should_skip_test(should_skip "${test}")
-
-    get_filename_component(output_dir "${TEST_OUTPUT}" DIRECTORY)
-    file(MAKE_DIRECTORY "${output_dir}")
-
-    add_custom_command(
-      OUTPUT "${TEST_OUTPUT}"
-      COMMAND "${CLANG}" -std=c11 ${CLANG_FLAGS} "${test}" -o "${TEST_OUTPUT}"
-      MAIN_DEPENDENCY "${test}"
-    )
-
-    if (should_skip)
-      add_test(
-        NAME "run-fail/${test_file}"
-        COMMAND skip-test "${test}" test
-      )
-    else()
-      add_test(
-        NAME "run-fail/${test_file}"
-        COMMAND caffeine-bin "${TEST_OUTPUT}" test
-      )
-    endif()
-
-    set_tests_properties(
-      "run-fail/${test_file}"
-      PROPERTIES
-      WILL_FAIL TRUE
-      SKIP_RETURN_CODE 77
-    )
-
-    list(APPEND test_files "${TEST_OUTPUT}")
-  endforeach()
-endif()
-
-if (NOT "${CLANGXX}" STREQUAL "CLANGXX-NOTFOUND")
-  foreach(test ${cpp_tests})
-    file(RELATIVE_PATH test_file "${CMAKE_CURRENT_SOURCE_DIR}" "${test}")
-    set(TEST_OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/${test_file}.ll")
-    should_skip_test(should_skip "${test}")
-
-    get_filename_component(output_dir "${TEST_OUTPUT}" DIRECTORY)
-    file(MAKE_DIRECTORY "${output_dir}")
-
-    add_custom_command(
-      OUTPUT "${TEST_OUTPUT}"
-      COMMAND "${CLANGXX}" -std=c++17 ${CLANG_FLAGS} "${test}" -o "${TEST_OUTPUT}"
-      MAIN_DEPENDENCY "${test}"
-    )
-
-    if (should_skip)
-      add_test(
-        NAME "run-fail/${test_file}"
-        COMMAND skip-test "${test}" test
-      )
-    else()
-      add_test(
-        NAME "run-fail/${test_file}"
-        COMMAND caffeine-bin "${TEST_OUTPUT}" test
-      )
-    endif()
-
-    set_tests_properties(
-      "run-fail/${test_file}"
-      PROPERTIES
-      WILL_FAIL TRUE
-      SKIP_RETURN_CODE 77
-    )
-
-    list(APPEND test_files "${TEST_OUTPUT}")
-  endforeach()
-endif()
-
-# Custom commands don't run by default. We need a target to force them
-# to run.
-add_custom_target(
-  run-fail-tests ALL
-  DEPENDS "${test_files}"
-)
-

--- a/test/run-pass/CMakeLists.txt
+++ b/test/run-pass/CMakeLists.txt
@@ -1,15 +1,25 @@
 
-file(GLOB_RECURSE c_tests   CONFIGURE_DEPENDS *.c)
-file(GLOB_RECURSE cpp_tests CONFIGURE_DEPENDS *.cpp *.cc)
-file(GLOB_RECURSE ir_tests  CONFIGURE_DEPENDS *.ll)
-
-set(CLANG_FLAGS -S -emit-llvm -O3 -fcolor-diagnostics "-I${CMAKE_SOURCE_DIR}/interface")
+file(GLOB_RECURSE tests CONFIGURE_DEPENDS *.c *.cpp *.cc *.ll *.bc)
 
 include(testutils)
 
-foreach(test ${ir_tests})
+foreach(test ${tests})
   file(RELATIVE_PATH test_file "${CMAKE_CURRENT_SOURCE_DIR}" "${test}")
   should_skip_test(should_skip "${test}")
+  
+  string(REGEX REPLACE "\\\\|/" "_" TEST_TARGET "run-pass/${test_file}")
+  set(TEST_OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/${test_file}")
+
+  get_filename_component(output_dir "${TEST_OUTPUT}" DIRECTORY)
+  get_filename_component(basename "${TEST_OUTPUT}" NAME)
+  file(MAKE_DIRECTORY "${output_dir}")
+
+  add_llvm_ir_library("${TEST_TARGET}" "${test}")
+
+  add_dependencies("${TEST_TARGET}" caffeine-builtins)
+  target_link_libraries("${TEST_TARGET}" PRIVATE caffeine-builtins)
+  target_include_directories("${TEST_TARGET}" PRIVATE "${CMAKE_SOURCE_DIR}/interface")
+  target_compile_options("${TEST_TARGET}" PRIVATE -O3)
 
   if (should_skip)
     add_test(
@@ -19,95 +29,13 @@ foreach(test ${ir_tests})
   else()
     add_test(
       NAME "run-pass/${test_file}"
-      COMMAND caffeine-bin "${test}" test
+      COMMAND caffeine-bin "$<TARGET_FILE:${TEST_TARGET}>" test
     )
   endif()
-  
+
   set_tests_properties(
     "run-pass/${test_file}"
     PROPERTIES
     SKIP_RETURN_CODE 77
   )
 endforeach()
-
-if (NOT "${CLANG}" STREQUAL "CLANG-NOTFOUND")
-  foreach(test ${c_tests})
-    file(RELATIVE_PATH test_file "${CMAKE_CURRENT_SOURCE_DIR}" "${test}")
-    set(TEST_OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/${test_file}.ll")
-    should_skip_test(should_skip "${test}")
-
-    get_filename_component(output_dir "${TEST_OUTPUT}" DIRECTORY)
-    file(MAKE_DIRECTORY "${output_dir}")
-
-    add_custom_command(
-      OUTPUT "${TEST_OUTPUT}"
-      COMMAND "${CLANG}" -std=c11 ${CLANG_FLAGS} "${test}" -o "${TEST_OUTPUT}"
-      MAIN_DEPENDENCY "${test}"
-    )
-
-    if (should_skip)
-      add_test(
-        NAME "run-pass/${test_file}"
-        COMMAND skip-test "${test}" test
-      )
-    else()
-      add_test(
-        NAME "run-pass/${test_file}"
-        COMMAND caffeine-bin "${TEST_OUTPUT}" test
-      )
-    endif()
-
-    set_tests_properties(
-      "run-pass/${test_file}"
-      PROPERTIES
-      SKIP_RETURN_CODE 77
-    )
-
-    list(APPEND test_files "${TEST_OUTPUT}")
-  endforeach()
-endif()
-
-if (NOT "${CLANGXX}" STREQUAL "CLANGXX-NOTFOUND")
-  foreach(test ${cpp_tests})
-    file(RELATIVE_PATH test_file "${CMAKE_CURRENT_SOURCE_DIR}" "${test}")
-    set(TEST_OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/${test_file}.ll")
-    should_skip_test(should_skip "${test}")
-
-    get_filename_component(output_dir "${TEST_OUTPUT}" DIRECTORY)
-    file(MAKE_DIRECTORY "${output_dir}")
-
-    add_custom_command(
-      OUTPUT "${TEST_OUTPUT}"
-      COMMAND "${CLANGXX}" -std=c++17 ${CLANG_FLAGS} "${test}" -o "${TEST_OUTPUT}"
-      MAIN_DEPENDENCY "${test}"
-    )
-
-    if (should_skip)
-      add_test(
-        NAME "run-pass/${test_file}"
-        COMMAND skip-test "${test}" test
-      )
-    else()
-      add_test(
-        NAME "run-pass/${test_file}"
-        COMMAND caffeine-bin "${TEST_OUTPUT}" test
-      )
-    endif()
-
-    set_tests_properties(
-      "run-pass/${test_file}"
-      PROPERTIES
-      SKIP_RETURN_CODE 77
-    )
-
-    list(APPEND test_files "${TEST_OUTPUT}")
-  endforeach()
-endif()
-
-# Custom commands don't run by default. We need a target to force them
-# to run.
-add_custom_target(
-  run-pass-tests ALL
-  DEPENDS "${test_files}"
-)
-


### PR DESCRIPTION
When writing the code for malloc and free I needed to be able to link some runtime IR into the final bitcode for test cases. This PR adds the required code to be able to have LLVM IR libraries that are linked together.

It works by defining new cmake languages that compile to llvm bitcode and a linker language that shells out to llvm-link to link it all together. I've also rewritten the test cmake files to use the new methods.

See the explanatory comments within `LLVMIRUtils.cmake` for a bit of how it works but TBH it's probably not worth trying to understand it all.