### PR TITLE
Modify PrintingFailureLogger to print a backtrace of the symbolic program

### DIFF
--- a/include/caffeine/Interpreter/Context.h
+++ b/include/caffeine/Interpreter/Context.h
@@ -21,7 +21,7 @@ namespace caffeine {
 
 class Context {
 private:
-  std::vector<StackFrame> stack;
+  std::vector<StackFrame> stack_;
   // The current set of invariants for this context
   std::vector<Assertion> assertions_;
   std::unordered_map<llvm::GlobalVariable*, ContextValue> globals_;
@@ -48,6 +48,8 @@ public:
    */
   const StackFrame& stack_top() const;
   StackFrame& stack_top();
+
+  const std::vector<StackFrame>& stack() const;
 
   // Utility methods for adding/removing stack frames
   /**


### PR DESCRIPTION
This is less useful for our test cases but as they get bigger it's a useful capability to have. In the future we could get it down to the source code line when debuginfo is present.