### PR TITLE
[2/N] Optimize internal representation of known-size symbolic arrays

### DIFF
--- a/include/caffeine/ADT/PersistentArray.h
+++ b/include/caffeine/ADT/PersistentArray.h
@@ -23,6 +23,8 @@ namespace detail {
   template <typename... Ts>
   using first_of_t = typename first_of<Ts...>::type;
 
+  [[noreturn]] void throw_out_of_bounds(size_t n, size_t size);
+
 } // namespace detail
 
 /**
@@ -64,19 +66,19 @@ public:
 private:
   struct Node;
 
-  ref<Node> data_;
   size_t size_ = 0;
+  ref<Node> data_;
 
 public:
   constexpr PersistentArray() = default;
   ~PersistentArray() = default;
 
   PersistentArray(const std::vector<T>& vec)
-      : data_(make_ref<Node>(vec)), size_(vec.size()) {}
+      : size_(vec.size()), data_(make_ref<Node>(vec)) {}
   PersistentArray(std::vector<T>&& vec)
-      : data_(make_ref<Node>(std::move(vec))), size_(vec.size()) {}
+      : size_(vec.size()), data_(make_ref<Node>(std::move(vec))) {}
   PersistentArray(std::initializer_list<T> list)
-      : data_(make_ref<Node>(std::vector<T>(list))), size_(list.size()) {}
+      : size_(list.size()), data_(make_ref<Node>(std::vector<T>(list))) {}
   PersistentArray(llvm::ArrayRef<T> array) : PersistentArray(array.vec()) {}
 
   template <typename It>
@@ -280,9 +282,8 @@ private:
     }
   };
 
-  [[noreturn]] static void throw_out_of_range(size_t i) {
-    std::vector<T>().at(i);
-    llvm_unreachable("Vector didn't throw exception");
+  [[noreturn]] void throw_out_of_range(size_t i) const {
+    detail::throw_out_of_bounds(i, size());
   }
 
   void reroot() {

--- a/include/caffeine/ADT/PersistentArray.h
+++ b/include/caffeine/ADT/PersistentArray.h
@@ -4,6 +4,7 @@
 #include "caffeine/ADT/Ref.h"
 
 #include <llvm/ADT/ArrayRef.h>
+#include <llvm/ADT/Hashing.h>
 
 #include <initializer_list>
 #include <type_traits>
@@ -417,6 +418,11 @@ public:
     }
   };
 };
+
+template <typename T>
+llvm::hash_code hash_value(const PersistentArray<T>& array) {
+  return llvm::hash_combine_range(std::begin(array), std::end(array));
+}
 
 } // namespace caffeine
 

--- a/src/ADT/PersistentArray.cpp
+++ b/src/ADT/PersistentArray.cpp
@@ -1,0 +1,11 @@
+#include "caffeine/ADT/PersistentArray.h"
+
+#include <fmt/format.h>
+
+namespace caffeine::detail {
+[[noreturn]] void throw_out_of_bounds(size_t n, size_t size) {
+  throw std::out_of_range(fmt::format(
+      "index out of bounds: n (which is {}) >= this->size() (which is {})", n,
+      size));
+}
+} // namespace caffeine::detail

--- a/test/unit/ADT/PersistentArray.cpp
+++ b/test/unit/ADT/PersistentArray.cpp
@@ -57,3 +57,9 @@ TEST(PersistentArray, vec_roundtrip) {
   ASSERT_TRUE(array.empty());
   ASSERT_EQ(vec, original);
 }
+
+TEST(PersistentArray, vec_move_ctor_size_correct) {
+  PersistentArray<uint32_t> array(std::vector<uint32_t>{1, 2, 3, 4});
+
+  ASSERT_EQ(array.size(), 4);
+}


### PR DESCRIPTION
This PR fixes some issues that cropped up within the implementation of PersistentArray. Notably, if you used the vector move constructor it would initialize the size to 0 even if the vector contained elements.