### PR TITLE
[3/N] Optimize internal representation of known-size symbolic arrays

### DIFF
--- a/include/caffeine/IR/Operation.inl
+++ b/include/caffeine/IR/Operation.inl
@@ -38,6 +38,7 @@ static_assert(sizeof(AllocOp) == sizeof(Operation));
 static_assert(sizeof(LoadOp) == sizeof(Operation));
 static_assert(sizeof(StoreOp) == sizeof(Operation));
 static_assert(sizeof(Undef) == sizeof(Operation));
+static_assert(sizeof(FixedArray) == sizeof(Operation));
 
 namespace detail {
   template <typename T>
@@ -398,6 +399,17 @@ inline const ref<Operation>& StoreOp::value() const {
 }
 
 /***************************************************
+ * FixedArray                                      *
+ ***************************************************/
+inline const PersistentArray<ref<Operation>>& FixedArray::data() const {
+  return std::get<PersistentArray<ref<Operation>>>(inner_);
+}
+
+inline ref<Operation> FixedArray::size() const {
+  return ConstantInt::Create(llvm::APInt(type().bitwidth(), data().size()));
+}
+
+/***************************************************
  * classof method function impls                   *
  ***************************************************/
 #define CAFFEINE_OP_DECL_CLASSOF(derived, opcode_)                             \
@@ -414,6 +426,7 @@ CAFFEINE_OP_DECL_CLASSOF(AllocOp, Alloc);
 CAFFEINE_OP_DECL_CLASSOF(LoadOp, Load);
 CAFFEINE_OP_DECL_CLASSOF(StoreOp, Store);
 CAFFEINE_OP_DECL_CLASSOF(Undef, Undef);
+CAFFEINE_OP_DECL_CLASSOF(FixedArray, FixedArray);
 
 inline bool Constant::classof(const Operation* op) {
   return op->opcode() == ConstantNamed || op->opcode() == ConstantNumbered;
@@ -435,7 +448,7 @@ inline bool FCmpOp::classof(const Operation* op) {
 
 inline bool ArrayBase::classof(const Operation* op) {
   return op->opcode() == ConstantArray || op->opcode() == Alloc ||
-         op->opcode() == Store;
+         op->opcode() == Store || op->opcode() == FixedArray;
 }
 
 #undef CAFFEINE_OP_DECL_CLASSOF

--- a/include/caffeine/IR/Visitor.h
+++ b/include/caffeine/IR/Visitor.h
@@ -95,6 +95,7 @@ public:
   RetTy visitConstantFloat(transform_t<ConstantFloat>& O) { return CAFFEINE_OP_DELEGATE(Operation); }
   RetTy visitConstantArray(transform_t<ConstantArray>& O) { return CAFFEINE_OP_DELEGATE(ArrayBase); }
   RetTy visitUndef        (transform_t<Undef>        & O) { return CAFFEINE_OP_DELEGATE(Operation); }
+  RetTy visitFixedArray   (transform_t<FixedArray>   & O) { return CAFFEINE_OP_DELEGATE(ArrayBase); }
 
   RetTy visitBinaryOp(transform_t<BinaryOp>& O) { return CAFFEINE_OP_DELEGATE(Operation); }
   RetTy visitUnaryOp (transform_t<UnaryOp> & O) { return CAFFEINE_OP_DELEGATE(Operation); }

--- a/include/caffeine/IR/Visitor.inl
+++ b/include/caffeine/IR/Visitor.inl
@@ -70,6 +70,7 @@ RetTy OpVisitorBase<Transform, SubClass, RetTy>::visit(
     DELEGATE(ConstantFloat, ConstantFloat);
     DELEGATE(ConstantArray, ConstantArray);
     DELEGATE(Undef, Undef);
+    DELEGATE(FixedArray, FixedArray);
 
     DELEGATE(Trunc, UnaryOp);
     DELEGATE(SExt, UnaryOp);

--- a/src/IR/Operation.cpp
+++ b/src/IR/Operation.cpp
@@ -175,6 +175,7 @@ const char* Operation::opcode_name(Opcode op) {
     return "FCmp";
 
   case Select: return "Select";
+  case FixedArray: return "FixedArray";
 
   case Alloc: return "Alloc";
   case Load:  return "Load";
@@ -1217,6 +1218,26 @@ Undef::Undef(const Type& t) : Operation(Opcode::Undef, t) {}
 
 ref<Operation> Undef::Create(const Type& t) {
   return ref<Operation>(new Undef(t));
+}
+
+/***************************************************
+ * FixedArray                                      *
+ ***************************************************/
+FixedArray::FixedArray(Type t, const PersistentArray<ref<Operation>>& data)
+    : ArrayBase(Operation::FixedArray, t, data) {}
+
+ref<Operation> FixedArray::Create(Type index_ty,
+                                  const PersistentArray<ref<Operation>>& data) {
+  CAFFEINE_ASSERT(index_ty.is_int());
+
+  return ref<Operation>(
+      new FixedArray(Type::array_ty(index_ty.bitwidth()), data));
+}
+ref<Operation> FixedArray::Create(Type index_ty, const ref<Operation>& value,
+                                  size_t size) {
+  return FixedArray::Create(index_ty,
+                            PersistentArray<ref<Operation>>(
+                                std::vector<ref<Operation>>(size, value)));
 }
 
 /***************************************************

--- a/src/Solver/Solver.cpp
+++ b/src/Solver/Solver.cpp
@@ -29,6 +29,27 @@ public:
   Value visitConstantArray(const ConstantArray& op) {
     return Value(op.data(), Type::int_ty(op.type().bitwidth()));
   }
+  Value visitArrayBase(const ArrayBase& op) {
+    auto size_val = op.size();
+    uint64_t size = visit(*size_val).apint().getLimitedValue();
+    uint32_t bitwidth = size_val->type().bitwidth();
+
+    std::vector<char> bytes;
+    bytes.reserve(size);
+
+    for (uint64_t i = 0; i < size; ++i) {
+      auto load = LoadOp::Create(const_cast<ArrayBase&>(op).as_ref(),
+                                 ConstantInt::Create(llvm::APInt(bitwidth, i)));
+      auto val = visit(*load).apint();
+
+      CAFFEINE_ASSERT(val.getBitWidth() == 8);
+
+      bytes.push_back(static_cast<char>(
+          val.getLimitedValue(std::numeric_limits<uint8_t>::max())));
+    }
+
+    return Value(SharedArray(std::move(bytes)), Type::int_ty(bitwidth));
+  }
 
 #define DECL_BINOP(opcode, func)                                               \
   Value visit##opcode(const BinaryOp& op) {                                    \

--- a/src/Solver/Solver.cpp
+++ b/src/Solver/Solver.cpp
@@ -29,7 +29,7 @@ public:
   Value visitConstantArray(const ConstantArray& op) {
     return Value(op.data(), Type::int_ty(op.type().bitwidth()));
   }
-  Value visitArrayBase(const ArrayBase& op) {
+  Value visitFixedArray(const FixedArray& op) {
     auto size_val = op.size();
     uint64_t size = visit(*size_val).apint().getLimitedValue();
     uint32_t bitwidth = size_val->type().bitwidth();
@@ -38,9 +38,7 @@ public:
     bytes.reserve(size);
 
     for (uint64_t i = 0; i < size; ++i) {
-      auto load = LoadOp::Create(const_cast<ArrayBase&>(op).as_ref(),
-                                 ConstantInt::Create(llvm::APInt(bitwidth, i)));
-      auto val = visit(*load).apint();
+      auto val = visit(*op.data()[i]).apint();
 
       CAFFEINE_ASSERT(val.getBitWidth() == 8);
 

--- a/src/Solver/Z3Solver.cpp
+++ b/src/Solver/Z3Solver.cpp
@@ -341,7 +341,7 @@ z3::expr Z3OpVisitor::visitFixedArray(const FixedArray& op) {
   for (size_t i = 0; i < data.size(); ++i) {
     z3::expr value = visit(*data[i]);
     solver->add(
-        z3::select(array, ctx->bv_val(i, op.type().bitwidth()) == value));
+        z3::select(array, ctx->bv_val(i, op.type().bitwidth())) == value);
   }
 
   return array;

--- a/src/Solver/Z3Solver.cpp
+++ b/src/Solver/Z3Solver.cpp
@@ -340,8 +340,8 @@ z3::expr Z3OpVisitor::visitFixedArray(const FixedArray& op) {
 
   for (size_t i = 0; i < data.size(); ++i) {
     z3::expr value = visit(*data[i]);
-    solver->add(
-        z3::select(array, ctx->bv_val(i, op.type().bitwidth())) == value);
+    solver->add(z3::select(array, ctx->bv_val(i, op.type().bitwidth())) ==
+                value);
   }
 
   return array;

--- a/src/Solver/Z3Solver.cpp
+++ b/src/Solver/Z3Solver.cpp
@@ -332,6 +332,20 @@ z3::expr Z3OpVisitor::visitUndef(const Undef& op) {
   CAFFEINE_UNIMPLEMENTED(
       fmt::format(FMT_STRING("Unsupported undef type {}"), type));
 }
+z3::expr Z3OpVisitor::visitFixedArray(const FixedArray& op) {
+  const auto& data = op.data();
+
+  z3::expr array = next_const(
+      ctx->array_sort(ctx->bv_sort((op.type().bitwidth())), ctx->bv_sort(8)));
+
+  for (size_t i = 0; i < data.size(); ++i) {
+    z3::expr value = visit(*data[i]);
+    solver->add(
+        z3::select(array, ctx->bv_val(i, op.type().bitwidth()) == value));
+  }
+
+  return array;
+}
 
 #define CAFFEINE_BINOP_IMPL(name, op_code)                                     \
   z3::expr Z3OpVisitor::visit##name(const BinaryOp& op) {                      \

--- a/src/Solver/Z3Solver.h
+++ b/src/Solver/Z3Solver.h
@@ -70,6 +70,7 @@ public:
   z3::expr visitConstantFloat(const ConstantFloat& op);
   z3::expr visitConstantArray(const ConstantArray& op);
   z3::expr visitUndef        (const Undef& op);
+  z3::expr visitFixedArray   (const FixedArray& op);
 
   // Binary operations
   z3::expr visitAdd (const BinaryOp& op);


### PR DESCRIPTION
This adds a `FixedArray` opcode that is a more efficient implementation of a fixed-size array.

Currently depends on ~all my other PRs and still WIP so keeping as draft for now.