### PR TITLE
Check read width when validating pointers

### DIFF
--- a/include/caffeine/Memory/MemHeap.h
+++ b/include/caffeine/Memory/MemHeap.h
@@ -208,7 +208,7 @@ public:
    * the absolute value with those of all existant allocations and returns an
    * assertion that the pointer points within one of them.
    */
-  Assertion check_valid(const Pointer& value);
+  Assertion check_valid(const Pointer& value, uint32_t width);
 
   /**
    * Get an assertion that checks whether the provided pointer points to the

--- a/src/Interpreter/Interpreter.cpp
+++ b/src/Interpreter/Interpreter.cpp
@@ -806,7 +806,8 @@ ExecutionResult Interpreter::visitLoadInst(llvm::LoadInst& inst) {
   // TODO: What are the vector semantics for loads?
   const Pointer& pointer = operand.pointer();
 
-  auto assertion = ctx->heap().check_valid(pointer);
+  auto assertion =
+      ctx->heap().check_valid(pointer, layout.getTypeStoreSize(inst.getType()));
   auto model = ctx->resolve(!assertion);
   if (model->result() == SolverResult::SAT) {
     logger->log_failure(*model, *ctx, Failure(!assertion));
@@ -856,7 +857,8 @@ ExecutionResult Interpreter::visitStoreInst(llvm::StoreInst& inst) {
   const llvm::DataLayout& layout = inst.getModule()->getDataLayout();
   const Pointer& pointer = dest.pointer();
 
-  auto assertion = ctx->heap().check_valid(pointer);
+  auto assertion = ctx->heap().check_valid(
+      pointer, layout.getTypeStoreSize(inst.getOperand(0)->getType()));
   auto model = ctx->resolve(!assertion);
   if (model->result() == SolverResult::SAT) {
     logger->log_failure(*model, *ctx, Failure(!assertion));

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -18,5 +18,6 @@ if ("${CLANGXX}" STREQUAL "CLANGXX-NOTFOUND")
 add_subdirectory(unit)
 add_subdirectory(run-pass)
 add_subdirectory(run-fail)
+add_subdirectory(regression)
 
 add_executable(skip-test skip-test.cpp)

--- a/test/regression/CMakeLists.txt
+++ b/test/regression/CMakeLists.txt
@@ -1,0 +1,43 @@
+
+include(testutils)
+
+# Add a regression test case. Regression test files are named
+# according to the following convention:
+#
+#     issue-<issue_no>.(pass|fail).<arbitrary-user-string>.<ext>
+#
+# This designed to quickly give context as well as a specification
+# of whether the test is supposed to pass or fail. Other than that
+# these use the normal test infra structure so putting the string
+# "SKIP TEST" anywhere on the first line of the test file will
+# cause it to be skipped.
+function(add_regression_test source)
+  get_filename_component(basename "${source}" NAME)
+
+  declare_test(TEST_NAME "${source}")
+
+  if(basename MATCHES "^issue-[0-9]+\.(pass|fail)\.")
+    if(CMAKE_MATCH_1 STREQUAL "fail")
+      set_tests_properties(
+        "${TEST_NAME}"
+        PROPERTIES
+        WILL_FAIL TRUE
+      )
+    endif()
+  else()
+    message(SEND_ERROR
+      " Regression test didn't match naming convention!\n"
+      " Expected the start of the test name to match\n"
+      "    issue-[0-9]+\.(pass|fail)\.\n"
+      " The actual test name was\n"
+      "    ${basename}\n"
+    )
+  endif()
+endfunction()
+
+file(GLOB tests CONFIGURE_DEPENDS *.c *.ll *.cpp)
+
+foreach(test ${tests})
+  add_regression_test("${test}")
+endforeach()
+

--- a/test/regression/issue-103.fail.write-spans-allocation-boundary.c
+++ b/test/regression/issue-103.fail.write-spans-allocation-boundary.c
@@ -1,0 +1,9 @@
+
+#include "caffeine.h"
+#include <stdint.h>
+#include <stdlib.h>
+
+void test() {
+  volatile uint32_t* mem = (volatile uint32_t*)malloc(10);
+  mem[2] = 0;
+}

--- a/test/regression/issue-103.pass.write-at-end-of-allocation.c
+++ b/test/regression/issue-103.pass.write-at-end-of-allocation.c
@@ -1,0 +1,9 @@
+
+#include "caffeine.h"
+#include <stdint.h>
+#include <stdlib.h>
+
+void test() {
+  volatile uint32_t* mem = (volatile uint32_t*)malloc(sizeof(uint32_t) * 3);
+  mem[2] = 0;
+}

--- a/test/unit/Memory/MemHeap.cpp
+++ b/test/unit/Memory/MemHeap.cpp
@@ -57,7 +57,7 @@ TEST_F(MemHeapTests, resolve_pointer_single) {
 
   auto ptr = Pointer(BinaryOp::CreateAdd(heap[alloc].address(), offset));
 
-  ASSERT_EQ(context.check(!heap.check_valid(ptr)), SolverResult::UNSAT);
+  ASSERT_EQ(context.check(!heap.check_valid(ptr, 0)), SolverResult::UNSAT);
 
   auto res = heap.resolve(ptr, context);
 


### PR DESCRIPTION
Previously a read that was only partially within an allocation wouldn't trigger an error but would instead just silently delete that branch. That was incorrect and it now will properly pass a test failure.

To make it easier to keep track of regression tests like this I've added a `test/regressions` folder with tests that are meant to be named in a defined format that makes it easier to keep look at the file name and find the relevant issue.

Closes #103 