### PR TITLE
Implement some more utility methods for Operation

### DIFF
--- a/include/caffeine/IR/Operation.h
+++ b/include/caffeine/IR/Operation.h
@@ -334,7 +334,8 @@ public:
    * Create a new operation using the same opcode as the current one but with
    * new operands.
    */
-  ref<Operation> with_new_operands(llvm::ArrayRef<ref<Operation>> operands) const;
+  ref<Operation>
+  with_new_operands(llvm::ArrayRef<ref<Operation>> operands) const;
 
   /**
    * Accessors to operand references.

--- a/include/caffeine/IR/Operation.h
+++ b/include/caffeine/IR/Operation.h
@@ -258,7 +258,7 @@ protected:
   Operation(Opcode op, Type t, const Inner& inner);
   Operation(Opcode op, Type t, Inner&& inner);
 
-  Operation(Opcode op, Type t, ref<Operation>* operands);
+  Operation(Opcode op, Type t, const ref<Operation>* operands);
 
   Operation(Opcode op, Type t, const ref<Operation>& op0);
   Operation(Opcode op, Type t, const ref<Operation>& op0,
@@ -325,6 +325,12 @@ public:
   }
 
   /**
+   * Create a new operation using the same opcode as the current one but with
+   * new operands.
+   */
+  ref<Operation> with_new_operands(llvm::ArrayRef<ref<Operation>> operands) const;
+
+  /**
    * Accessors to operand references.
    */
   ref<Operation>& operand_at(size_t idx);
@@ -347,6 +353,9 @@ protected:
    * however they want.
    */
   uint16_t aux_data() const;
+
+private:
+  ref<Operation> into_ref() const;
 };
 
 std::ostream& operator<<(std::ostream& os, const Operation& op);

--- a/include/caffeine/IR/Operation.h
+++ b/include/caffeine/IR/Operation.h
@@ -303,6 +303,12 @@ public:
   ref<Operation> as_ref();
   ref<const Operation> as_ref() const;
 
+  /**
+   * Get this operation as a ref, or create a new ref with a copy if it isn't
+   * already a reference.
+   */
+  ref<Operation> into_ref() const;
+
   typedef detail::double_deref_iterator<ref<Operation>> operand_iterator;
   typedef detail::double_deref_iterator<const ref<Operation>>
       const_operand_iterator;
@@ -353,9 +359,6 @@ protected:
    * however they want.
    */
   uint16_t aux_data() const;
-
-private:
-  ref<Operation> into_ref() const;
 };
 
 std::ostream& operator<<(std::ostream& os, const Operation& op);

--- a/include/caffeine/IR/Operation.inl
+++ b/include/caffeine/IR/Operation.inl
@@ -209,6 +209,12 @@ inline const ref<Operation>& Operation::operand_at(size_t idx) const {
   return std::get<OpVec>(inner_)[idx];
 }
 
+inline ref<Operation> Operation::into_ref() const {
+  if (refcnt() == 0)
+    return make_ref<Operation>(*this);
+  return ref<Operation>(const_cast<Operation*>(this));
+}
+
 /***************************************************
  * Constant                                        *
  ***************************************************/

--- a/src/IR/Operation.cpp
+++ b/src/IR/Operation.cpp
@@ -122,7 +122,8 @@ Operation::with_new_operands(llvm::ArrayRef<ref<Operation>> operands) const {
   if (equal)
     return into_ref();
 
-  return ref<Operation>(new Operation((Opcode)opcode(), type(), operands.data()));
+  return ref<Operation>(
+      new Operation((Opcode)opcode(), type(), operands.data()));
 }
 
 const char* Operation::opcode_name() const {


### PR DESCRIPTION
This allows you to create an operation with the same opcode and type as an existing one while replacing the opcodes with new ones.