### PR TITLE
Implement non-ConstantData globals

### DIFF
--- a/include/caffeine/IR/Operation.inl
+++ b/include/caffeine/IR/Operation.inl
@@ -257,6 +257,10 @@ inline const SharedArray& ConstantArray::data() const {
   return std::get<SharedArray>(inner_);
 }
 
+inline ref<Operation> ConstantArray::size() const {
+  return ConstantInt::Create(llvm::APInt(type().bitwidth(), data().size()));
+}
+
 /***************************************************
  * BinaryOp                                        *
  ***************************************************/
@@ -340,10 +344,7 @@ inline bool FCmpOp::is_unordered() const {
 /***************************************************
  * AllocOp                                         *
  ***************************************************/
-inline ref<Operation>& AllocOp::size() {
-  return operand_at(0);
-}
-inline const ref<Operation>& AllocOp::size() const {
+inline ref<Operation> AllocOp::size() const {
   return operand_at(0);
 }
 
@@ -374,6 +375,10 @@ inline const ref<Operation>& LoadOp::offset() const {
 /***************************************************
  * StoreOp                                         *
  ***************************************************/
+inline ref<Operation> StoreOp::size() const {
+  return llvm::cast<ArrayBase>(*data()).size();
+}
+
 inline ref<Operation>& StoreOp::data() {
   return operand_at(0);
 }
@@ -429,6 +434,11 @@ inline bool ICmpOp::classof(const Operation* op) {
 inline bool FCmpOp::classof(const Operation* op) {
   return detail::opcode(fcmp_base, 0, 0) <= op->opcode() &&
          op->opcode() <= detail::opcode(fcmp_base, 3, 0xF);
+}
+
+inline bool ArrayBase::classof(const Operation* op) {
+  return op->opcode() == ConstantArray || op->opcode() == Alloc ||
+         op->opcode() == Store;
 }
 
 #undef CAFFEINE_OP_DECL_CLASSOF

--- a/include/caffeine/IR/Visitor.h
+++ b/include/caffeine/IR/Visitor.h
@@ -88,18 +88,20 @@ public:
   void visitOperation(transform_t<Operation>&) {}
 
   // clang-format off
+  RetTy visitArray(transform_t<Array>& O) { return CAFFEINE_OP_DELEGATE(Operation); }
+
   RetTy visitConstant     (transform_t<Constant>     & O) { return CAFFEINE_OP_DELEGATE(Operation); }
   RetTy visitConstantInt  (transform_t<ConstantInt>  & O) { return CAFFEINE_OP_DELEGATE(Operation); }
   RetTy visitConstantFloat(transform_t<ConstantFloat>& O) { return CAFFEINE_OP_DELEGATE(Operation); }
-  RetTy visitConstantArray(transform_t<ConstantArray>& O) { return CAFFEINE_OP_DELEGATE(Operation); }
+  RetTy visitConstantArray(transform_t<ConstantArray>& O) { return CAFFEINE_OP_DELEGATE(ArrayBase); }
   RetTy visitUndef        (transform_t<Undef>        & O) { return CAFFEINE_OP_DELEGATE(Operation); }
 
   RetTy visitBinaryOp(transform_t<BinaryOp>& O) { return CAFFEINE_OP_DELEGATE(Operation); }
   RetTy visitUnaryOp (transform_t<UnaryOp> & O) { return CAFFEINE_OP_DELEGATE(Operation); }
   RetTy visitSelectOp(transform_t<SelectOp>& O) { return CAFFEINE_OP_DELEGATE(Operation); }
 
-  RetTy visitAllocOp(transform_t<AllocOp>& O) { return CAFFEINE_OP_DELEGATE(Operation); }
-  RetTy visitStoreOp(transform_t<StoreOp>& O) { return CAFFEINE_OP_DELEGATE(Operation); }
+  RetTy visitAllocOp(transform_t<AllocOp>& O) { return CAFFEINE_OP_DELEGATE(ArrayBase); }
+  RetTy visitStoreOp(transform_t<StoreOp>& O) { return CAFFEINE_OP_DELEGATE(ArrayBase); }
   RetTy visitLoadOp (transform_t<LoadOp>&  O) { return CAFFEINE_OP_DELEGATE(Operation); }
 
   // Binary operations

--- a/include/caffeine/IR/Visitor.h
+++ b/include/caffeine/IR/Visitor.h
@@ -88,7 +88,7 @@ public:
   void visitOperation(transform_t<Operation>&) {}
 
   // clang-format off
-  RetTy visitArray(transform_t<Array>& O) { return CAFFEINE_OP_DELEGATE(Operation); }
+  RetTy visitArrayBase(transform_t<ArrayBase>& O) { return CAFFEINE_OP_DELEGATE(Operation); }
 
   RetTy visitConstant     (transform_t<Constant>     & O) { return CAFFEINE_OP_DELEGATE(Operation); }
   RetTy visitConstantInt  (transform_t<ConstantInt>  & O) { return CAFFEINE_OP_DELEGATE(Operation); }

--- a/src/IR/Operation.cpp
+++ b/src/IR/Operation.cpp
@@ -349,9 +349,9 @@ ref<Operation> ConstantFloat::Create(double value) {
  * ConstantArray                                   *
  ***************************************************/
 ConstantArray::ConstantArray(Type t, const SharedArray& array)
-    : Operation(Opcode::ConstantArray, t, array) {}
+    : ArrayBase(Opcode::ConstantArray, t, array) {}
 ConstantArray::ConstantArray(Type t, SharedArray&& array)
-    : Operation(Opcode::ConstantArray, t, std::move(array)) {}
+    : ArrayBase(Opcode::ConstantArray, t, std::move(array)) {}
 
 ref<Operation> ConstantArray::Create(Type index_ty, const SharedArray& array) {
   CAFFEINE_ASSERT(index_ty.is_int(),
@@ -1148,7 +1148,7 @@ ref<Operation> FCmpOp::CreateFCmp(FCmpOpcode cmp, const ref<Operation>& lhs,
  * AllocOp                                         *
  ***************************************************/
 AllocOp::AllocOp(const ref<Operation>& size, const ref<Operation>& defaultval)
-    : Operation(Opcode::Alloc, Type::array_ty(size->type().bitwidth()), size,
+    : ArrayBase(Opcode::Alloc, Type::array_ty(size->type().bitwidth()), size,
                 defaultval) {}
 
 ref<Operation> AllocOp::Create(const ref<Operation>& size,
@@ -1194,7 +1194,7 @@ ref<Operation> LoadOp::Create(const ref<Operation>& data,
  ***************************************************/
 StoreOp::StoreOp(const ref<Operation>& data, const ref<Operation>& offset,
                  const ref<Operation>& value)
-    : Operation(Opcode::Store, data->type(), data, offset, value) {}
+    : ArrayBase(Opcode::Store, data->type(), data, offset, value) {}
 
 ref<Operation> StoreOp::Create(const ref<Operation>& data,
                                const ref<Operation>& offset,

--- a/test/run-pass/mem/global-int-store.c
+++ b/test/run-pass/mem/global-int-store.c
@@ -1,0 +1,9 @@
+
+#include "caffeine.h"
+#include <stdint.h>
+
+uint32_t global = 4;
+
+void test() {
+  global = 6;
+}


### PR DESCRIPTION
This fixes one of the issues discovered while running the test cases generated by #148. Specifically we don't support globals that don't derive from `ConstantData`.

Here's the summary of the changes that were added to make this work:
- Added a pure virtual `ArrayBase` operation so that it's possible to get the size of an array generically. 
- Implemented global evaluation by evaluating the constant itself and then storing writing it to a data array.

I haven't implemented support for vector stores yet since what that will actually entail hasn't been worked out yet. I've added a simple test case but most of the behaviour here makes use of other, already tested, work.