### PR TITLE
Move EmptyModel from Z3Solver.cpp to Solver.h

### DIFF
--- a/include/caffeine/Solver/Solver.h
+++ b/include/caffeine/Solver/Solver.h
@@ -137,13 +137,18 @@ public:
   // Calls resolve with an empty extra assertion.
   std::unique_ptr<Model> resolve(std::vector<Assertion>& assertions);
 
-protected:
-  // Protected so that derived classes can still be copyable if they so choose.
   Solver(const Solver&) = default;
   Solver(Solver&&) = default;
 
   Solver& operator=(const Solver&) = default;
   Solver& operator=(Solver&&) = default;
+};
+
+class EmptyModel final : public Model {
+public:
+  EmptyModel(SolverResult result);
+
+  Value lookup(const Constant&) const override;
 };
 
 } // namespace caffeine

--- a/include/caffeine/Solver/Z3Solver.h
+++ b/include/caffeine/Solver/Z3Solver.h
@@ -43,6 +43,9 @@ public:
    */
   std::unique_ptr<Model> resolve(std::vector<Assertion>& assertions,
                                  const Assertion& extra) override;
+
+  Z3Solver(Z3Solver&&) = default;
+  Z3Solver& operator=(Z3Solver&&) = default;
 };
 
 } // namespace caffeine

--- a/src/Solver/Solver.cpp
+++ b/src/Solver/Solver.cpp
@@ -155,4 +155,12 @@ std::unique_ptr<Model> Solver::resolve(std::vector<Assertion>& assertions) {
   return resolve(assertions, Assertion());
 }
 
+EmptyModel::EmptyModel(SolverResult result) : Model(result) {
+  CAFFEINE_ASSERT(result != SolverResult::SAT);
+}
+
+Value EmptyModel::lookup(const Constant&) const {
+  CAFFEINE_ABORT("Model was empty");
+}
+
 } // namespace caffeine

--- a/src/Solver/Z3Solver.cpp
+++ b/src/Solver/Z3Solver.cpp
@@ -149,17 +149,6 @@ static z3::sort type_to_sort(z3::context& ctx, const Type& type) {
   CAFFEINE_UNREACHABLE();
 }
 
-class EmptyModel : public Model {
-public:
-  EmptyModel(SolverResult result) : Model(result) {
-    CAFFEINE_ASSERT(result != SolverResult::SAT);
-  }
-
-  Value lookup(const Constant&) const override {
-    CAFFEINE_ABORT("Model was empty");
-  }
-};
-
 /***************************************************
  * Z3Model                                         *
  ***************************************************/


### PR DESCRIPTION
It's useful more broadly than `Z3Solver` and this will allow it to be used as such.