### PR TITLE
Implement memcpy and memmove intrinsics

### DIFF
--- a/include/caffeine/Interpreter/Interpreter.h
+++ b/include/caffeine/Interpreter/Interpreter.h
@@ -84,6 +84,7 @@ public:
   ExecutionResult visitAllocaInst(llvm::AllocaInst& inst);
 
   ExecutionResult visitMemCpyInst(llvm::MemCpyInst& memcpy);
+  ExecutionResult visitMemMoveInst(llvm::MemMoveInst& memmove);
 
 private:
   ExecutionResult visitExternFunc(llvm::CallInst& inst);

--- a/include/caffeine/Interpreter/Interpreter.h
+++ b/include/caffeine/Interpreter/Interpreter.h
@@ -83,6 +83,8 @@ public:
   ExecutionResult visitShuffleVectorInst(llvm::ShuffleVectorInst& inst);
   ExecutionResult visitAllocaInst(llvm::AllocaInst& inst);
 
+  ExecutionResult visitMemCpyInst(llvm::MemCpyInst& memcpy);
+
 private:
   ExecutionResult visitExternFunc(llvm::CallInst& inst);
 

--- a/include/caffeine/Interpreter/Interpreter.h
+++ b/include/caffeine/Interpreter/Interpreter.h
@@ -92,6 +92,8 @@ private:
   ExecutionResult visitMalloc(llvm::CallInst& inst);
   ExecutionResult visitCalloc(llvm::CallInst& inst);
   ExecutionResult visitFree(llvm::CallInst& inst);
+
+  ExecutionResult visitBuiltinResolve(llvm::CallInst& inst);
 };
 
 } // namespace caffeine

--- a/libraries/builtins/string.c
+++ b/libraries/builtins/string.c
@@ -1,0 +1,36 @@
+
+#include "caffeine-builtins.h"
+
+#include <stdint.h>
+#include <string.h>
+
+// This function is called implicitly by the interpreter to implement the memcpy
+// intrinsic.
+void caffeine_builtin_memcpy(void* dst_, void* src_, size_t size) {
+  char* dst = caffeine_builtin_resolve(dst_, size);
+  char* src = caffeine_builtin_resolve(src_, size);
+
+  // Assert that the ranges don't overlap
+  caffeine_assert(dst + size <= src || src + size <= dst);
+
+  for (size_t i = 0; i < size; ++i) {
+    dst[i] = src[i];
+  }
+}
+
+// This function is called implicitly by the interpreter to implement the
+// memmove intrinsic.
+void caffeine_builtin_memmove(void* dst_, void* src_, size_t size) {
+  char* dst = caffeine_builtin_resolve(dst_, size);
+  char* src = caffeine_builtin_resolve(src_, size);
+
+  // If dst and src overlap and writes to dst would overwrite part of src before
+  // we would reach it then we need to copy backwards.
+  if (dst + size > src && src + size > dst && dst >= src) {
+    for (size_t i = size; i != 0; --i) {
+      dst[i - 1] = src[i - 1];
+    }
+  } else {
+    caffeine_builtin_memcpy(dst, src, size);
+  }
+}

--- a/libraries/builtins/string.c
+++ b/libraries/builtins/string.c
@@ -4,18 +4,22 @@
 #include <stdint.h>
 #include <string.h>
 
-// This function is called implicitly by the interpreter to implement the memcpy
-// intrinsic.
-void caffeine_builtin_memcpy(void* dst_, void* src_, size_t size) {
+static void caffeine_builtin_memcpy_nocheck(void* dst_, void* src_, size_t size) {
   char* dst = caffeine_builtin_resolve(dst_, size);
   char* src = caffeine_builtin_resolve(src_, size);
-
-  // Assert that the ranges don't overlap
-  caffeine_assert(dst + size <= src || src + size <= dst);
 
   for (size_t i = 0; i < size; ++i) {
     dst[i] = src[i];
   }
+}
+
+// This function is called implicitly by the interpreter to implement the memcpy
+// intrinsic.
+void caffeine_builtin_memcpy(void* dst, void* src, size_t size) {
+  // Assert that the ranges don't overlap
+  caffeine_assert(dst + size <= src || src + size <= dst);
+
+  caffeine_builtin_memcpy_nocheck(dst, src, size);
 }
 
 // This function is called implicitly by the interpreter to implement the
@@ -31,6 +35,6 @@ void caffeine_builtin_memmove(void* dst_, void* src_, size_t size) {
       dst[i - 1] = src[i - 1];
     }
   } else {
-    caffeine_builtin_memcpy(dst, src, size);
+    caffeine_builtin_memcpy_nocheck(dst, src, size);
   }
 }

--- a/src/Interpreter/Interpreter.cpp
+++ b/src/Interpreter/Interpreter.cpp
@@ -892,6 +892,16 @@ ExecutionResult Interpreter::visitAllocaInst(llvm::AllocaInst& inst) {
   return ExecutionResult::Continue;
 }
 
+ExecutionResult Interpreter::visitMemCpyInst(llvm::MemCpyInst& memcpy) {
+  // memcpy is implemented by a C function within the builtins library so we
+  // just forward the call to that.
+  auto memcpy_fn = memcpy.getModule()->getFunction("caffeine_builtin_memcpy");
+  CAFFEINE_ASSERT(memcpy_fn);
+  memcpy.setCalledFunction(memcpy_fn);
+
+  return visitCall(memcpy);
+}
+
 /***************************************************
  * External function                               *
  ***************************************************/

--- a/src/Interpreter/Interpreter.cpp
+++ b/src/Interpreter/Interpreter.cpp
@@ -895,11 +895,20 @@ ExecutionResult Interpreter::visitAllocaInst(llvm::AllocaInst& inst) {
 ExecutionResult Interpreter::visitMemCpyInst(llvm::MemCpyInst& memcpy) {
   // memcpy is implemented by a C function within the builtins library so we
   // just forward the call to that.
-  auto memcpy_fn = memcpy.getModule()->getFunction("caffeine_builtin_memcpy");
-  CAFFEINE_ASSERT(memcpy_fn);
-  memcpy.setCalledFunction(memcpy_fn);
+  auto func = memcpy.getModule()->getFunction("caffeine_builtin_memcpy");
+  CAFFEINE_ASSERT(func);
+  memcpy.setCalledFunction(func);
 
   return visitCall(memcpy);
+}
+ExecutionResult Interpreter::visitMemMoveInst(llvm::MemMoveInst& memmove) {
+  // memmove is implemented by a C function within the builtins library so we
+  // just forward the call to that.
+  auto func = memmove.getModule()->getFunction("caffeine_builtin_memmove");
+  CAFFEINE_ASSERT(func);
+  memmove.setCalledFunction(func);
+
+  return visitCall(memmove);
 }
 
 /***************************************************

--- a/test/run-pass/mem/memcpy-basic.c
+++ b/test/run-pass/mem/memcpy-basic.c
@@ -1,0 +1,15 @@
+
+#include "caffeine.h"
+#include <stdlib.h>
+#include <string.h>
+
+const char data[] = "test data";
+char dest[20];
+
+void test(void) {
+  memcpy(dest, data, sizeof(data));
+
+  for (size_t i = 0; i < sizeof(data); ++i) {
+    caffeine_assert(dest[i] == data[i]);
+  }
+}

--- a/test/run-pass/mem/memmove-basic.c
+++ b/test/run-pass/mem/memmove-basic.c
@@ -1,0 +1,15 @@
+
+#include "caffeine.h"
+#include <stdlib.h>
+#include <string.h>
+
+char reference[] = "56789012340123456789";
+char data[] = "01234567890123456789";
+
+void test(void) {
+  memmove(data, data + 5, 10);
+
+  for (size_t i = 0; i < sizeof(data); ++i) {
+    caffeine_assert(reference[i] == data[i]);
+  }
+}


### PR DESCRIPTION
This PR implements the `memcpy` and `memmove` intrinsics by forwarding them to some C functions defined within the `caffeine-builtins` library.

Closes #135.