### PR TITLE
Implement alloca instruction

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,3 +44,8 @@ if (NOT CLANG_FORMAT STREQUAL "CLANG_FORMAT-NOTFOUND")
   include(formatting)
 endif()
 
+# This is only supported for cmake >= 3.17
+if("${CMAKE_VERSION}" VERSION_GREATER_EQUAL "3.17")
+  list(APPEND CMAKE_CTEST_ARGUMENTS "--output-on-failure")
+endif()
+

--- a/include/caffeine/Interpreter/Context.h
+++ b/include/caffeine/Interpreter/Context.h
@@ -48,6 +48,10 @@ public:
   StackFrame& stack_top();
 
   // Utility methods for adding/removing stack frames
+  /**
+   * Note: This method also deallocates all stack-allocated allocations within
+   *       the current frame.
+   */
   void pop();
   void push(StackFrame&& frame);
   void push(const StackFrame& frame);

--- a/include/caffeine/Interpreter/Interpreter.h
+++ b/include/caffeine/Interpreter/Interpreter.h
@@ -72,6 +72,7 @@ public:
   ExecutionResult visitReturnInst(llvm::ReturnInst& inst);
   ExecutionResult visitCallInst(llvm::CallInst& inst);
   ExecutionResult visitSelectInst(llvm::SelectInst& inst);
+  ExecutionResult visitIntrinsicInst(llvm::IntrinsicInst& inst);
 
   ExecutionResult visitGetElementPtrInst(llvm::GetElementPtrInst& inst);
   ExecutionResult visitLoadInst(llvm::LoadInst& inst);

--- a/include/caffeine/Interpreter/Interpreter.h
+++ b/include/caffeine/Interpreter/Interpreter.h
@@ -80,6 +80,7 @@ public:
   ExecutionResult visitInsertElementInst(llvm::InsertElementInst& inst);
   ExecutionResult visitExtractElementInst(llvm::ExtractElementInst& inst);
   ExecutionResult visitShuffleVectorInst(llvm::ShuffleVectorInst& inst);
+  ExecutionResult visitAllocaInst(llvm::AllocaInst& inst);
 
 private:
   ExecutionResult visitExternFunc(llvm::CallInst& inst);

--- a/include/caffeine/Interpreter/StackFrame.h
+++ b/include/caffeine/Interpreter/StackFrame.h
@@ -10,6 +10,7 @@
 #include "caffeine/IR/Operation.h"
 #include "caffeine/Interpreter/Value.h"
 #include "caffeine/Memory/MemHeap.h"
+
 namespace caffeine {
 
 class Context;

--- a/include/caffeine/Interpreter/StackFrame.h
+++ b/include/caffeine/Interpreter/StackFrame.h
@@ -5,10 +5,11 @@
 #include <llvm/IR/BasicBlock.h>
 
 #include <unordered_map>
+#include <vector>
 
 #include "caffeine/IR/Operation.h"
 #include "caffeine/Interpreter/Value.h"
-
+#include "caffeine/Memory/MemHeap.h"
 namespace caffeine {
 
 class Context;
@@ -24,6 +25,9 @@ public:
   llvm::BasicBlock* current_block;
   llvm::BasicBlock* prev_block;
   llvm::BasicBlock::iterator current;
+
+  // Allocations within the current frame.
+  std::vector<AllocId> allocations;
 
   StackFrame(llvm::Function* function);
 

--- a/include/caffeine/Memory/MemHeap.h
+++ b/include/caffeine/Memory/MemHeap.h
@@ -16,6 +16,15 @@ class Assertion;
 class MemHeap;
 
 /**
+ * An allocation category.
+ *
+ * This is used to verify that, when a deallocation is being done, that the
+ * allocation was allocated by a compatible function. As an example, free
+ * cannot be used to deallocate an allocation created by alloca.
+ */
+enum class AllocationKind { Alloca, Malloc, Global };
+
+/**
  * A memory allocation (either alive or dead).
  *
  * In general, an allocation is a tuple (address, size, data, dead) where
@@ -38,19 +47,18 @@ private:
   ref<Operation> size_;
   ref<Operation> data_;
 
-  mutable size_t refcount = 0;
-
-  template <typename T, typename Deleter>
-  friend class ref;
+  AllocationKind kind_;
 
 public:
   Allocation(const ref<Operation>& address, const ref<Operation>& size,
-             const ref<Operation>& data);
+             const ref<Operation>& data, AllocationKind kind);
   Allocation(const ref<Operation>& address, const ConstantInt& size,
-             const ref<Operation>& data);
+             const ref<Operation>& data, AllocationKind kind);
 
   const ref<Operation>& size() const;
   ref<Operation>& size();
+
+  AllocationKind kind() const;
 
   const ref<Operation>& data() const;
   ref<Operation>& data();
@@ -175,7 +183,8 @@ public:
    * This will add the corresponding assertions to the context as well.
    */
   AllocId allocate(const ref<Operation>& size, const ref<Operation>& alignment,
-                   const ref<Operation>& data, Context& ctx);
+                   const ref<Operation>& data, AllocationKind kind,
+                   Context& ctx);
 
   /**
    * Deallocate an existing allocation.

--- a/include/caffeine/Memory/MemHeap.inl
+++ b/include/caffeine/Memory/MemHeap.inl
@@ -32,6 +32,10 @@ inline ref<Operation>& Allocation::address() {
   return address_;
 }
 
+inline AllocationKind Allocation::kind() const {
+  return kind_;
+}
+
 /***************************************************
  * Pointer                                         *
  ***************************************************/

--- a/src/Interpreter/Context.cpp
+++ b/src/Interpreter/Context.cpp
@@ -61,6 +61,15 @@ void Context::push(StackFrame&& frame) {
 }
 void Context::pop() {
   CAFFEINE_ASSERT(!stack.empty());
+
+  auto& frame = stack.back();
+  for (auto allocid : frame.allocations) {
+    CAFFEINE_ASSERT(heap()[allocid].kind() == AllocationKind::Alloca,
+                    "found non-stack allocation on the stack");
+
+    heap().deallocate(allocid);
+  }
+
   stack.pop_back();
 }
 

--- a/src/Interpreter/CtxConstEval.cpp
+++ b/src/Interpreter/CtxConstEval.cpp
@@ -222,7 +222,8 @@ ContextValue evaluate_global(Context* ctx, llvm::GlobalVariable* global) {
 
   auto alloc = ctx->heap_.allocate(
       ConstantInt::Create(llvm::APInt(bitwidth, array.data().size())),
-      ConstantInt::Create(llvm::APInt(bitwidth, alignment)), data, *ctx);
+      ConstantInt::Create(llvm::APInt(bitwidth, alignment)), data,
+      AllocationKind::Global, *ctx);
 
   auto pointer = ContextValue(
       Pointer(alloc, ConstantInt::Create(llvm::APInt(bitwidth, 0))));

--- a/src/Interpreter/Interpreter.cpp
+++ b/src/Interpreter/Interpreter.cpp
@@ -907,9 +907,9 @@ ExecutionResult Interpreter::visitAllocaInst(llvm::AllocaInst& inst) {
       AllocOp::Create(size_op, ConstantInt::Create(llvm::APInt(8, 0xDD))),
       AllocationKind::Alloca, *ctx);
 
-  frame.insert(
-      &inst, ContextValue(Pointer(
-                 alloc, ConstantInt::Create(llvm::APInt(ptr_width, 0)))));
+  frame.insert(&inst,
+               ContextValue(Pointer(
+                   alloc, ConstantInt::Create(llvm::APInt(ptr_width, 0)))));
   frame.allocations.push_back(alloc);
 
   return ExecutionResult::Continue;

--- a/src/Interpreter/Interpreter.cpp
+++ b/src/Interpreter/Interpreter.cpp
@@ -891,6 +891,7 @@ ExecutionResult Interpreter::visitStoreInst(llvm::StoreInst& inst) {
   return ExecutionResult::Stop;
 }
 ExecutionResult Interpreter::visitAllocaInst(llvm::AllocaInst& inst) {
+  auto& frame = ctx->stack_top();
   const auto& layout = inst.getModule()->getDataLayout();
 
   uint64_t size =
@@ -906,9 +907,10 @@ ExecutionResult Interpreter::visitAllocaInst(llvm::AllocaInst& inst) {
       AllocOp::Create(size_op, ConstantInt::Create(llvm::APInt(8, 0xDD))),
       AllocationKind::Alloca, *ctx);
 
-  ctx->stack_top().insert(
+  frame.insert(
       &inst, ContextValue(Pointer(
                  alloc, ConstantInt::Create(llvm::APInt(ptr_width, 0)))));
+  frame.allocations.push_back(alloc);
 
   return ExecutionResult::Continue;
 }

--- a/src/Memory/MemHeap.cpp
+++ b/src/Memory/MemHeap.cpp
@@ -236,6 +236,9 @@ bool MemHeap::check_live(const AllocId& alloc) const {
 
 Assertion MemHeap::check_valid(const Pointer& ptr) {
   if (ptr.is_resolved()) {
+    if (!check_live(ptr.alloc()))
+      return ConstantInt::Create(false);
+
     return ICmpOp::CreateICmp(ICmpOpcode::ULE, ptr.offset(),
                               (*this)[ptr.alloc()].size());
   }
@@ -259,6 +262,9 @@ Assertion MemHeap::check_valid(const Pointer& ptr) {
 
 Assertion MemHeap::check_starts_allocation(const Pointer& ptr) {
   if (ptr.is_resolved()) {
+    if (!check_live(ptr.alloc()))
+      return ConstantInt::Create(false);
+
     return ICmpOp::CreateICmp(ICmpOpcode::EQ, ptr.offset(), 0);
   }
 
@@ -282,6 +288,7 @@ llvm::SmallVector<Pointer, 1> MemHeap::resolve(const Pointer& ptr,
   if (ptr.is_resolved()) {
     if (!check_live(ptr.alloc()))
       return results;
+
     const Allocation& alloc = (*this)[ptr.alloc()];
     if (ctx.check(alloc.check_inbounds(ptr.offset(), 0)) == SolverResult::UNSAT)
       return results;

--- a/test/run-fail/CMakeLists.txt
+++ b/test/run-fail/CMakeLists.txt
@@ -12,3 +12,5 @@ foreach(test ${tests})
     WILL_FAIL TRUE
   )
 endforeach()
+
+target_compile_options(run-fail_mem_alloca-escaped.c PRIVATE -Wno-return-stack-address)

--- a/test/run-fail/mem/alloca-escaped.c
+++ b/test/run-fail/mem/alloca-escaped.c
@@ -1,0 +1,13 @@
+
+#include "caffeine.h"
+
+__attribute__((noinline)) unsigned* returns_internal_alloca(unsigned x) {
+  unsigned mem[32];
+  mem[5] = x;
+  return mem;
+}
+
+void test() {
+  unsigned* mem = returns_internal_alloca(5);
+  mem[2] = 0;
+}

--- a/test/run-fail/mem/free-stack-alloca.c
+++ b/test/run-fail/mem/free-stack-alloca.c
@@ -1,0 +1,11 @@
+
+#include "caffeine.h"
+#include <stdlib.h>
+
+void test(unsigned x) {
+  unsigned mem[32];
+  mem[5] = x;
+  free(mem);
+
+  caffeine_assert(mem[5] == x);
+}

--- a/test/run-fail/mem/free-stack-alloca.c
+++ b/test/run-fail/mem/free-stack-alloca.c
@@ -7,5 +7,6 @@ void test(unsigned x) {
   mem[5] = x;
   free(mem);
 
+  // Needed since otherwise clang will optimize away the free
   caffeine_assert(mem[5] == x);
 }

--- a/test/run-pass/mem/alloca-basic.c
+++ b/test/run-pass/mem/alloca-basic.c
@@ -1,0 +1,24 @@
+
+#include "caffeine.h"
+#include <stdint.h>
+#include <stdlib.h>
+
+// Needed to avoid vector load/stores
+__attribute__((noinline)) uint32_t mul2(uint32_t x) {
+  return x * 2;
+}
+
+void test(size_t x) {
+  caffeine_assume(x < 4);
+  caffeine_assume(x >= 1);
+
+  uint32_t mem[4];
+
+  for (uint32_t i = 0; i < x; ++i) {
+    mem[i] = mul2(i);
+  }
+
+  for (uint32_t i = 0; i < x; ++i) {
+    caffeine_assert(mem[i] == i * 2);
+  }
+}

--- a/test/unit/Memory/MemHeap.cpp
+++ b/test/unit/Memory/MemHeap.cpp
@@ -50,7 +50,7 @@ TEST_F(MemHeapTests, resolve_pointer_single) {
   auto alloc = heap.allocate(
       size, align,
       AllocOp::Create(size, ConstantInt::Create(llvm::APInt(8, 0xDD))),
-      context);
+      AllocationKind::Alloca, context);
   auto offset = Constant::Create(Type::int_ty(index_size), "offset");
 
   context.add(ICmpOp::CreateICmp(ICmpOpcode::ULT, offset, size));


### PR DESCRIPTION
Here's what was changed:
- We now have support for the `llvm.lifetime.(start|end).*` intrinsics. They have no effects and so they're ignored.
- Allocations now have a kind to verify that the right deallocation method is being used. (e.g. so we can emit errors if someone tries to free a global or stack allocation)
- Extra logic to delete stack allocations upon returning from a function
- And of course, implementing the alloca instruction itself

I've also discovered that cmake versions 3.17+ allow you to add flags to the ctest invocation so I've configured it to add the `--output-on-default` flag if using a supported version.

Closes #50.