### PR TITLE
Implement calloc

### DIFF
--- a/include/caffeine/Interpreter/Interpreter.h
+++ b/include/caffeine/Interpreter/Interpreter.h
@@ -90,6 +90,7 @@ private:
   ExecutionResult visitAssert(llvm::CallInst& inst);
 
   ExecutionResult visitMalloc(llvm::CallInst& inst);
+  ExecutionResult visitCalloc(llvm::CallInst& inst);
   ExecutionResult visitFree(llvm::CallInst& inst);
 };
 

--- a/interface/caffeine-builtins.c
+++ b/interface/caffeine-builtins.c
@@ -4,6 +4,7 @@
  
 // This is a more limited version of malloc that expects size != 0
 void* caffeine_malloc(size_t size);
+void* caffeine_calloc(size_t size);
 
 // This is a more limited version of free that expects mem != nullptr
 void caffeine_free(void* mem);
@@ -13,6 +14,15 @@ void* malloc(size_t size) {
     return NULL;
 
   return caffeine_malloc(size);
+}
+
+void* calloc(size_t num, size_t size) {
+  size_t total = num * size;
+
+  if (total == 0)
+    return NULL;
+
+  return caffeine_calloc(total);
 }
 
 void free(void* mem) {

--- a/src/Interpreter/Interpreter.cpp
+++ b/src/Interpreter/Interpreter.cpp
@@ -933,6 +933,8 @@ ExecutionResult Interpreter::visitExternFunc(llvm::CallInst& call) {
 
   if (name == "caffeine_malloc")
     return visitMalloc(call);
+  if (name == "caffeine_calloc")
+    return visitCalloc(call);
   if (name == "caffeine_free")
     return visitFree(call);
 
@@ -999,6 +1001,43 @@ ExecutionResult Interpreter::visitMalloc(llvm::CallInst& call) {
       size_op,
       ConstantInt::Create(llvm::APInt(ptr_width, options.malloc_alignment)),
       AllocOp::Create(size_op, ConstantInt::Create(llvm::APInt(8, 0xDD))),
+      AllocationKind::Malloc, *ctx);
+
+  ctx->stack_top().insert(
+      &call, ContextValue(Pointer(
+                 alloc, ConstantInt::Create(llvm::APInt(ptr_width, 0)))));
+
+  return ExecutionResult::Continue;
+}
+ExecutionResult Interpreter::visitCalloc(llvm::CallInst& call) {
+  CAFFEINE_ASSERT(call.getNumArgOperands() == 1, "Invalid malloc signature");
+  CAFFEINE_ASSERT(call.getType()->isPointerTy(), "Invalid malloc signature");
+
+  auto size = ctx->lookup(call.getArgOperand(0)).scalar();
+  const llvm::DataLayout& layout = call.getModule()->getDataLayout();
+
+  CAFFEINE_ASSERT(size->type().is_int(), "Invalid malloc signature");
+  CAFFEINE_ASSERT(
+      size->type().bitwidth() ==
+          layout.getIndexSizeInBits(call.getType()->getPointerAddressSpace()),
+      "Invalid malloc signature");
+
+  auto ptr_width =
+      layout.getPointerSizeInBits(call.getType()->getPointerAddressSpace());
+
+  if (options.malloc_can_return_null) {
+    Context forked = ctx->fork();
+    forked.stack_top().insert(
+        &call,
+        ContextValue(Pointer(ConstantInt::Create(llvm::APInt(ptr_width, 0)))));
+    queue->add_context(std::move(forked));
+  }
+
+  auto size_op = UnaryOp::CreateTruncOrZExt(Type::int_ty(ptr_width), size);
+  auto alloc = ctx->heap().allocate(
+      size_op,
+      ConstantInt::Create(llvm::APInt(ptr_width, options.malloc_alignment)),
+      AllocOp::Create(size_op, ConstantInt::Create(llvm::APInt(8, 0x00))),
       AllocationKind::Malloc, *ctx);
 
   ctx->stack_top().insert(

--- a/src/Interpreter/Interpreter.cpp
+++ b/src/Interpreter/Interpreter.cpp
@@ -1010,17 +1010,17 @@ ExecutionResult Interpreter::visitMalloc(llvm::CallInst& call) {
   return ExecutionResult::Continue;
 }
 ExecutionResult Interpreter::visitCalloc(llvm::CallInst& call) {
-  CAFFEINE_ASSERT(call.getNumArgOperands() == 1, "Invalid malloc signature");
-  CAFFEINE_ASSERT(call.getType()->isPointerTy(), "Invalid malloc signature");
+  CAFFEINE_ASSERT(call.getNumArgOperands() == 1, "Invalid calloc signature");
+  CAFFEINE_ASSERT(call.getType()->isPointerTy(), "Invalid calloc signature");
 
   auto size = ctx->lookup(call.getArgOperand(0)).scalar();
   const llvm::DataLayout& layout = call.getModule()->getDataLayout();
 
-  CAFFEINE_ASSERT(size->type().is_int(), "Invalid malloc signature");
+  CAFFEINE_ASSERT(size->type().is_int(), "Invalid calloc signature");
   CAFFEINE_ASSERT(
       size->type().bitwidth() ==
           layout.getIndexSizeInBits(call.getType()->getPointerAddressSpace()),
-      "Invalid malloc signature");
+      "Invalid calloc signature");
 
   auto ptr_width =
       layout.getPointerSizeInBits(call.getType()->getPointerAddressSpace());

--- a/test/run-pass/mem/calloc-is-all-zero.c
+++ b/test/run-pass/mem/calloc-is-all-zero.c
@@ -1,0 +1,11 @@
+
+#include "caffeine.h"
+#include <stdint.h>
+#include <stdlib.h>
+
+void test() {
+  uint32_t* mem = (uint32_t*)calloc(32, sizeof(uint32_t));
+
+  for (size_t i = 0; i < 32; ++i)
+    caffeine_assert(mem[i] == 0);
+}


### PR DESCRIPTION
As in title.

The implementation is basically a copy-paste implementation of malloc except that the memory is initialized to zero.

Closes #128.