### PR TITLE
Refactor the model class

### DIFF
--- a/include/caffeine/IR/Type.h
+++ b/include/caffeine/IR/Type.h
@@ -45,7 +45,8 @@ public:
     FloatingPoint,
     Pointer,
     FunctionPointer,
-    Array
+    Array,
+    Vector
   };
 
 private:
@@ -68,6 +69,7 @@ public:
   bool is_pointer() const;
   bool is_function_pointer() const;
   bool is_array() const;
+  bool is_vector() const;
 
   uint32_t bitwidth() const;
   uint32_t mantissa_bits() const;
@@ -92,6 +94,7 @@ public:
   // Note: Bitwidth is the bitwidth of the integer used to
   //       index into the byte array.
   static Type array_ty(uint32_t bitwidth);
+  static Type vector_ty();
 
   static Type from_llvm(llvm::Type* type);
 

--- a/include/caffeine/IR/Type.inl
+++ b/include/caffeine/IR/Type.inl
@@ -30,6 +30,9 @@ inline bool Type::is_function_pointer() const {
 inline bool Type::is_array() const {
   return kind() == Array;
 }
+inline bool Type::is_vector() const {
+  return kind() == Vector;
+}
 
 inline uint32_t Type::bitwidth() const {
   CAFFEINE_ASSERT(is_int() || is_array());

--- a/include/caffeine/IR/Value.h
+++ b/include/caffeine/IR/Value.h
@@ -46,11 +46,9 @@ private:
     T data;
     uint32_t index_bitwidth;
 
-    ArrayData(const T& data) : data(data), index_bitwidth(0){};
-    ArrayData(T&& data) : data(data), index_bitwidth(0){};
-    ArrayData(const T& data, uint32_t idx_width)
+    ArrayData(const T& data, uint32_t idx_width = 0)
         : data(data), index_bitwidth(idx_width){};
-    ArrayData(T&& data, uint32_t idx_width)
+    ArrayData(T&& data, uint32_t idx_width = 0)
         : data(data), index_bitwidth(idx_width){};
   };
 

--- a/include/caffeine/IR/Value.h
+++ b/include/caffeine/IR/Value.h
@@ -28,6 +28,7 @@ class ConstantFloat;
  * - A floating-point type (via llvm::APFloat)
  * - A byte array (via SharedArray)
  * - An empty value
+ * - A Vector of Values
  *
  * Each of these representations have a set of operations that are valid on them
  * (e.g. bvxxx for integers, fxxx for floats). All operations assert that their
@@ -37,7 +38,7 @@ class ConstantFloat;
 class Value {
 public:
   // Note: These correspond to the variant indices.
-  enum Kind { Empty, Int, Float, Array, NestedArray };
+  enum Kind { Empty, Int, Float, Array, Vector };
 
 private:
   template <typename T>
@@ -45,6 +46,8 @@ private:
     T data;
     uint32_t index_bitwidth;
 
+    ArrayData(const T& data) : data(data), index_bitwidth(0){};
+    ArrayData(T&& data) : data(data), index_bitwidth(0){};
     ArrayData(const T& data, uint32_t idx_width)
         : data(data), index_bitwidth(idx_width){};
     ArrayData(T&& data, uint32_t idx_width)
@@ -69,8 +72,8 @@ public:
   Value(const SharedArray& array, Type index_ty);
   Value(SharedArray&& array, Type index_ty);
 
-  Value(const std::vector<Value>& array, Type index_ty);
-  Value(std::vector<Value>&& array, Type index_ty);
+  Value(const std::vector<Value>& array);
+  Value(std::vector<Value>&& array);
 
   Value(const ConstantInt& constant);
   Value(const ConstantFloat& constant);
@@ -80,7 +83,7 @@ public:
   bool is_float() const { return inner_.index() == Float; }
   bool is_empty() const { return inner_.index() == Empty; }
   bool is_array() const { return inner_.index() == Array; }
-  bool is_nested_array() const { return inner_.index() == NestedArray; }
+  bool is_vector() const { return inner_.index() == Vector; }
 
   Kind kind() const { return static_cast<Kind>(inner_.index()); }
   Type type() const;
@@ -100,8 +103,8 @@ public:
   SharedArray& array();
   const SharedArray& array() const;
 
-  std::vector<Value>& nested_array();
-  const std::vector<Value>& nested_array() const;
+  std::vector<Value>& vector();
+  const std::vector<Value>& vector() const;
 
   // Value operations
   static Value bvadd(const Value& lhs, const Value& rhs);

--- a/include/caffeine/Solver/Solver.h
+++ b/include/caffeine/Solver/Solver.h
@@ -6,6 +6,7 @@
 
 #include "caffeine/ADT/Ref.h"
 #include "caffeine/IR/Value.h"
+#include "caffeine/Interpreter/Value.h"
 
 namespace caffeine {
 
@@ -39,9 +40,14 @@ public:
    * expression (i.e. is_constant returns true) with the value of said constant.
    *
    * It is invalid to call this method if the model is not SAT.
+   *
+   * Usage: end users should use this method in order to get the value of an
+   * expression in the given model.
    */
-  virtual Value evaluate(const Operation& expr) const;
+  Value evaluate(const Operation& expr) const;
+  Value evaluate(const ContextValue& expr, Context& ctx) const;
 
+protected:
   /**
    * Look up the value of a symbolic constant in this model. Returns an
    * appropriate constant expression with the value of said constant.
@@ -49,15 +55,21 @@ public:
    * If there are no constants with the given name then returns a null pointer.
    *
    * It is invalid to call this method if the model is not SAT.
+   *
+   * Usage: subclasses should override this method and implement appropriate
+   * lookup logic. End users should use the `evaluate` method because it
+   * performs the appropriate operations on the expression tree to evaluate it
+   * (it uses `lookup` under the hood).
    */
   virtual Value lookup(const Constant& constant) const = 0;
 
-protected:
   Model(const Model&) = default;
   Model(Model&&) = default;
 
   Model& operator=(const Model&) = default;
   Model& operator=(Model&&) = default;
+
+  friend class ExprEvaluator;
 };
 
 /**

--- a/src/IR/Type.cpp
+++ b/src/IR/Type.cpp
@@ -53,6 +53,10 @@ Type Type::array_ty(uint32_t bitwidth) {
   return Type(Array, bitwidth);
 }
 
+Type Type::vector_ty() {
+  return Type(Vector, 0);
+}
+
 llvm::FunctionType* Type::signature() const {
   CAFFEINE_ASSERT(is_function_pointer());
 
@@ -165,6 +169,9 @@ std::ostream& operator<<(std::ostream& os, const Type& t) {
 
   if (t.is_array())
     return os << "array";
+
+  if (t.is_vector())
+    return os << "vector";
 
   // TODO: Properly implement printing for any missing types
   return os << "<unimplemented>";

--- a/src/IR/Value.cpp
+++ b/src/IR/Value.cpp
@@ -13,14 +13,6 @@ using llvm::APInt;
 
 namespace caffeine {
 
-// template <typename T>
-// Value::ArrayData::ArrayData(const T& data, uint32_t idx_width)
-//     : data(data), index_bitwidth(idx_width) {}
-
-// template <typename T>
-// Value::ArrayData::ArrayData(T&& data, uint32_t idx_width)
-//     : data(data), index_bitwidth(idx_width) {}
-
 Value::Value(const APInt& apint) : inner_(apint) {}
 Value::Value(APInt&& apint) : inner_(std::move(apint)) {}
 

--- a/src/Interpreter/PrintingFailureLogger.cpp
+++ b/src/Interpreter/PrintingFailureLogger.cpp
@@ -33,7 +33,7 @@ public:
     if (!seen.insert(c.name()).second)
       return;
 
-    auto value = model->lookup(c);
+    auto value = model->evaluate(c);
 
     os << "  " << c.name() << " = " << value << "\n";
   }

--- a/src/Solver/Solver.cpp
+++ b/src/Solver/Solver.cpp
@@ -136,12 +136,7 @@ Value Model::evaluate(const ContextValue& expr, Context& ctx) const {
     std::transform(vec.begin(), vec.end(), nested_arr.begin(),
                    [&](const auto& i) -> Value { return evaluate(i, ctx); });
 
-    // If it's an empty nested array, then the bitwidth is 0 since we can't
-    // really determine it from anything else
-    return Value(std::move(nested_arr),
-                 vec.size() == 0
-                     ? Type::int_ty(0)
-                     : Type::int_ty(nested_arr[0].type().bitwidth()));
+    return Value(std::move(nested_arr));
   }
 
   CAFFEINE_UNREACHABLE();

--- a/src/Solver/Solver.cpp
+++ b/src/Solver/Solver.cpp
@@ -2,6 +2,7 @@
 #include "caffeine/IR/Assertion.h"
 #include "caffeine/IR/Value.h"
 #include "caffeine/IR/Visitor.h"
+#include "caffeine/Interpreter/Context.h"
 
 #include <fmt/format.h>
 
@@ -119,6 +120,31 @@ Model::Model(SolverResult result) : result_(result) {}
 
 Value Model::evaluate(const Operation& expr) const {
   return ExprEvaluator(this).visit(expr);
+}
+
+Value Model::evaluate(const ContextValue& expr, Context& ctx) const {
+  if (expr.is_scalar()) {
+    return ExprEvaluator(this).visit(*expr.scalar());
+  } else if (expr.is_pointer()) {
+    auto ptr_val = expr.pointer().value(ctx.heap());
+    return ExprEvaluator(this).visit(*ptr_val);
+  } else if (expr.is_vector()) {
+    const auto& vec = expr.vector();
+    std::vector<Value> nested_arr;
+    nested_arr.resize(vec.size());
+
+    std::transform(vec.begin(), vec.end(), nested_arr.begin(),
+                   [&](const auto& i) -> Value { return evaluate(i, ctx); });
+
+    // If it's an empty nested array, then the bitwidth is 0 since we can't
+    // really determine it from anything else
+    return Value(std::move(nested_arr),
+                 vec.size() == 0
+                     ? Type::int_ty(0)
+                     : Type::int_ty(nested_arr[0].type().bitwidth()));
+  }
+
+  CAFFEINE_UNREACHABLE();
 }
 
 SolverResult Solver::check(std::vector<Assertion>& assertions) {

--- a/src/Solver/Z3Solver.cpp
+++ b/src/Solver/Z3Solver.cpp
@@ -143,7 +143,7 @@ static z3::sort type_to_sort(z3::context& ctx, const Type& type) {
   case Type::FunctionPointer:
     CAFFEINE_ABORT("Cannot make symbolic function constants");
   case Type::Vector:
-    CAFFEINE_ABORT("Symbolic vectors are unimplemented");
+    CAFFEINE_ABORT("Cannot make symbolic vector constants");
   }
 
   CAFFEINE_UNREACHABLE();

--- a/src/Solver/Z3Solver.cpp
+++ b/src/Solver/Z3Solver.cpp
@@ -142,6 +142,8 @@ static z3::sort type_to_sort(z3::context& ctx, const Type& type) {
     CAFFEINE_ABORT("Cannot make symbolic pointer constants");
   case Type::FunctionPointer:
     CAFFEINE_ABORT("Cannot make symbolic function constants");
+  case Type::Vector:
+    CAFFEINE_ABORT("Symbolic vectors are unimplemented");
   }
 
   CAFFEINE_UNREACHABLE();


### PR DESCRIPTION
Copy pasted from #173:

The Model superclass evaluate expressions, and its subclasses just take care of lookups of constants in various solvers. The implications of this is that `evaluate` doesn't need to be `virtual` and `lookup` should be protected.

Also add some documentation for class to explain that.

Finally we want an overload for `evaluate(ContextValue)` for easier access.