### PR TITLE
Implement canonicalizing solver

### DIFF
--- a/include/caffeine/IR/Transforms.h
+++ b/include/caffeine/IR/Transforms.h
@@ -43,4 +43,14 @@ namespace caffeine::transforms {
  */
 void decompose(std::vector<Assertion>& assertions);
 
+/**
+ * Attempts to convert the assertions into a canonical form that is suitable for
+ * cache lookups (or one that can be transformed into such a form with little
+ * effort).
+ *
+ * Currently all it does is apply existing constant-folding and remove exactly
+ * duplicate expressions from the vector but in the future it will do more.
+ */
+void canonicalize(std::vector<Assertion>& assertions);
+
 } // namespace caffeine::transforms

--- a/include/caffeine/Solver/CanonicalizingSolver.h
+++ b/include/caffeine/Solver/CanonicalizingSolver.h
@@ -11,7 +11,7 @@ namespace caffeine {
  * but currently there are two guarantees from this solver:
  *  - There will be no unevaluated constant subexpressions (e.g. 3 + 4)
  *  - There will be no repeated duplicate assertions
- * 
+ *
  * Always returns unknown.
  */
 class CanonicalizingSolver final : public Solver {

--- a/include/caffeine/Solver/CanonicalizingSolver.h
+++ b/include/caffeine/Solver/CanonicalizingSolver.h
@@ -23,9 +23,6 @@ public:
 
   std::unique_ptr<Model> resolve(std::vector<Assertion>& assertions,
                                  const Assertion& extra) override;
-
-private:
-  void canonicalize_all(std::vector<Assertion>& assertions);
 };
 
 } // namespace caffeine

--- a/include/caffeine/Solver/CanonicalizingSolver.h
+++ b/include/caffeine/Solver/CanonicalizingSolver.h
@@ -1,0 +1,31 @@
+#pragma once
+
+#include "caffeine/Solver/Solver.h"
+
+namespace caffeine {
+
+/**
+ * Solver that attempts to convert expressions to a canonical form.
+ *
+ * What exactly the canonical form for expressions are hasn't been defined yet
+ * but currently there are two guarantees from this solver:
+ *  - There will be no unevaluated constant subexpressions (e.g. 3 + 4)
+ *  - There will be no repeated duplicate assertions
+ * 
+ * Always returns unknown.
+ */
+class CanonicalizingSolver final : public Solver {
+public:
+  CanonicalizingSolver() = default;
+
+  SolverResult check(std::vector<Assertion>& assertions,
+                     const Assertion& extra) override;
+
+  std::unique_ptr<Model> resolve(std::vector<Assertion>& assertions,
+                                 const Assertion& extra) override;
+
+private:
+  void canonicalize_all(std::vector<Assertion>& assertions);
+};
+
+} // namespace caffeine

--- a/src/IR/Transforms/canonicalize.cpp
+++ b/src/IR/Transforms/canonicalize.cpp
@@ -81,7 +81,6 @@ void canonicalize(std::vector<Assertion>& assertions) {
           [](const Assertion& a) { return a.is_constant_value(false); })) {
     assertions.clear();
     assertions.push_back(Assertion(ConstantInt::Create(false)));
-    return;
   }
 }
 

--- a/src/IR/Transforms/canonicalize.cpp
+++ b/src/IR/Transforms/canonicalize.cpp
@@ -1,0 +1,88 @@
+#include "caffeine/IR/Transforms.h"
+
+#include "caffeine/IR/Assertion.h"
+#include "caffeine/IR/Visitor.h"
+#include <algorithm>
+#include <llvm/ADT/SmallVector.h>
+#include <unordered_map>
+#include <unordered_set>
+
+namespace caffeine::transforms {
+
+namespace {
+  using ReferenceMap = std::unordered_map<Operation, ref<Operation>>;
+
+  class CanonicalizeVisitor
+      : public ConstOpVisitor<CanonicalizeVisitor, ref<Operation>> {
+    ReferenceMap seen;
+
+  public:
+    ref<Operation> visit(const Operation* op) {
+      return visit(*op);
+    }
+    ref<Operation> visit(const Operation& op) {
+      auto it = seen.find(op);
+      if (it != seen.end())
+        return it->second;
+
+      auto res = ConstOpVisitor<CanonicalizeVisitor, ref<Operation>>::visit(op);
+      seen.emplace(op, res);
+      return res;
+    }
+
+    ref<Operation> visitOperation(const Operation& op) {
+      llvm::SmallVector<ref<Operation>, 3> operands;
+
+      for (auto& operand : op.operands()) {
+        operands.push_back(visit(operand));
+      }
+
+      return op.with_new_operands(operands);
+    }
+
+    ref<Operation> visitFixedArray(const FixedArray& array) {
+      auto data = array.data();
+      bool set_any = false;
+
+      for (size_t i = 0; i < data.size(); ++i) {
+        ref<Operation> elem = data[i];
+        auto rel = visit(*elem);
+
+        if (rel != elem) {
+          data.set(i, std::move(rel));
+          set_any = true;
+        }
+      }
+
+      if (!set_any)
+        return array.into_ref();
+
+      return FixedArray::Create(Type::int_ty(array.type().bitwidth()), data);
+    }
+  };
+} // namespace
+
+void canonicalize(std::vector<Assertion>& assertions) {
+  std::unordered_set<Operation*> known;
+  CanonicalizeVisitor visitor;
+
+  auto it = std::remove_if(
+      std::begin(assertions), std::end(assertions), [&](Assertion& assertion) {
+        assertion.value() = visitor.visit(assertion.value().get());
+        return !known.insert(assertion.value().get()).second ||
+               assertion.is_constant_value(true);
+      });
+  assertions.erase(it, assertions.end());
+
+  // The canonical form for an assertion that has a false literal is just an
+  // array with a single constant-false assertion.
+  if (std::any_of(
+          std::begin(assertions), std::end(assertions),
+          [](const Assertion& a) { return a.is_constant_value(false); })) {
+    assertions.clear();
+    assertions.push_back(Assertion(ConstantInt::Create(false)));
+    return;
+  }
+}
+
+} // namespace caffeine::transforms

--- a/src/Solver/CanonicalizingSolver.cpp
+++ b/src/Solver/CanonicalizingSolver.cpp
@@ -2,7 +2,7 @@
 
 #include "caffeine/IR/Assertion.h"
 #include "caffeine/IR/Operation.h"
-#include "caffeine/IR/Visitor.h"
+#include "caffeine/IR/Transforms.h"
 
 #include <llvm/ADT/SmallVector.h>
 
@@ -10,81 +10,15 @@
 
 namespace caffeine {
 
-using ReferenceMap = std::unordered_map<Operation, ref<Operation>>;
-
-namespace {
-  class CanonicalizeVisitor
-      : public ConstOpVisitor<CanonicalizeVisitor, ref<Operation>> {
-    ReferenceMap seen;
-
-  public:
-    ref<Operation> visit(const Operation* op) {
-      return visit(*op);
-    }
-    ref<Operation> visit(const Operation& op) {
-      auto it = seen.find(op);
-      if (it != seen.end())
-        return it->second;
-
-      auto res = ConstOpVisitor<CanonicalizeVisitor, ref<Operation>>::visit(op);
-      seen.emplace(op, res);
-      return res;
-    }
-
-    ref<Operation> visitOperation(const Operation& op) {
-      llvm::SmallVector<ref<Operation>, 3> operands;
-
-      for (auto& operand : op.operands()) {
-        operands.push_back(visit(operand));
-      }
-
-      return op.with_new_operands(operands);
-    }
-
-    ref<Operation> visitFixedArray(const FixedArray& array) {
-      auto data = array.data();
-      bool set_any = false;
-
-      for (size_t i = 0; i < data.size(); ++i) {
-        ref<Operation> elem = data[i];
-        auto rel = visit(*elem);
-
-        if (rel != elem) {
-          data.set(i, std::move(rel));
-          set_any = true;
-        }
-      }
-
-      if (!set_any)
-        return array.into_ref();
-
-      return FixedArray::Create(Type::int_ty(array.type().bitwidth()), data);
-    }
-  };
-} // namespace
-
-void CanonicalizingSolver::canonicalize_all(
-    std::vector<Assertion>& assertions) {
-  std::unordered_set<Operation*> known_assertions;
-  CanonicalizeVisitor visitor;
-
-  auto it = std::remove_if(
-      assertions.begin(), assertions.end(), [&](Assertion& assertion) {
-        assertion.value() = visitor.visit(assertion.value().get());
-        return !known_assertions.insert(assertion.value().get()).second;
-      });
-  assertions.erase(it, assertions.end());
-}
-
 SolverResult CanonicalizingSolver::check(std::vector<Assertion>& assertions,
                                          const Assertion&) {
-  canonicalize_all(assertions);
+  transforms::canonicalize(assertions);
   return SolverResult::Unknown;
 }
 std::unique_ptr<Model>
 CanonicalizingSolver::resolve(std::vector<Assertion>& assertions,
                               const Assertion&) {
-  canonicalize_all(assertions);
+  transforms::canonicalize(assertions);
   return std::make_unique<EmptyModel>(SolverResult::Unknown);
 }
 

--- a/src/Solver/CanonicalizingSolver.cpp
+++ b/src/Solver/CanonicalizingSolver.cpp
@@ -1,0 +1,84 @@
+#include "caffeine/Solver/CanonicalizingSolver.h"
+
+#include "caffeine/IR/Assertion.h"
+#include "caffeine/IR/Operation.h"
+
+#include <llvm/ADT/SmallVector.h>
+
+#include <unordered_set>
+
+namespace caffeine {
+
+using ReferenceMap = std::unordered_map<Operation, ref<Operation>>;
+
+static ref<Operation> canonicalize(const ref<Operation>& op,
+                                   ReferenceMap& seen);
+
+static ref<Operation> canonicalize_(const ref<Operation>& op,
+                                    ReferenceMap& seen) {
+  if (auto* array = llvm::dyn_cast<FixedArray>(op.get())) {
+    auto data = array->data();
+    bool set_any = false;
+
+    for (size_t i = 0; i < data.size(); ++i) {
+      auto elem = data[i];
+      auto rel = canonicalize(elem, seen);
+
+      if (rel != elem) {
+        data.set(i, std::move(rel));
+        set_any = true;
+      }
+    }
+
+    if (!set_any)
+      return op;
+    return FixedArray::Create(Type::int_ty(op->type().bitwidth()), data);
+  } else {
+    llvm::SmallVector<ref<Operation>, 3> operands;
+
+    size_t nops = op->num_operands();
+    for (size_t i = 0; i < nops; ++i) {
+      operands.push_back(canonicalize(op->operand_at(i), seen));
+    }
+
+    return op->with_new_operands(operands);
+  }
+}
+
+static ref<Operation> canonicalize(const ref<Operation>& op,
+                                   ReferenceMap& seen) {
+  auto it = seen.find(*op);
+  if (it != seen.end())
+    return it->second;
+
+  auto res = canonicalize_(op, seen);
+  seen.emplace(*op, res);
+  return res;
+}
+
+void CanonicalizingSolver::canonicalize_all(
+    std::vector<Assertion>& assertions) {
+  std::unordered_set<Operation*> known_assertions;
+  ReferenceMap seen;
+
+  auto it = std::remove_if(
+      assertions.begin(), assertions.end(), [&](Assertion& assertion) {
+        assertion.value() = canonicalize(assertion.value(), seen);
+        return !known_assertions.insert(assertion.value().get()).second;
+      });
+  assertions.erase(it, assertions.end());
+}
+
+SolverResult CanonicalizingSolver::check(std::vector<Assertion>& assertions,
+                                         const Assertion&) {
+  canonicalize_all(assertions);
+  return SolverResult::Unknown;
+}
+std::unique_ptr<Model>
+CanonicalizingSolver::resolve(std::vector<Assertion>& assertions,
+                              const Assertion&) {
+  canonicalize_all(assertions);
+  return std::make_unique<EmptyModel>(SolverResult::Unknown);
+}
+
+} // namespace caffeine

--- a/test/unit/IR/Transform/canonicalize.cpp
+++ b/test/unit/IR/Transform/canonicalize.cpp
@@ -1,0 +1,20 @@
+
+#include "caffeine/IR/Assertion.h"
+#include "caffeine/IR/Transforms.h"
+
+#include <gtest/gtest.h>
+
+using namespace caffeine;
+using namespace caffeine::transforms;
+
+TEST(CanonicalizeTransformTests, canonicalFalseAssertions) {
+  std::vector<Assertion> assertions = {
+      Assertion(ConstantInt::Create(false)),
+      Assertion(ConstantInt::Create(true)),
+      Assertion(Constant::Create(Type::int_ty(1), 0))};
+
+  canonicalize(assertions);
+
+  ASSERT_EQ(assertions.size(), 1);
+  ASSERT_TRUE(assertions[0].is_constant_value(false));
+}


### PR DESCRIPTION
This is a solver that attempts to convert expressions to a canonical form. We haven't really defined what we want out of a canonical form yet so all the solver does right now is eliminate duplicate assertions and remove unevaluated constant subexpressions.