### PR TITLE
Implement expression-tree matching utilities

### DIFF
--- a/include/caffeine/IR/Matching.h
+++ b/include/caffeine/IR/Matching.h
@@ -38,8 +38,11 @@ namespace matching {
    * and have first and second be set to the expression nodes that were matched
    * against. However, ref<Operation> doesn't implement the protocol (and you'd
    * need a reference anyway). To work around this matchers use the MatcherImpl
-   * type internally. This is a template which resolves to T unless T is a
-   * ref<Operation> in which case it resolves to RefOperationMatcher.
+   * type internally. This is a template which resolves to T unless T is one of
+   * a few custom types in which case it resolves to custom matcher.
+   *
+   * Currently the only special case is RefOperationMatcher if T is
+   * ref<Operation> or ref<Operation>*.
    *
    * For an example of how this is used check out UnaryOpMatcher. Custom
    * matchers should be implemented along the same lines.

--- a/include/caffeine/IR/Matching.h
+++ b/include/caffeine/IR/Matching.h
@@ -50,6 +50,20 @@ namespace matching {
    */
 
   /**
+   * Matches any expression node.
+   *
+   * This is more or less the simplest possible matcher.
+   */
+  struct Any {
+    Any() = default;
+
+    bool matches(const ref<Operation>&) const {
+      return true;
+    }
+    void on_match(const ref<Operation>&) const {}
+  };
+
+  /**
    * Matcher to capture an expression tree node.
    */
   struct RefOperationMatcher {
@@ -112,20 +126,6 @@ namespace matching {
     T
   >::type;
   // clang-format on
-
-  /**
-   * Matches any expression node.
-   *
-   * This is more or less the simplest possible matcher.
-   */
-  struct Any {
-    Any() = default;
-
-    bool matches(const ref<Operation>&) const {
-      return true;
-    }
-    void on_match(const ref<Operation>&) const {}
-  };
 
   /**
    * Match a binary operation with a defined opcode.

--- a/include/caffeine/IR/Matching.h
+++ b/include/caffeine/IR/Matching.h
@@ -239,13 +239,13 @@ namespace matching {
   static_assert(true)
 
 #define CAFFEINE_DECL_ZEROOP_MATCHER(name, opclass)                            \
-  OpClassMatcher<opclass> name() {                                             \
+  inline OpClassMatcher<opclass> name() {                                      \
     return OpClassMatcher<opclass>();                                          \
   };                                                                           \
-  OpClassMatcher<opclass> name(ref<Operation>& op) {                           \
+  inline OpClassMatcher<opclass> name(ref<Operation>& op) {                    \
     return OpClassMatcher<opclass>(&op);                                       \
   }                                                                            \
-  OpClassMatcher<opclass> name(ref<Operation>* op) {                           \
+  inline OpClassMatcher<opclass> name(ref<Operation>* op) {                    \
     return OpClassMatcher<opclass>(op);                                        \
   }                                                                            \
   static_assert(true)

--- a/include/caffeine/IR/Matching.h
+++ b/include/caffeine/IR/Matching.h
@@ -41,8 +41,8 @@ namespace matching {
    * type internally. This is a template which resolves to T unless T is a
    * ref<Operation> in which case it resolves to RefOperationMatcher.
    *
-   * For an example of how this used check out UnaryOpMatcher. Custom matchers
-   * should be implemented along the same lines.
+   * For an example of how this is used check out UnaryOpMatcher. Custom
+   * matchers should be implemented along the same lines.
    */
 
   /**
@@ -373,9 +373,9 @@ bool matches(const ref<Operation>& op, const Matcher& matcher) {
  * ========
  * Remove all occurrences of double-not anywhere in an expression
  *
- *    ref<Operation> parent, child;
+ *    ref<Operation> child;
  *    while (auto match = matches_anywhere(expr, Not(Not(child))))
- *      *parent = *child;
+ *      *match = *child;
  *
  * Note the use of capture to get the parent node.
  *

--- a/include/caffeine/IR/Matching.h
+++ b/include/caffeine/IR/Matching.h
@@ -1,0 +1,200 @@
+#ifndef CAFFEINE_IR_MATCHING_H
+#define CAFFEINE_IR_MATCHING_H
+
+#include "caffeine/IR/Operation.h"
+
+namespace caffeine {
+namespace matching {
+
+  /**
+   * Matching protocol:
+   *
+   * Every matching object exposes two methods:
+   *  - bool matches(<ast node>) const
+   *  - void on_match(<ast node>) const
+   *
+   * These methods are used to first check whether a match would occur and then
+   * record whatever information is needed by the caller.
+   *
+   * Matchers can assume that on_match will only be passed ast nodes for which
+   * matches returned true. Furthermore, they should
+   */
+
+  struct RefOperationMatcher {
+  private:
+    ref<Operation>* output;
+
+  public:
+    RefOperationMatcher(ref<Operation>& output) : output(&output) {}
+
+    bool matches(const ref<Operation>&) const {
+      return true;
+    }
+    void on_match(const ref<Operation>& op) const {
+      *output = op;
+    }
+  };
+
+  /**
+   * There's a special case for ref<Operation> arguments since they don't have
+   * the required methods but we'd like to use them as captures.
+   */
+  template <typename T>
+  using MatcherImpl = std::conditional_t<std::is_same_v<T, ref<Operation>>,
+                                         RefOperationMatcher, T>;
+
+  /**
+   * Matches any expression node and optionally captures a reference to that
+   * expression node.
+   *
+   * This is more or less the simplest possible matcher.
+   */
+  struct Any {
+    Any() = default;
+
+    bool matches(const ref<Operation>&) const {
+      return true;
+    }
+    void on_match(const ref<Operation>&) const {}
+  };
+
+  /**
+   * Match a binary operation with a defined opcode.
+   */
+  template <Operation::Opcode opcode, typename M1, typename M2>
+  class BinaryOpMatcher {
+  private:
+    MatcherImpl<M1> lhs;
+    MatcherImpl<M2> rhs;
+
+    static_assert(detail::opcode_nargs(opcode) == 2,
+                  "Opcode was not a binary operation");
+
+  public:
+    template <typename T1, typename T2>
+    BinaryOpMatcher(T1&& lhs, T2&& rhs)
+        : lhs(std::forward<T1>(lhs)), rhs(std::forward<T2>(rhs)) {}
+
+    bool matches(const ref<Operation>& op) const {
+      if (op->opcode() != static_cast<uint16_t>(opcode))
+        return false;
+
+      return lhs.matches(op->operand_at(0)) && rhs.matches(op->operand_at(1));
+    }
+    void on_match(const ref<Operation>& op) const {
+      lhs.on_match(op->operand_at(0));
+      rhs.on_match(op->operand_at(1));
+    }
+  };
+
+  /**
+   * Match a unary operation with a defined opcode.
+   */
+  template <Operation::Opcode opcode, typename M>
+  class UnaryOpMatcher {
+  private:
+    MatcherImpl<M> inner;
+
+    static_assert(detail::opcode_nargs(opcode) == 1,
+                  "Opcode was not a unary operation");
+
+  public:
+    template <typename T>
+    UnaryOpMatcher(T&& inner) : inner(std::forward<T>(inner)) {}
+
+    bool matches(const ref<Operation>& op) const {
+      if (op->opcode() != static_cast<uint16_t>(opcode))
+        return false;
+
+      return inner.matches(op->operand_at(0));
+    }
+    void on_match(const ref<Operation>& op) const {
+      inner.on_match(op->operand_at(0));
+    }
+  };
+
+  // Note: We define an extra (unnecessary) type here so that error messages at
+  //       least contain the names of the opcodes they're matching against.
+  //
+  // However, we put them in an internal namespace so that they don't pollute
+  // the actual public interface.
+#define CAFFEINE_DECL_UNOP_MATCHER(name, opcode)                               \
+  namespace detail {                                                           \
+    template <typename M>                                                      \
+    struct name##Matcher : public UnaryOpMatcher<(opcode), M> {                \
+      using UnaryOpMatcher<(opcode), M>::UnaryOpMatcher;                       \
+    };                                                                         \
+  }                                                                            \
+  template <typename M>                                                        \
+  detail::name##Matcher<std::decay_t<M>> name(M&& op) {                        \
+    return detail::name##Matcher<std::decay_t<M>>(std::forward<M>(op));        \
+  }                                                                            \
+  static_assert(true)
+
+#define CAFFEINE_DECL_BINOP_MATCHER(name, opcode)                              \
+  namespace detail {                                                           \
+    template <typename M1, typename M2>                                        \
+    struct name##Matcher : public BinaryOpMatcher<(opcode), M1, M2> {          \
+      using BinaryOpMatcher<(opcode), M1, M2>::BinaryOpMatcher;                \
+    };                                                                         \
+  }                                                                            \
+  template <typename M1, typename M2>                                          \
+  detail::name##Matcher<std::decay_t<M1>, std::decay_t<M2>> name(M1&& lhs,     \
+                                                                 M2&& rhs) {   \
+    return detail::name##Matcher<std::decay_t<M1>, std::decay_t<M2>>(          \
+        std::forward<M1>(lhs), std::forward<M2>(rhs));                         \
+  }                                                                            \
+  static_assert(true)
+
+  CAFFEINE_DECL_BINOP_MATCHER(Add, Operation::Add);
+  CAFFEINE_DECL_BINOP_MATCHER(Sub, Operation::Sub);
+  CAFFEINE_DECL_BINOP_MATCHER(Mul, Operation::Mul);
+  CAFFEINE_DECL_BINOP_MATCHER(UDiv, Operation::UDiv);
+  CAFFEINE_DECL_BINOP_MATCHER(SDiv, Operation::SDiv);
+  CAFFEINE_DECL_BINOP_MATCHER(URem, Operation::URem);
+  CAFFEINE_DECL_BINOP_MATCHER(SRem, Operation::SRem);
+
+  CAFFEINE_DECL_BINOP_MATCHER(And, Operation::And);
+  CAFFEINE_DECL_BINOP_MATCHER(Or, Operation::Or);
+  CAFFEINE_DECL_BINOP_MATCHER(Xor, Operation::Xor);
+  CAFFEINE_DECL_BINOP_MATCHER(Shl, Operation::Shl);
+  CAFFEINE_DECL_BINOP_MATCHER(LShr, Operation::LShr);
+  CAFFEINE_DECL_BINOP_MATCHER(AShr, Operation::AShr);
+
+  CAFFEINE_DECL_BINOP_MATCHER(FAdd, Operation::FAdd);
+  CAFFEINE_DECL_BINOP_MATCHER(FSub, Operation::FSub);
+  CAFFEINE_DECL_BINOP_MATCHER(FMul, Operation::FMul);
+  CAFFEINE_DECL_BINOP_MATCHER(FDiv, Operation::FDiv);
+  CAFFEINE_DECL_BINOP_MATCHER(FRem, Operation::FRem);
+
+  CAFFEINE_DECL_UNOP_MATCHER(Not, Operation::Not);
+  CAFFEINE_DECL_UNOP_MATCHER(FNeg, Operation::FNeg);
+  CAFFEINE_DECL_UNOP_MATCHER(FIsNaN, Operation::FIsNaN);
+
+  CAFFEINE_DECL_UNOP_MATCHER(Trunc, Operation::Trunc);
+  CAFFEINE_DECL_UNOP_MATCHER(SExt, Operation::SExt);
+  CAFFEINE_DECL_UNOP_MATCHER(ZExt, Operation::ZExt);
+  CAFFEINE_DECL_UNOP_MATCHER(FpTrunc, Operation::FpTrunc);
+  CAFFEINE_DECL_UNOP_MATCHER(FpExt, Operation::FpExt);
+  CAFFEINE_DECL_UNOP_MATCHER(FpToUI, Operation::FpToUI);
+  CAFFEINE_DECL_UNOP_MATCHER(FpToSI, Operation::FpToSI);
+  CAFFEINE_DECL_UNOP_MATCHER(UIToFp, Operation::UIToFp);
+  CAFFEINE_DECL_UNOP_MATCHER(SIToFp, Operation::SIToFp);
+  CAFFEINE_DECL_UNOP_MATCHER(Bitcast, Operation::Bitcast);
+
+#undef CAFFEINE_DECL_UNOP_MATCHER
+#undef CAFFEINE_DECL_BINOP_MATCHER
+
+} // namespace matching
+
+template <typename Matcher>
+bool matches(const ref<Operation>& op, const Matcher& matcher) {
+  bool is_match = matcher.matches(op);
+  if (is_match)
+    matcher.on_match(op);
+  return is_match;
+}
+
+} // namespace caffeine
+
+#endif

--- a/include/caffeine/IR/Matching.h
+++ b/include/caffeine/IR/Matching.h
@@ -359,7 +359,7 @@ bool matches(const ref<Operation>& op, const Matcher& matcher) {
     matcher.on_match(op);
   return is_match;
 }
-template<typename Matcher>
+template <typename Matcher>
 bool matches(const Assertion& assertion, const Matcher& matcher) {
   return matches(assertion.value(), matcher);
 }
@@ -413,8 +413,9 @@ ref<Operation> matches_anywhere(const ref<Operation>& op,
 
   return nullptr;
 }
-template<typename Matcher>
-ref<Operation> matches_anywhere(const Assertion& assertion, const Matcher& matcher) {
+template <typename Matcher>
+ref<Operation> matches_anywhere(const Assertion& assertion,
+                                const Matcher& matcher) {
   return matches_anywhere(assertion.value(), matcher);
 }
 

--- a/include/caffeine/IR/Matching.h
+++ b/include/caffeine/IR/Matching.h
@@ -1,6 +1,7 @@
 #ifndef CAFFEINE_IR_MATCHING_H
 #define CAFFEINE_IR_MATCHING_H
 
+#include "caffeine/IR/Assertion.h"
 #include "caffeine/IR/Operation.h"
 
 namespace caffeine {
@@ -358,6 +359,10 @@ bool matches(const ref<Operation>& op, const Matcher& matcher) {
     matcher.on_match(op);
   return is_match;
 }
+template<typename Matcher>
+bool matches(const Assertion& assertion, const Matcher& matcher) {
+  return matches(assertion.value(), matcher);
+}
 
 /**
  * Match anywhere in an expression.
@@ -407,6 +412,10 @@ ref<Operation> matches_anywhere(const ref<Operation>& op,
   }
 
   return nullptr;
+}
+template<typename Matcher>
+ref<Operation> matches_anywhere(const Assertion& assertion, const Matcher& matcher) {
+  return matches_anywhere(assertion.value(), matcher);
 }
 
 } // namespace caffeine

--- a/include/caffeine/IR/Matching.h
+++ b/include/caffeine/IR/Matching.h
@@ -71,8 +71,8 @@ namespace matching {
     ref<Operation>* output;
 
   public:
-    RefOperationMatcher(ref<Operation>& output) : output(&output) {}
-    RefOperationMatcher(ref<Operation>* output) : output(output) {}
+    explicit RefOperationMatcher(ref<Operation>& output) : output(&output) {}
+    explicit RefOperationMatcher(ref<Operation>* output) : output(output) {}
 
     bool matches(const ref<Operation>&) const {
       return true;
@@ -169,7 +169,7 @@ namespace matching {
 
   public:
     template <typename T>
-    UnaryOpMatcher(T&& inner) : inner(std::forward<T>(inner)) {}
+    explicit UnaryOpMatcher(T&& inner) : inner(std::forward<T>(inner)) {}
 
     bool matches(const ref<Operation>& op) const {
       if (op->opcode() != static_cast<uint16_t>(opcode))
@@ -193,8 +193,8 @@ namespace matching {
 
   public:
     OpClassMatcher() = default;
-    OpClassMatcher(ref<Operation>& cap) : capture(&cap) {}
-    OpClassMatcher(ref<Operation>* cap) : capture(cap) {}
+    explicit OpClassMatcher(ref<Operation>& cap) : capture(&cap) {}
+    explicit OpClassMatcher(ref<Operation>* cap) : capture(cap) {}
 
     bool matches(const ref<Operation>& op) const {
       return llvm::isa<OpClass>(op.get());

--- a/include/caffeine/IR/Matching.h
+++ b/include/caffeine/IR/Matching.h
@@ -113,8 +113,7 @@ namespace matching {
   // clang-format on
 
   /**
-   * Matches any expression node and optionally captures a reference to that
-   * expression node.
+   * Matches any expression node.
    *
    * This is more or less the simplest possible matcher.
    */

--- a/include/caffeine/IR/Operation.h
+++ b/include/caffeine/IR/Operation.h
@@ -342,6 +342,7 @@ protected:
    */
   uint16_t aux_data() const;
 
+public:
   /**
    * Accessors to operand references.
    */

--- a/include/caffeine/IR/Operation.h
+++ b/include/caffeine/IR/Operation.h
@@ -324,6 +324,12 @@ public:
     return llvm::isa<T>(*this);
   }
 
+  /**
+   * Accessors to operand references.
+   */
+  ref<Operation>& operand_at(size_t idx);
+  const ref<Operation>& operand_at(size_t idx) const;
+
   // Need to define this since refcount shouldn't be copied/moved.
   Operation(const Operation& op);
   Operation(Operation&& op) noexcept;
@@ -341,13 +347,6 @@ protected:
    * however they want.
    */
   uint16_t aux_data() const;
-
-public:
-  /**
-   * Accessors to operand references.
-   */
-  ref<Operation>& operand_at(size_t idx);
-  const ref<Operation>& operand_at(size_t idx) const;
 };
 
 std::ostream& operator<<(std::ostream& os, const Operation& op);

--- a/test/unit/IR/Matching.cpp
+++ b/test/unit/IR/Matching.cpp
@@ -1,0 +1,42 @@
+#include "caffeine/IR/Matching.h"
+
+#include <gtest/gtest.h>
+
+using namespace caffeine;
+using namespace caffeine::matching;
+
+// Make sure the test namespace is correct
+class MatchingTests : public ::testing::Test {};
+
+TEST_F(MatchingTests, match_any) {
+  auto expr = ConstantInt::Create(true);
+
+  ASSERT_TRUE(matches(expr, Any()));
+}
+
+TEST_F(MatchingTests, match_binop) {
+  auto add = BinaryOp::CreateAdd(Constant::Create(Type::int_ty(32), 0), 55);
+
+  ref<Operation> first, second;
+  ASSERT_TRUE(matches(add, Add(first, second)));
+}
+
+TEST_F(MatchingTests, match_nested) {
+  auto expr = BinaryOp::CreateAdd(
+      BinaryOp::CreateSub(Constant::Create(Type::int_ty(32), 0), 77),
+      Constant::Create(Type::int_ty(32), 1));
+
+  ref<Operation> first, second;
+  ASSERT_TRUE(matches(expr, Add(Sub(first, second), Any())));
+
+  ASSERT_EQ(first->opcode(), Operation::ConstantNumbered);
+  ASSERT_EQ(second->opcode(), Operation::ConstantInt);
+}
+
+TEST_F(MatchingTests, match_unop) {
+  auto expr = UnaryOp::CreateNot(Constant::Create(Type::int_ty(32), 0));
+
+  ref<Operation> cnst;
+  ASSERT_TRUE(matches(expr, Not(cnst)));
+  ASSERT_EQ(cnst->opcode(), Operation::ConstantNumbered);
+}

--- a/test/unit/IR/Matching.cpp
+++ b/test/unit/IR/Matching.cpp
@@ -53,3 +53,12 @@ TEST_F(MatchingTests, replace_double_not) {
 
   ASSERT_TRUE(llvm::isa<Constant>(expr.get()));
 }
+
+TEST_F(MatchingTests, fixedarray) {
+  auto expr = FixedArray::Create(Type::int_ty(32),
+                                 UnaryOp::CreateNot(UnaryOp::CreateNot(
+                                     Constant::Create(Type::int_ty(1), 0))),
+                                 64);
+
+  ASSERT_TRUE(matches_anywhere(expr, Not(Not(Any()))));
+}

--- a/test/unit/IR/Matching.cpp
+++ b/test/unit/IR/Matching.cpp
@@ -27,7 +27,7 @@ TEST_F(MatchingTests, match_nested) {
       Constant::Create(Type::int_ty(32), 1));
 
   ref<Operation> first, second;
-  ASSERT_TRUE(matches(expr, Add(Sub(first, second), Any())));
+  ASSERT_TRUE(matches(expr, Add(Sub(&first, second), Any())));
 
   ASSERT_EQ(first->opcode(), Operation::ConstantNumbered);
   ASSERT_EQ(second->opcode(), Operation::ConstantInt);

--- a/test/unit/IR/Matching.cpp
+++ b/test/unit/IR/Matching.cpp
@@ -40,3 +40,16 @@ TEST_F(MatchingTests, match_unop) {
   ASSERT_TRUE(matches(expr, Not(cnst)));
   ASSERT_EQ(cnst->opcode(), Operation::ConstantNumbered);
 }
+
+TEST_F(MatchingTests, replace_double_not) {
+  using caffeine::Constant;
+
+  auto expr = UnaryOp::CreateNot(
+      UnaryOp::CreateNot(Constant::Create(Type::int_ty(18), 0)));
+
+  ref<Operation> child;
+  while (auto parent = matches_anywhere(expr, Not(Not(child))))
+    *parent = *child;
+
+  ASSERT_TRUE(llvm::isa<Constant>(expr.get()));
+}


### PR DESCRIPTION
Pretty soon we're going to want to perform various query optimizations. As part of this we'll need an easy way to check if an expression is an expected expression tree. This PR is the first part of what's needed for that. It adds a (somewhat) complete set of patterns along with methods to use them.

To see how this code is supposed to be used check out the docs on `matches` and `matches_anywhere`.