### PR TITLE
Implement expression decomposition solver

### DIFF
--- a/include/caffeine/IR/Transforms.h
+++ b/include/caffeine/IR/Transforms.h
@@ -1,0 +1,46 @@
+#pragma once
+
+/**
+ * This header is meant to contain a number of transforms which can be used as
+ * needed.
+ *
+ * Most of the time they will probably be used by various types of solvers but
+ * since they're common functionality it is useful to have them all in one
+ * place.
+ *
+ * To avoid polluting the caffeine namespace unnecessarily I've placed them
+ * within the caffeine::transforms namespace.
+ *
+ * General Notes on Writing a Transform
+ * ====================================
+ * In some cases it is correct to perform an in-place substitution of an
+ * expression node. For example, doing something like
+ *     *expr = *UnaryOp::CreateNot(other_expr))
+ * is only valid under certain conditions. In all other cases you need to
+ * rebuild the expression tree with the replaced node.
+ *
+ * The required conditions for an in-place transform to be valid are:
+ * 1. The transform can only use semantics local to the expression node being
+ *    transformed. As an example, replacing not(not(x)) with x is fine, but
+ *    taking an external x = true and using that to replace not(not(x)) in-place
+ *    with true is not.
+ * 2. The expression node is not being shared across threads. This is due to
+ *    thread-safety concerns but is generally not something the internal
+ *    implementation of a transform algorithm should have to worry about.
+ */
+
+#include <vector>
+
+namespace caffeine {
+class Assertion;
+}
+
+namespace caffeine::transforms {
+
+/**
+ * Attempts to break down large and complex assertions into multiple simpler
+ * assertions that are equivalent to the larger one.
+ */
+void decompose(std::vector<Assertion>& assertions);
+
+} // namespace caffeine::transforms

--- a/include/caffeine/Solver/DecompSolver.h
+++ b/include/caffeine/Solver/DecompSolver.h
@@ -1,0 +1,34 @@
+#ifndef CAFFEINE_SOLVER_DECOMPSOLVER_H
+#define CAFFEINE_SOLVER_DECOMPSOLVER_H
+
+#include "caffeine/Solver/Solver.h"
+
+namespace caffeine {
+
+/**
+ * Solver that tries to break down large but complex assertions into multiple
+ * simpler ones that are equivalent to the original one.
+ *
+ * Always returns unknown.
+ */
+class DecompSolver final : public Solver {
+public:
+  SolverResult check(std::vector<Assertion>& assertions,
+                     const Assertion& extra) override;
+
+  std::unique_ptr<Model> resolve(std::vector<Assertion>& assertions,
+                                 const Assertion& extra) override;
+
+  DecompSolver() = default;
+  DecompSolver(const DecompSolver&) = default;
+  DecompSolver(DecompSolver&&) = default;
+  DecompSolver& operator=(const DecompSolver&) = default;
+  DecompSolver& operator=(DecompSolver&&) = default;
+
+private:
+  void transform(std::vector<Assertion>& assertions);
+};
+
+} // namespace caffeine
+
+#endif

--- a/src/IR/Transforms/decompose.cpp
+++ b/src/IR/Transforms/decompose.cpp
@@ -1,7 +1,7 @@
 
-#include "caffeine/IR/Transforms.h"
 #include "caffeine/IR/Assertion.h"
 #include "caffeine/IR/Matching.h"
+#include "caffeine/IR/Transforms.h"
 
 namespace caffeine::transforms {
 

--- a/src/IR/Transforms/decompose.cpp
+++ b/src/IR/Transforms/decompose.cpp
@@ -1,0 +1,42 @@
+
+#include "caffeine/IR/Transforms.h"
+#include "caffeine/IR/Assertion.h"
+#include "caffeine/IR/Matching.h"
+
+namespace caffeine::transforms {
+
+void decompose(std::vector<Assertion>& assertions) {
+  using std::swap;
+  using namespace matching;
+
+  for (size_t i = 0; i < assertions.size(); ++i) {
+    // Keep breaking the expression down until it stops working
+    while (true) {
+      ref<Operation> lhs, rhs, value;
+
+      // A & B -> A, B
+      if (matches(assertions[i], And(lhs, rhs))) {
+        *assertions[i].value() = *lhs;
+        assertions.push_back(std::move(rhs));
+        continue;
+      }
+
+      // !(A | B) -> !A, !B
+      if (matches(assertions[i], Not(Or(lhs, rhs)))) {
+        *assertions[i].value() = *UnaryOp::CreateNot(lhs);
+        assertions.push_back(UnaryOp::CreateNot(rhs));
+        continue;
+      }
+
+      // !!A -> A
+      if (matches(assertions[i], Not(Not(value)))) {
+        *assertions[i].value() = *value;
+        continue;
+      }
+
+      break;
+    }
+  }
+}
+
+} // namespace caffeine::transforms

--- a/src/Solver/DecompSolver.cpp
+++ b/src/Solver/DecompSolver.cpp
@@ -2,7 +2,6 @@
 #include "caffeine/Solver/DecompSolver.h"
 #include "caffeine/IR/Assertion.h"
 #include "caffeine/IR/Transforms.h"
-#include "caffeine/Solver/SequenceSolver.h"
 
 #include <algorithm>
 
@@ -10,7 +9,7 @@ namespace caffeine {
 
 void DecompSolver::transform(std::vector<Assertion>& assertions) {
   transforms::decompose(assertions);
-  
+
   auto it = std::remove_if(
       assertions.begin(), assertions.end(),
       [](const auto& assertion) { return assertion.is_constant_value(true); });
@@ -27,4 +26,5 @@ std::unique_ptr<Model> DecompSolver::resolve(std::vector<Assertion>& assertions,
   transform(assertions);
   return std::make_unique<EmptyModel>(SolverResult::Unknown);
 }
+
 } // namespace caffeine

--- a/src/Solver/DecompSolver.cpp
+++ b/src/Solver/DecompSolver.cpp
@@ -14,7 +14,7 @@ void DecompSolver::transform(std::vector<Assertion>& assertions) {
 
   auto it = std::remove_if(
       assertions.begin(), assertions.end(),
-      [](const auto& assertion) { return assertion.is_constant(true); });
+      [](const auto& assertion) { return assertion.is_constant_value(true); });
   assertions.erase(it, assertions.end());
 
   for (size_t i = 0; i < assertions.size(); ++i) {

--- a/src/Solver/DecompSolver.cpp
+++ b/src/Solver/DecompSolver.cpp
@@ -1,0 +1,57 @@
+
+#include "caffeine/Solver/DecompSolver.h"
+#include "caffeine/IR/Assertion.h"
+#include "caffeine/IR/Matching.h"
+#include "caffeine/Solver/SequenceSolver.h"
+
+#include <algorithm>
+
+namespace caffeine {
+
+void DecompSolver::transform(std::vector<Assertion>& assertions) {
+  using std::swap;
+  using namespace matching;
+
+  auto it = std::remove_if(
+      assertions.begin(), assertions.end(),
+      [](const auto& assertion) { return assertion.is_constant(true); });
+  assertions.erase(it, assertions.end());
+
+  for (size_t i = 0; i < assertions.size(); ++i) {
+    // Keep performing the transformations until they stop working
+    while (true) {
+      ref<Operation> lhs, rhs, value;
+
+      if (matches(assertions[i], And(lhs, rhs))) {
+        *assertions[i].value() = *lhs;
+        assertions.emplace_back(std::move(rhs));
+        continue;
+      }
+
+      if (matches(assertions[i], Not(Or(lhs, rhs)))) {
+        *assertions[i].value() = *UnaryOp::CreateNot(lhs);
+        assertions.emplace_back(UnaryOp::CreateNot(rhs));
+        continue;
+      }
+
+      if (matches(assertions[i], Not(Not(value)))) {
+        *assertions[i].value() = *value;
+        continue;
+      }
+
+      break;
+    }
+  }
+}
+
+SolverResult DecompSolver::check(std::vector<Assertion>& assertions,
+                                 const Assertion&) {
+  transform(assertions);
+  return SolverResult::Unknown;
+}
+std::unique_ptr<Model> DecompSolver::resolve(std::vector<Assertion>& assertions,
+                                             const Assertion&) {
+  transform(assertions);
+  return std::make_unique<EmptyModel>(SolverResult::Unknown);
+}
+} // namespace caffeine

--- a/src/Solver/DecompSolver.cpp
+++ b/src/Solver/DecompSolver.cpp
@@ -1,7 +1,7 @@
 
 #include "caffeine/Solver/DecompSolver.h"
 #include "caffeine/IR/Assertion.h"
-#include "caffeine/IR/Matching.h"
+#include "caffeine/IR/Transforms.h"
 #include "caffeine/Solver/SequenceSolver.h"
 
 #include <algorithm>
@@ -9,39 +9,12 @@
 namespace caffeine {
 
 void DecompSolver::transform(std::vector<Assertion>& assertions) {
-  using std::swap;
-  using namespace matching;
-
+  transforms::decompose(assertions);
+  
   auto it = std::remove_if(
       assertions.begin(), assertions.end(),
       [](const auto& assertion) { return assertion.is_constant_value(true); });
   assertions.erase(it, assertions.end());
-
-  for (size_t i = 0; i < assertions.size(); ++i) {
-    // Keep performing the transformations until they stop working
-    while (true) {
-      ref<Operation> lhs, rhs, value;
-
-      if (matches(assertions[i], And(lhs, rhs))) {
-        *assertions[i].value() = *lhs;
-        assertions.emplace_back(std::move(rhs));
-        continue;
-      }
-
-      if (matches(assertions[i], Not(Or(lhs, rhs)))) {
-        *assertions[i].value() = *UnaryOp::CreateNot(lhs);
-        assertions.emplace_back(UnaryOp::CreateNot(rhs));
-        continue;
-      }
-
-      if (matches(assertions[i], Not(Not(value)))) {
-        *assertions[i].value() = *value;
-        continue;
-      }
-
-      break;
-    }
-  }
 }
 
 SolverResult DecompSolver::check(std::vector<Assertion>& assertions,

--- a/test/unit/IR/Transform/decompose.cpp
+++ b/test/unit/IR/Transform/decompose.cpp
@@ -1,0 +1,52 @@
+#include "caffeine/IR/Assertion.h"
+#include "caffeine/IR/Transforms.h"
+#include <gtest/gtest.h>
+
+using namespace caffeine;
+using namespace caffeine::transforms;
+
+TEST(DecomposeTransformTests, breaks_down_top_level_and) {
+  std::vector<Assertion> assertions = {Assertion(BinaryOp::CreateAnd(
+      BinaryOp::CreateAnd(Constant::Create(Type::int_ty(1), 0),
+                          Constant::Create(Type::int_ty(1), 1)),
+      Constant::Create(Type::int_ty(1), 2)))};
+
+  decompose(assertions);
+
+  ASSERT_EQ(assertions.size(), 3);
+
+  std::sort(assertions.begin(), assertions.end(),
+            [](const auto& a, const auto& b) {
+              const auto* lhs = llvm::cast<Constant>(a.value().get());
+              const auto* rhs = llvm::cast<Constant>(b.value().get());
+              return lhs->number() < rhs->number();
+            });
+
+  ASSERT_EQ(llvm::cast<Constant>(*assertions[0].value()).number(), 0);
+  ASSERT_EQ(llvm::cast<Constant>(*assertions[0].value()).number(), 0);
+  ASSERT_EQ(llvm::cast<Constant>(*assertions[0].value()).number(), 0);
+}
+
+TEST(DecomposeTransformTests, breaks_down_top_level_not_or) {
+  std::vector<Assertion> assertions = {
+      Assertion(UnaryOp::CreateNot(BinaryOp::CreateOr(
+          UnaryOp::CreateNot(
+              BinaryOp::CreateAnd(Constant::Create(Type::int_ty(1), 0),
+                                  Constant::Create(Type::int_ty(1), 1))),
+          UnaryOp::CreateNot(Constant::Create(Type::int_ty(1), 2)))))};
+
+  decompose(assertions);
+
+  ASSERT_EQ(assertions.size(), 3);
+
+  std::sort(assertions.begin(), assertions.end(),
+            [](const auto& a, const auto& b) {
+              const auto* lhs = llvm::cast<Constant>(a.value().get());
+              const auto* rhs = llvm::cast<Constant>(b.value().get());
+              return lhs->number() < rhs->number();
+            });
+
+  ASSERT_EQ(llvm::cast<Constant>(*assertions[0].value()).number(), 0);
+  ASSERT_EQ(llvm::cast<Constant>(*assertions[0].value()).number(), 0);
+  ASSERT_EQ(llvm::cast<Constant>(*assertions[0].value()).number(), 0);
+}


### PR DESCRIPTION
This adds a new intermediate solver, DecompSolver, that breaks down top-level assertions into multiple smaller ones that are 
to the original assertion.

The transforms currently implemented are
```
 - true          -> nothing
 - and(a, b)     -> a, b
 - not(or(a, b)) -> not(a), not(b)
```

By itself this solver doesn't give a large gain but it's an important building block towards others that do. The actual details of the decomposition algorithm have been put in a separate method exposed through `IR/Transforms.h`. Unit tests are also included.

Draft since it depends on #157, #187, and #176.