### PR TITLE
Implement zeroinitializer globals

### DIFF
--- a/src/Interpreter/CtxConstEval.cpp
+++ b/src/Interpreter/CtxConstEval.cpp
@@ -239,6 +239,13 @@ static ref<Operation> evaluate_global_data(Context* ctx,
     return ConstantArray::Create(idxty, SharedArray(raw.data(), raw.size()));
   }
 
+  if (auto* data = llvm::dyn_cast<llvm::ConstantAggregateZero>(constant)) {
+    return AllocOp::Create(ConstantInt::Create(llvm::APInt(
+                               layout.getPointerSizeInBits(),
+                               layout.getTypeStoreSize(constant->getType()))),
+                           ConstantInt::Create(llvm::APInt(8, 0)));
+  }
+
   auto eval = evaluate(ctx, constant);
 
   // TODO: Support vectors.

--- a/test/run-pass/mem/global-zeroinitializer.c
+++ b/test/run-pass/mem/global-zeroinitializer.c
@@ -1,0 +1,9 @@
+
+#include "caffeine.h"
+#include <stdint.h>
+
+uint32_t zeros[4] = {0, 0, 0, 0};
+
+void test() {
+  caffeine_assert(zeros[0] == 0);
+}


### PR DESCRIPTION
This adds support for globals initialized using the `zeroinitializer` LLVM IR keyword. Also includes a test case.