### PR TITLE
Implement malloc and free

### DIFF
--- a/include/caffeine/Interpreter/Interpreter.h
+++ b/include/caffeine/Interpreter/Interpreter.h
@@ -86,6 +86,8 @@ private:
 
   ExecutionResult visitAssume(llvm::CallInst& inst);
   ExecutionResult visitAssert(llvm::CallInst& inst);
+
+  ExecutionResult visitMalloc(llvm::CallInst& inst);
 };
 
 } // namespace caffeine

--- a/include/caffeine/Interpreter/Interpreter.h
+++ b/include/caffeine/Interpreter/Interpreter.h
@@ -6,6 +6,7 @@
 #include "caffeine/IR/Assertion.h"
 #include "caffeine/Interpreter/Executor.h"
 #include "caffeine/Interpreter/FailureLogger.h"
+#include "caffeine/Interpreter/Options.h"
 #include "caffeine/Support/Assert.h"
 
 #include <llvm/IR/InstVisitor.h>
@@ -19,13 +20,15 @@ private:
   Context* ctx;
   Executor* queue;
   FailureLogger* logger;
+  InterpreterOptions options;
 
 public:
   /**
    * The interpreter constructor needs an executor and context as well as a way
    * to log assertion failures.
    */
-  Interpreter(Executor* queue, Context* ctx, FailureLogger* logger);
+  Interpreter(Executor* queue, Context* ctx, FailureLogger* logger,
+              const InterpreterOptions& options = InterpreterOptions());
 
   void execute();
 

--- a/include/caffeine/Interpreter/Interpreter.h
+++ b/include/caffeine/Interpreter/Interpreter.h
@@ -88,6 +88,7 @@ private:
   ExecutionResult visitAssert(llvm::CallInst& inst);
 
   ExecutionResult visitMalloc(llvm::CallInst& inst);
+  ExecutionResult visitFree(llvm::CallInst& inst);
 };
 
 } // namespace caffeine

--- a/include/caffeine/Interpreter/Options.h
+++ b/include/caffeine/Interpreter/Options.h
@@ -1,0 +1,22 @@
+#ifndef CAFFEINE_INTERPRETER_OPTIONS_H
+#define CAFFEINE_INTERPRETER_OPTIONS_H
+
+namespace caffeine {
+
+struct InterpreterOptions {
+  /**
+   * Determines whether it's possible for malloc to ever return nullptr when
+   * being called.
+   *
+   * Most programs don't want this so it defaults to false.
+   */
+  bool malloc_can_return_null = false;
+
+  uint64_t malloc_alignment = 16;
+
+  InterpreterOptions() = default;
+};
+
+} // namespace caffeine
+
+#endif

--- a/include/caffeine/Memory/MemHeap.h
+++ b/include/caffeine/Memory/MemHeap.h
@@ -202,6 +202,16 @@ public:
   Assertion check_valid(const Pointer& value);
 
   /**
+   * Get an assertion that checks whether the provided pointer points to the
+   * start of any existing allocation.
+   *
+   * If the pointer has already been resolved then this just checks that the
+   * offset is equal to 0. Otherwise, it compares the absolute value with those
+   * of all extant allocations.
+   */
+  Assertion check_starts_allocation(const Pointer& value);
+
+  /**
    * Resolve all the allocations that a pointer could point to.
    *
    * This returns a resolved pointer for each allocation. Although it takes a

--- a/interface/caffeine-builtins.c
+++ b/interface/caffeine-builtins.c
@@ -1,0 +1,23 @@
+
+#include "caffeine.h"
+#include <stddef.h>
+ 
+// This is a more limited version of malloc that expects size != 0
+void* caffeine_malloc(size_t size);
+
+// This is a more limited version of free that expects mem != nullptr
+void caffeine_free(void* mem);
+
+void* malloc(size_t size) {
+  if (size == 0)
+    return NULL;
+
+  return caffeine_malloc(size);
+}
+
+void free(void* mem) {
+  if (!mem)
+    return;
+
+  return caffeine_free(mem);
+}

--- a/src/Interpreter/CtxConstEval.cpp
+++ b/src/Interpreter/CtxConstEval.cpp
@@ -261,6 +261,15 @@ static ContextValue evaluate(Context* ctx, llvm::Constant* constant) {
   if (auto* cnst = llvm::dyn_cast<llvm::ConstantFP>(constant))
     return ContextValue(ConstantFloat::Create(cnst->getValueAPF()));
 
+  if (auto* null = llvm::dyn_cast<llvm::ConstantPointerNull>(constant)) {
+    auto pointer_bitwidth =
+        ctx->llvm_module()->getDataLayout().getPointerSizeInBits(
+            null->getType()->getPointerAddressSpace());
+
+    return ContextValue(
+        Pointer(ConstantInt::Create(llvm::APInt(pointer_bitwidth, 0))));
+  }
+
   if (auto* vec = llvm::dyn_cast<llvm::ConstantVector>(constant))
     return evaluate_const_vector(ctx, vec);
 

--- a/src/Interpreter/Interpreter.cpp
+++ b/src/Interpreter/Interpreter.cpp
@@ -977,11 +977,11 @@ ExecutionResult Interpreter::visitMalloc(llvm::CallInst& call) {
 ExecutionResult Interpreter::visitFree(llvm::CallInst& call) {
   CAFFEINE_ASSERT(call.getNumArgOperands() == 1, "Invalid free signature");
   CAFFEINE_ASSERT(call.getType()->isVoidTy(), "Invalid free signature");
-  CAFFEINE_ASSERT(call.getArgOperand(1)->getType()->isPointerTy(),
+  CAFFEINE_ASSERT(call.getArgOperand(0)->getType()->isPointerTy(),
                   "Invalid free signature");
 
   auto& heap = ctx->heap();
-  auto memptr = ctx->lookup(call.getArgOperand(1)).pointer();
+  auto memptr = ctx->lookup(call.getArgOperand(0)).pointer();
 
   auto is_valid_ptr = heap.check_starts_allocation(memptr);
   auto model = ctx->resolve(!is_valid_ptr);

--- a/src/Interpreter/Interpreter.cpp
+++ b/src/Interpreter/Interpreter.cpp
@@ -28,8 +28,9 @@ auto zip(R1& range1, R2& range2) {
          });
 }
 
-Interpreter::Interpreter(Executor* queue, Context* ctx, FailureLogger* logger)
-    : ctx{ctx}, queue{queue}, logger{logger} {}
+Interpreter::Interpreter(Executor* queue, Context* ctx, FailureLogger* logger,
+                         const InterpreterOptions& options)
+    : ctx{ctx}, queue{queue}, logger{logger}, options(options) {}
 
 void Interpreter::execute() {
   ExecutionResult exec;

--- a/src/Interpreter/Interpreter.cpp
+++ b/src/Interpreter/Interpreter.cpp
@@ -934,10 +934,10 @@ ExecutionResult Interpreter::visitAssert(llvm::CallInst& call) {
  * size to never be 0.
  */
 ExecutionResult Interpreter::visitMalloc(llvm::CallInst& call) {
-  CAFFEINE_ASSERT(call.getNumOperands() == 1, "Invalid malloc signature");
+  CAFFEINE_ASSERT(call.getNumArgOperands() == 1, "Invalid malloc signature");
   CAFFEINE_ASSERT(call.getType()->isPointerTy(), "Invalid malloc signature");
 
-  auto size = ctx->lookup(call.getOperand(0)).scalar();
+  auto size = ctx->lookup(call.getArgOperand(0)).scalar();
   const llvm::DataLayout& layout = call.getModule()->getDataLayout();
 
   CAFFEINE_ASSERT(size->type().is_int(), "Invalid malloc signature");

--- a/src/Interpreter/Interpreter.cpp
+++ b/src/Interpreter/Interpreter.cpp
@@ -975,13 +975,13 @@ ExecutionResult Interpreter::visitMalloc(llvm::CallInst& call) {
  * to be a null pointer.
  */
 ExecutionResult Interpreter::visitFree(llvm::CallInst& call) {
-  CAFFEINE_ASSERT(call.getNumOperands() == 1, "Invalid free signature");
+  CAFFEINE_ASSERT(call.getNumArgOperands() == 1, "Invalid free signature");
   CAFFEINE_ASSERT(call.getType()->isVoidTy(), "Invalid free signature");
-  CAFFEINE_ASSERT(call.getOperand(0)->getType()->isPointerTy(),
+  CAFFEINE_ASSERT(call.getArgOperand(1)->getType()->isPointerTy(),
                   "Invalid free signature");
 
   auto& heap = ctx->heap();
-  auto memptr = ctx->lookup(call.getOperand(0)).pointer();
+  auto memptr = ctx->lookup(call.getArgOperand(1)).pointer();
 
   auto is_valid_ptr = heap.check_starts_allocation(memptr);
   auto model = ctx->resolve(!is_valid_ptr);

--- a/src/Solver/Z3Solver.cpp
+++ b/src/Solver/Z3Solver.cpp
@@ -537,5 +537,11 @@ z3::expr Z3OpVisitor::visitLoadOp(const LoadOp& op) {
 z3::expr Z3OpVisitor::visitStoreOp(const StoreOp& op) {
   return z3::store(visit(op[0]), visit(op[1]), visit(op[2]));
 }
+z3::expr Z3OpVisitor::visitAllocOp(const AllocOp& op) {
+  auto value = visit(*op.default_value());
+  auto index_width = op.size()->type().bitwidth();
+
+  return z3::const_array(ctx->bv_sort(index_width), value);
+}
 
 } // namespace caffeine

--- a/src/Solver/Z3Solver.h
+++ b/src/Solver/Z3Solver.h
@@ -103,6 +103,7 @@ public:
 
   z3::expr visitLoadOp(const LoadOp& op);
   z3::expr visitStoreOp(const StoreOp& op);
+  z3::expr visitAllocOp(const AllocOp& op);
 
   // Unary operations
   z3::expr visitNot (const UnaryOp& op);

--- a/test/run-pass/mem/malloc-free.c
+++ b/test/run-pass/mem/malloc-free.c
@@ -9,7 +9,7 @@ void test(size_t x) {
   caffeine_assume(x >= 1);
 
   uint32_t* mem = malloc(x * sizeof(uint32_t));
-  
+
   for (uint32_t i = 0; i < x; ++i) {
     mem[i] = i * 2;
   }

--- a/test/run-pass/mem/malloc-free.c
+++ b/test/run-pass/mem/malloc-free.c
@@ -21,4 +21,6 @@ void test(size_t x) {
   for (uint32_t i = 0; i < x; ++i) {
     caffeine_assert(mem[i] == i * 2);
   }
+
+  free(mem);
 }

--- a/test/run-pass/mem/malloc-free.c
+++ b/test/run-pass/mem/malloc-free.c
@@ -1,17 +1,21 @@
-// SKIP TEST
 
 #include "caffeine.h"
 #include <stdint.h>
 #include <stdlib.h>
 
+// Needed to avoid vector load/stores
+__attribute__((noinline)) uint32_t mul2(uint32_t x) {
+  return x * 2;
+}
+
 void test(size_t x) {
-  caffeine_assume(x < 32);
+  caffeine_assume(x < 4);
   caffeine_assume(x >= 1);
 
   uint32_t* mem = malloc(x * sizeof(uint32_t));
 
   for (uint32_t i = 0; i < x; ++i) {
-    mem[i] = i * 2;
+    mem[i] = mul2(i);
   }
 
   for (uint32_t i = 0; i < x; ++i) {

--- a/test/run-pass/mem/malloc-free.c
+++ b/test/run-pass/mem/malloc-free.c
@@ -1,0 +1,20 @@
+// SKIP TEST
+
+#include "caffeine.h"
+#include <stdint.h>
+#include <stdlib.h>
+
+void test(size_t x) {
+  caffeine_assume(x < 32);
+  caffeine_assume(x >= 1);
+
+  uint32_t* mem = malloc(x * sizeof(uint32_t));
+  
+  for (uint32_t i = 0; i < x; ++i) {
+    mem[i] = i * 2;
+  }
+
+  for (uint32_t i = 0; i < x; ++i) {
+    caffeine_assert(mem[i] == i * 2);
+  }
+}


### PR DESCRIPTION
Pretty much as in title. 

Implements `malloc` and `free` by implementing two builtin functions `caffeine_malloc` and `caffeine_free` and then using an external module to implement the required behaviour of `malloc` and `free`. 

Closes #83. Closes #107.