### PR TITLE
Implement solver which composes other solvers

### DIFF
--- a/include/caffeine/Solver/SequenceSolver.h
+++ b/include/caffeine/Solver/SequenceSolver.h
@@ -1,0 +1,72 @@
+#ifndef CAFFEINE_SOLVER_SEQUENCESOLVER_H
+#define CAFFEINE_SOLVER_SEQUENCESOLVER_H
+
+#include "caffeine/Solver/Solver.h"
+
+#include <tuple>
+
+namespace caffeine {
+
+/**
+ * Solver which calls a sequence of other solvers in series.
+ *
+ * If any of the solvers in the chain return a result other than Unknown then
+ * execution of the sequence stops there and that result is returned. If none of
+ * the solvers return a result then Unknown is returned.
+ */
+template <typename... Ts>
+class SequenceSolver final : public Solver {
+private:
+  std::tuple<Ts...> solvers;
+
+public:
+  SequenceSolver(Ts&&... solvers) : solvers(std::move(solvers)...) {}
+  SequenceSolver(const Ts&... solvers) : solvers(solvers...) {}
+
+  SolverResult check(std::vector<Assertion>& assertions,
+                     const Assertion& extra) override {
+    return check_internal<0>(assertions, extra);
+  }
+
+  std::unique_ptr<Model> resolve(std::vector<Assertion>& assertions,
+                                 const Assertion& extra) override {
+    return resolve_internal<0>(assertions, extra);
+  }
+
+private:
+  template <size_t i>
+  SolverResult check_internal(std::vector<Assertion>& assertions,
+                              const Assertion& extra) {
+    SolverResult result = std::get<i>(solvers).check(assertions, extra);
+    if (result != SolverResult::Unknown)
+      return result;
+
+    if constexpr (i != sizeof...(Ts) - 1) {
+      return check_internal<i + 1>(assertions, extra);
+    } else {
+      return SolverResult::Unknown;
+    }
+  }
+
+  template <size_t i>
+  std::unique_ptr<Model> resolve_internal(std::vector<Assertion>& assertions,
+                                          const Assertion& extra) {
+    std::unique_ptr<Model> model =
+        std::get<i>(solvers).resolve(assertions, extra);
+    if (model->result() != SolverResult::Unknown)
+      return model;
+
+    if constexpr (i != sizeof...(Ts) - 1) {
+      return resolve_internal<i + 1>(assertions, extra);
+    } else {
+      return std::make_unique<EmptyModel>(SolverResult::Unknown);
+    }
+  }
+
+  static_assert(sizeof...(Ts) != 0);
+  static_assert((... && std::is_base_of_v<Solver, Ts>));
+};
+
+} // namespace caffeine
+
+#endif


### PR DESCRIPTION
Basically it keeps trying new solvers until one of them returns something other than `Unknown`. This is meant to be used for combining multiple simplifying solvers. (i.e. ones that just modify the assertions and never actually solve the expression)