### PR TITLE
Refactor cmake test declaration scripts

### DIFF
--- a/cmake/testutils.cmake
+++ b/cmake/testutils.cmake
@@ -1,4 +1,6 @@
 
+include(LLVMIRUtils)
+
 # Extract the first line of the file into OUTVAR
 function(extract_first_line RESULT FILE)
   file(READ "${FILE}" contents)
@@ -21,4 +23,54 @@ function(should_skip_test RESULT testfile)
   else()
     set(${RESULT} FALSE PARENT_SCOPE)
   endif()
+endfunction()
+
+# Utility function for declaring a test case
+function(declare_test TEST_NAME_OUT test)
+  file(RELATIVE_PATH test_name "${CMAKE_SOURCE_DIR}/test" "${test}")
+  should_skip_test(should_skip "${test}")
+
+  string(REGEX REPLACE "\\\\|/" "_" test_target "${test_name}")
+  
+  get_filename_component(test_ext "${test_name}" LAST_EXT)
+  
+  if("${test_ext}" STREQUAL ".ll" OR "${test_ext}" STREQUAL ".bc")
+    set(test_output "${CMAKE_BINARY_DIR}/test/${test_name}")
+  else()
+    set(test_output "${CMAKE_BINARY_DIR}/test/${test_name}.ll")
+  endif()
+
+  get_filename_component(output_dir "${test_output}" DIRECTORY)
+  get_filename_component(basename   "${test_output}" NAME_WLE)
+  file(MAKE_DIRECTORY "${output_dir}")
+
+  add_llvm_ir_library("${test_target}" "${test}")
+  
+  add_dependencies("${test_target}" caffeine-builtins)
+  target_include_directories("${test_target}" PRIVATE "$<TARGET_PROPERTY:caffeine-builtins,INCLUDE_DIRECTORIES>")
+  target_link_libraries     ("${test_target}" PRIVATE caffeine-builtins)
+  target_compile_options    ("${test_target}" PRIVATE -O3)
+
+  set_target_properties(
+    "${test_target}"
+    PROPERTIES
+    OUTPUT_NAME "${basename}"
+    LIBRARY_OUTPUT_DIRECTORY "${output_dir}"
+  )
+
+  if(should_skip)
+    add_test(
+      NAME "${test_name}"
+      COMMAND skip-test "$<TARGET_FILE:${test_target}>"
+    )
+  else()
+    add_test(
+      NAME "${test_name}"
+      COMMAND caffeine-bin "$<TARGET_FILE:${test_target}>" test
+    )
+  endif()
+
+  set("${TEST_NAME_OUT}" "${test_name}" PARENT_SCOPE)
+
+  set_tests_properties("${test_name}" PROPERTIES SKIP_RETURN_CODE 77)
 endfunction()

--- a/test/run-fail/CMakeLists.txt
+++ b/test/run-fail/CMakeLists.txt
@@ -4,39 +4,11 @@ file(GLOB_RECURSE tests CONFIGURE_DEPENDS *.c *.cpp *.cc *.ll *.bc)
 include(testutils)
 
 foreach(test ${tests})
-  file(RELATIVE_PATH test_file "${CMAKE_CURRENT_SOURCE_DIR}" "${test}")
-  should_skip_test(should_skip "${test}")
-  
-  string(REGEX REPLACE "\\\\|/" "_" TEST_TARGET "run-fail/${test_file}")
-  set(TEST_OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/${test_file}")
-
-  get_filename_component(output_dir "${TEST_OUTPUT}" DIRECTORY)
-  get_filename_component(basename "${TEST_OUTPUT}" NAME)
-  file(MAKE_DIRECTORY "${output_dir}")
-
-  add_llvm_ir_library("${TEST_TARGET}" "${test}")
-
-  add_dependencies("${TEST_TARGET}" caffeine-builtins)
-  target_link_libraries("${TEST_TARGET}" PRIVATE caffeine-builtins)
-  target_include_directories("${TEST_TARGET}" PRIVATE "${CMAKE_SOURCE_DIR}/interface")
-  target_compile_options("${TEST_TARGET}" PRIVATE -O3)
-
-  if (should_skip)
-    add_test(
-      NAME "run-fail/${test_file}"
-      COMMAND skip-test "${test}" test
-    )
-  else()
-    add_test(
-      NAME "run-fail/${test_file}"
-      COMMAND caffeine-bin "$<TARGET_FILE:${TEST_TARGET}>" test
-    )
-  endif()
+  declare_test(TEST_NAME "${test}")
 
   set_tests_properties(
-    "run-fail/${test_file}"
+    "${TEST_NAME}"
     PROPERTIES
     WILL_FAIL TRUE
-    SKIP_RETURN_CODE 77
   )
 endforeach()

--- a/test/run-pass/CMakeLists.txt
+++ b/test/run-pass/CMakeLists.txt
@@ -4,38 +4,5 @@ file(GLOB_RECURSE tests CONFIGURE_DEPENDS *.c *.cpp *.cc *.ll *.bc)
 include(testutils)
 
 foreach(test ${tests})
-  file(RELATIVE_PATH test_file "${CMAKE_CURRENT_SOURCE_DIR}" "${test}")
-  should_skip_test(should_skip "${test}")
-  
-  string(REGEX REPLACE "\\\\|/" "_" TEST_TARGET "run-pass/${test_file}")
-  set(TEST_OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/${test_file}")
-
-  get_filename_component(output_dir "${TEST_OUTPUT}" DIRECTORY)
-  get_filename_component(basename "${TEST_OUTPUT}" NAME)
-  file(MAKE_DIRECTORY "${output_dir}")
-
-  add_llvm_ir_library("${TEST_TARGET}" "${test}")
-
-  add_dependencies("${TEST_TARGET}" caffeine-builtins)
-  target_link_libraries("${TEST_TARGET}" PRIVATE caffeine-builtins)
-  target_include_directories("${TEST_TARGET}" PRIVATE "${CMAKE_SOURCE_DIR}/interface")
-  target_compile_options("${TEST_TARGET}" PRIVATE -O3)
-
-  if (should_skip)
-    add_test(
-      NAME "run-pass/${test_file}"
-      COMMAND skip-test "${test}" test
-    )
-  else()
-    add_test(
-      NAME "run-pass/${test_file}"
-      COMMAND caffeine-bin "$<TARGET_FILE:${TEST_TARGET}>" test
-    )
-  endif()
-
-  set_tests_properties(
-    "run-pass/${test_file}"
-    PROPERTIES
-    SKIP_RETURN_CODE 77
-  )
+  declare_test(TEST_NAME "${test}")
 endforeach()


### PR DESCRIPTION
There's two benefits to this:
- We only need to make changes in 1 place when we need to modify the cmake configuration of the tests
- The output IR files now mirror the input files in directory structure which is quite useful when running them manually
- I managed to make some of the used values a bit less dependent on directly structure

Other than that the change is mostly copy-paste.