### PR TITLE
Keep pointers resolved for constant getelementptr operations

### DIFF
--- a/src/Interpreter/CtxConstEval.cpp
+++ b/src/Interpreter/CtxConstEval.cpp
@@ -177,7 +177,7 @@ static ContextValue evaluate_expr(Context* ctx, llvm::ConstantExpr* expr) {
       const auto& ptr = value.pointer();
 
       return ContextValue(
-          Pointer(BinaryOp::CreateAdd(ptr.value(ctx->heap()), offset)));
+          Pointer(ptr.alloc(), BinaryOp::CreateAdd(ptr.offset(), offset)));
     };
     return transform_value(func, ptr);
   }


### PR DESCRIPTION
For a number of yarpgen tests the majority of the time is spent resolving pointers that don't already have an associated allocation.
This was made worse by the fact that constant getelementptr instructions were stripping out the attached allocation. This is just a point fix to keep the corresponding allocation.

In short, it's a 1-line change that gives a 50%+ performance boost on common memory access operations.