### PR TITLE
Miscellaneous refactoring

### DIFF
--- a/include/caffeine/IR/Operation.h
+++ b/include/caffeine/IR/Operation.h
@@ -485,6 +485,30 @@ public:
   static ref<Operation> CreateFRem(const ref<Operation>& lhs,
                                    const ref<Operation>& rhs);
 
+  // Utility methods for creating integer arithmetic when one of the operations
+  // is a constant.
+
+#define CAFFEINE_DECL_BINOP_INT_CONST(op)                                      \
+  static ref<Operation> Create##op(const ref<Operation>& lhs, int64_t rhs);    \
+  static ref<Operation> Create##op(int64_t lhs, const ref<Operation>& rhs)
+
+  CAFFEINE_DECL_BINOP_INT_CONST(Add);
+  CAFFEINE_DECL_BINOP_INT_CONST(Sub);
+  CAFFEINE_DECL_BINOP_INT_CONST(Mul);
+  CAFFEINE_DECL_BINOP_INT_CONST(UDiv);
+  CAFFEINE_DECL_BINOP_INT_CONST(SDiv);
+  CAFFEINE_DECL_BINOP_INT_CONST(URem);
+  CAFFEINE_DECL_BINOP_INT_CONST(SRem);
+
+  CAFFEINE_DECL_BINOP_INT_CONST(And);
+  CAFFEINE_DECL_BINOP_INT_CONST(Or);
+  CAFFEINE_DECL_BINOP_INT_CONST(Xor);
+  CAFFEINE_DECL_BINOP_INT_CONST(Shl);
+  CAFFEINE_DECL_BINOP_INT_CONST(LShr);
+  CAFFEINE_DECL_BINOP_INT_CONST(AShr);
+
+#undef CAFFEINE_DECL_BINOP_INT_CONST
+
   static bool classof(const Operation* op);
 };
 

--- a/src/IR/Operation.cpp
+++ b/src/IR/Operation.cpp
@@ -701,6 +701,51 @@ DECL_BINOP_CREATE(FMul, ASSERT_FP);
 DECL_BINOP_CREATE(FDiv, ASSERT_FP);
 DECL_BINOP_CREATE(FRem, ASSERT_FP);
 
+#define DEF_INT_BINOP_CONST_CREATE_DETAIL(opcode, ty, signed)                  \
+  ref<Operation> BinaryOp::Create##opcode(const ref<Operation>& lhs, ty rhs) { \
+    CAFFEINE_ASSERT(lhs, "lhs is null");                                       \
+    CAFFEINE_ASSERT(lhs->type().is_int());                                     \
+                                                                               \
+    return BinaryOp::Create##opcode(                                           \
+        lhs, ConstantInt::Create(                                              \
+                 llvm::APInt(lhs->type().bitwidth(), rhs, signed)));           \
+  }                                                                            \
+  ref<Operation> BinaryOp::Create##opcode(ty lhs, const ref<Operation>& rhs) { \
+    CAFFEINE_ASSERT(rhs, "rhs is null");                                       \
+    CAFFEINE_ASSERT(rhs->type().is_int());                                     \
+                                                                               \
+    return BinaryOp::Create##opcode(                                           \
+        ConstantInt::Create(llvm::APInt(rhs->type().bitwidth(), lhs, signed)), \
+        rhs);                                                                  \
+  }                                                                            \
+  static_assert(true)
+
+// Note: if we want to add more overloads here then it'll be necessary to
+// overload for all integer types as once you've got 2 then C++ can no longer
+// figure out which to coerce to.
+//
+// I'm leaving this here so we can easily add such methods if we decide to.
+#define DEF_INT_BINOP_CONST_CREATE(opcode)                                     \
+  DEF_INT_BINOP_CONST_CREATE_DETAIL(opcode, int64_t, true)
+
+DEF_INT_BINOP_CONST_CREATE(Add);
+DEF_INT_BINOP_CONST_CREATE(Sub);
+DEF_INT_BINOP_CONST_CREATE(Mul);
+DEF_INT_BINOP_CONST_CREATE(UDiv);
+DEF_INT_BINOP_CONST_CREATE(SDiv);
+DEF_INT_BINOP_CONST_CREATE(URem);
+DEF_INT_BINOP_CONST_CREATE(SRem);
+
+DEF_INT_BINOP_CONST_CREATE(And);
+DEF_INT_BINOP_CONST_CREATE(Or);
+DEF_INT_BINOP_CONST_CREATE(Xor);
+DEF_INT_BINOP_CONST_CREATE(Shl);
+DEF_INT_BINOP_CONST_CREATE(LShr);
+DEF_INT_BINOP_CONST_CREATE(AShr);
+
+#undef DEF_INT_BINOP_CONST_CREATE
+#undef DEF_INT_BINOP_CONST_CREATE_DETAIL
+
 /***************************************************
  * UnaryOp                                         *
  ***************************************************/

--- a/src/Interpreter/CtxConstEval.cpp
+++ b/src/Interpreter/CtxConstEval.cpp
@@ -64,7 +64,9 @@ static ContextValue evaluate_expr(Context* ctx, llvm::ConstantExpr* expr) {
 #define OPERAND(expr, num)                                                     \
   evaluate(ctx, llvm::cast<llvm::Constant>((expr)->getOperand(num)))
 #define UNARY_OP(expr_) transform((expr_), OPERAND(expr, 0))
-#define BINARY_OP(expr_) transform((expr_), OPERAND(expr, 0), OPERAND(expr, 1))
+#define BINARY_OP(expr_)                                                       \
+  transform([=](const auto& a, const auto& b) { return (expr_)(a, b); },       \
+            OPERAND(expr, 0), OPERAND(expr, 1))
 #define CAST_OP(expr_)                                                         \
   transform(                                                                   \
       [=, type = Type::from_llvm(expr->getType())](                            \

--- a/src/Interpreter/Interpreter.cpp
+++ b/src/Interpreter/Interpreter.cpp
@@ -28,6 +28,9 @@ auto zip(R1& range1, R2& range2) {
          });
 }
 
+#define WRAP_FUNC(func) \
+  [](const auto&... args) { return (func)(args...); }
+
 Interpreter::Interpreter(Executor* queue, Context* ctx, FailureLogger* logger,
                          const InterpreterOptions& options)
     : ctx{ctx}, queue{queue}, logger{logger}, options(options) {}
@@ -63,7 +66,7 @@ ExecutionResult Interpreter::visitAdd(llvm::BinaryOperator& op) {
   auto lhs = ctx->lookup(op.getOperand(0));
   auto rhs = ctx->lookup(op.getOperand(1));
 
-  frame.insert(&op, transform(BinaryOp::CreateAdd, lhs, rhs));
+  frame.insert(&op, transform(WRAP_FUNC(BinaryOp::CreateAdd), lhs, rhs));
 
   return ExecutionResult::Continue;
 }
@@ -73,7 +76,7 @@ ExecutionResult Interpreter::visitSub(llvm::BinaryOperator& op) {
   auto lhs = ctx->lookup(op.getOperand(0));
   auto rhs = ctx->lookup(op.getOperand(1));
 
-  frame.insert(&op, transform(BinaryOp::CreateSub, lhs, rhs));
+  frame.insert(&op, transform(WRAP_FUNC(BinaryOp::CreateSub), lhs, rhs));
 
   return ExecutionResult::Continue;
 }
@@ -83,7 +86,7 @@ ExecutionResult Interpreter::visitMul(llvm::BinaryOperator& op) {
   auto lhs = ctx->lookup(op.getOperand(0));
   auto rhs = ctx->lookup(op.getOperand(1));
 
-  frame.insert(&op, transform(BinaryOp::CreateMul, lhs, rhs));
+  frame.insert(&op, transform(WRAP_FUNC(BinaryOp::CreateMul), lhs, rhs));
 
   return ExecutionResult::Continue;
 }
@@ -200,7 +203,7 @@ ExecutionResult Interpreter::visitShl(llvm::BinaryOperator& op) {
   auto lhs = ctx->lookup(op.getOperand(0));
   auto rhs = ctx->lookup(op.getOperand(1));
 
-  frame.insert(&op, transform(BinaryOp::CreateShl, lhs, rhs));
+  frame.insert(&op, transform(WRAP_FUNC(BinaryOp::CreateShl), lhs, rhs));
 
   return ExecutionResult::Continue;
 }
@@ -210,7 +213,7 @@ ExecutionResult Interpreter::visitLShr(llvm::BinaryOperator& op) {
   auto lhs = ctx->lookup(op.getOperand(0));
   auto rhs = ctx->lookup(op.getOperand(1));
 
-  frame.insert(&op, transform(BinaryOp::CreateLShr, lhs, rhs));
+  frame.insert(&op, transform(WRAP_FUNC(BinaryOp::CreateLShr), lhs, rhs));
 
   return ExecutionResult::Continue;
 }
@@ -220,7 +223,7 @@ ExecutionResult Interpreter::visitAShr(llvm::BinaryOperator& op) {
   auto lhs = ctx->lookup(op.getOperand(0));
   auto rhs = ctx->lookup(op.getOperand(1));
 
-  frame.insert(&op, transform(BinaryOp::CreateAShr, lhs, rhs));
+  frame.insert(&op, transform(WRAP_FUNC(BinaryOp::CreateAShr), lhs, rhs));
 
   return ExecutionResult::Continue;
 }
@@ -230,7 +233,7 @@ ExecutionResult Interpreter::visitAnd(llvm::BinaryOperator& op) {
   auto lhs = ctx->lookup(op.getOperand(0));
   auto rhs = ctx->lookup(op.getOperand(1));
 
-  frame.insert(&op, transform(BinaryOp::CreateAnd, lhs, rhs));
+  frame.insert(&op, transform(WRAP_FUNC(BinaryOp::CreateAnd), lhs, rhs));
 
   return ExecutionResult::Continue;
 }
@@ -240,7 +243,7 @@ ExecutionResult Interpreter::visitOr(llvm::BinaryOperator& op) {
   auto lhs = ctx->lookup(op.getOperand(0));
   auto rhs = ctx->lookup(op.getOperand(1));
 
-  frame.insert(&op, transform(BinaryOp::CreateOr, lhs, rhs));
+  frame.insert(&op, transform(WRAP_FUNC(BinaryOp::CreateOr), lhs, rhs));
 
   return ExecutionResult::Continue;
 }
@@ -250,7 +253,7 @@ ExecutionResult Interpreter::visitXor(llvm::BinaryOperator& op) {
   auto lhs = ctx->lookup(op.getOperand(0));
   auto rhs = ctx->lookup(op.getOperand(1));
 
-  frame.insert(&op, transform(BinaryOp::CreateXor, lhs, rhs));
+  frame.insert(&op, transform(WRAP_FUNC(BinaryOp::CreateXor), lhs, rhs));
 
   return ExecutionResult::Continue;
 }
@@ -259,7 +262,7 @@ ExecutionResult Interpreter::visitNot(llvm::BinaryOperator& op) {
 
   auto operand = ctx->lookup(op.getOperand(0));
 
-  frame.insert(&op, transform(UnaryOp::CreateNot, operand));
+  frame.insert(&op, transform(WRAP_FUNC(UnaryOp::CreateNot), operand));
 
   return ExecutionResult::Continue;
 }
@@ -270,7 +273,7 @@ ExecutionResult Interpreter::visitFAdd(llvm::BinaryOperator& op) {
   auto lhs = ctx->lookup(op.getOperand(0));
   auto rhs = ctx->lookup(op.getOperand(1));
 
-  frame.insert(&op, transform(BinaryOp::CreateFAdd, lhs, rhs));
+  frame.insert(&op, transform(WRAP_FUNC(BinaryOp::CreateFAdd), lhs, rhs));
 
   return ExecutionResult::Continue;
 }
@@ -280,7 +283,7 @@ ExecutionResult Interpreter::visitFSub(llvm::BinaryOperator& op) {
   auto lhs = ctx->lookup(op.getOperand(0));
   auto rhs = ctx->lookup(op.getOperand(1));
 
-  frame.insert(&op, transform(BinaryOp::CreateFSub, lhs, rhs));
+  frame.insert(&op, transform(WRAP_FUNC(BinaryOp::CreateFSub), lhs, rhs));
 
   return ExecutionResult::Continue;
 }
@@ -290,7 +293,7 @@ ExecutionResult Interpreter::visitFMul(llvm::BinaryOperator& op) {
   auto lhs = ctx->lookup(op.getOperand(0));
   auto rhs = ctx->lookup(op.getOperand(1));
 
-  frame.insert(&op, transform(BinaryOp::CreateFMul, lhs, rhs));
+  frame.insert(&op, transform(WRAP_FUNC(BinaryOp::CreateFMul), lhs, rhs));
 
   return ExecutionResult::Continue;
 }
@@ -300,7 +303,7 @@ ExecutionResult Interpreter::visitFDiv(llvm::BinaryOperator& op) {
   auto lhs = ctx->lookup(op.getOperand(0));
   auto rhs = ctx->lookup(op.getOperand(1));
 
-  frame.insert(&op, transform(BinaryOp::CreateFAdd, lhs, rhs));
+  frame.insert(&op, transform(WRAP_FUNC(BinaryOp::CreateFAdd), lhs, rhs));
 
   return ExecutionResult::Continue;
 }


### PR DESCRIPTION
It takes a lot of typing to create a binary operation with a constant integer operand. This PR adds methods that remove some of the useless boilerplate.

Specifically, for each `CreateXXX` method in `BinaryOp` there are now two more overloads that allow passing an integer in on each side. I've also gone through the codebase and simplified all the places where the new methods could apply.