### PR TITLE
Move builtins to their own folder within the libraries folder

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,7 +32,7 @@ if (NOT CAFFEINE_FMTONLY)
 
   add_subdirectory(src)
   add_subdirectory(test)
-  add_subdirectory(interface)
+  add_subdirectory(libraries)
 
 else()
   if (CLANG_FORMAT STREQUAL "CLANG_FORMAT-NOTFOUND")

--- a/interface/CMakeLists.txt
+++ b/interface/CMakeLists.txt
@@ -1,5 +1,0 @@
-
-add_llvm_ir_library(caffeine-builtins caffeine-builtins.c)
-
-target_compile_options(caffeine-builtins PRIVATE -O3)
-target_include_directories(caffeine-builtins PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}")

--- a/libraries/CMakeLists.txt
+++ b/libraries/CMakeLists.txt
@@ -1,0 +1,2 @@
+
+add_subdirectory(builtins)

--- a/libraries/builtins/CMakeLists.txt
+++ b/libraries/builtins/CMakeLists.txt
@@ -1,0 +1,16 @@
+
+file(
+  GLOB_RECURSE sources
+  CONFIGURE_DEPENDS
+  *.c
+  *.h
+)
+
+add_llvm_ir_library(caffeine-builtins
+  ${sources}
+  "${CMAKE_SOURCE_DIR}/interface/caffeine.h"
+)
+
+target_compile_options(caffeine-builtins PRIVATE -O3)
+target_include_directories(caffeine-builtins PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}")
+target_include_directories(caffeine-builtins PUBLIC "${CMAKE_SOURCE_DIR}/interface")

--- a/libraries/builtins/caffeine-builtins.h
+++ b/libraries/builtins/caffeine-builtins.h
@@ -1,0 +1,35 @@
+#pragma once
+
+#include "caffeine.h"
+
+#include <stdlib.h>
+
+/**
+ * Non-public builtin functions implemented by caffeine. Any such builtin
+ * functions should be put under the caffeine_builtin_XXX namespace.
+ *
+ * There are some exceptions for functions that were written before this
+ * reorganization occurred.
+ */
+
+/***************************************************
+ * Memory Allocation Functions                     *
+ ***************************************************/
+
+// This is a more limited version of malloc that expects size != 0
+void* caffeine_malloc(size_t size);
+void* caffeine_calloc(size_t size);
+
+// This is a more limited version of free that expects mem != nullptr
+void caffeine_free(void* mem);
+
+/***************************************************
+ * Pointer Functions                               *
+ ***************************************************/
+
+// Validate that mem is valid for a read/write of size and resolve the pointer
+// to all of its possible allocations.
+//
+// If you're going to perform a lot of reads or writes through a pointer then
+// this is probably something you'll want to do.
+void* caffeine_builtin_resolve(void* mem, size_t size);

--- a/libraries/builtins/memory.c
+++ b/libraries/builtins/memory.c
@@ -1,13 +1,6 @@
 
-#include "caffeine.h"
+#include "caffeine-builtins.h"
 #include <stddef.h>
- 
-// This is a more limited version of malloc that expects size != 0
-void* caffeine_malloc(size_t size);
-void* caffeine_calloc(size_t size);
-
-// This is a more limited version of free that expects mem != nullptr
-void caffeine_free(void* mem);
 
 void* malloc(size_t size) {
   if (size == 0)


### PR DESCRIPTION
I figure that we're going to have a number of libraries beyond the basic builtins stuff so moving it to a separate folder just made sense.