### PR TITLE
Add support for symbolic sizes in memory helper methods

### DIFF
--- a/include/caffeine/Memory/MemHeap.h
+++ b/include/caffeine/Memory/MemHeap.h
@@ -80,6 +80,8 @@ public:
    * given width would be a valid inbounds read.
    */
   Assertion check_inbounds(const ref<Operation>& offset, uint32_t width) const;
+  Assertion check_inbounds(const ref<Operation>& offset,
+                           const ref<Operation>& width) const;
 
   /**
    * Read the specified type from the allocation at the given offset.
@@ -216,6 +218,7 @@ public:
    * assertion that the pointer points within one of them.
    */
   Assertion check_valid(const Pointer& value, uint32_t width);
+  Assertion check_valid(const Pointer& value, const ref<Operation>& offset);
 
   /**
    * Get an assertion that checks whether the provided pointer points to the

--- a/src/Memory/MemHeap.cpp
+++ b/src/Memory/MemHeap.cpp
@@ -40,6 +40,11 @@ bool Allocation::is_constant_size() const {
 
 Assertion Allocation::check_inbounds(const ref<Operation>& offset,
                                      uint32_t width) const {
+  return check_inbounds(offset, ConstantInt::Create(llvm::APInt(
+                                    offset->type().bitwidth(), width)));
+}
+Assertion Allocation::check_inbounds(const ref<Operation>& offset,
+                                     const ref<Operation>& width) const {
   // Basic check: offset < size && offset + width < size.
   // Need to check that the entire range is within the allocation.
   // TODO: Should we check for wraparound, probably not worth it for now.
@@ -279,6 +284,10 @@ bool MemHeap::check_live(const AllocId& alloc) const {
 }
 
 Assertion MemHeap::check_valid(const Pointer& ptr, uint32_t width) {
+  return check_valid(ptr, ConstantInt::Create(llvm::APInt(
+                              ptr.offset()->type().bitwidth(), width)));
+}
+Assertion MemHeap::check_valid(const Pointer& ptr, const ref<Operation>& width) {
   /**
    * Implementation note: When checking that the end of the read is within the
    * allocation we check ptr < alloc + (size - width) instead of checking ptr +

--- a/src/Memory/MemHeap.cpp
+++ b/src/Memory/MemHeap.cpp
@@ -287,7 +287,8 @@ Assertion MemHeap::check_valid(const Pointer& ptr, uint32_t width) {
   return check_valid(ptr, ConstantInt::Create(llvm::APInt(
                               ptr.offset()->type().bitwidth(), width)));
 }
-Assertion MemHeap::check_valid(const Pointer& ptr, const ref<Operation>& width) {
+Assertion MemHeap::check_valid(const Pointer& ptr,
+                               const ref<Operation>& width) {
   /**
    * Implementation note: When checking that the end of the read is within the
    * allocation we check ptr < alloc + (size - width) instead of checking ptr +


### PR DESCRIPTION
As in title. No longer needed to support memcpy but useful anyway.