### PR TITLE
Remove ConstantArray Operation

### DIFF
--- a/include/caffeine/IR/Matching.h
+++ b/include/caffeine/IR/Matching.h
@@ -288,7 +288,6 @@ namespace matching {
 
   CAFFEINE_DECL_ZEROOP_MATCHER(ConstantInt, caffeine::ConstantInt);
   CAFFEINE_DECL_ZEROOP_MATCHER(ConstantFloat, caffeine::ConstantFloat);
-  CAFFEINE_DECL_ZEROOP_MATCHER(ConstantArray, caffeine::ConstantArray);
   CAFFEINE_DECL_ZEROOP_MATCHER(Constant, caffeine::Constant);
 
 #undef CAFFEINE_DECL_UNOP_MATCHER

--- a/include/caffeine/IR/Operation.h
+++ b/include/caffeine/IR/Operation.h
@@ -232,7 +232,7 @@ protected:
   using OpVec = boost::container::static_vector<ref<Operation>, 3>;
   using Inner =
       std::variant<std::monostate, OpVec, llvm::APInt, llvm::APFloat, uint64_t,
-                   std::string, SharedArray, PersistentArray<ref<Operation>>>;
+                   std::string, PersistentArray<ref<Operation>>>;
 
   uint16_t opcode_;
   uint16_t dummy_ = 0; // Unused, used for padding

--- a/include/caffeine/IR/Operation.h
+++ b/include/caffeine/IR/Operation.h
@@ -128,7 +128,7 @@ public:
     ConstantNumbered = detail::opcode(1, 0, 1),
     ConstantInt = detail::opcode(1, 0, 5),
     ConstantFloat = detail::opcode(1, 0, 6),
-    ConstantArray = detail::opcode(1, 0, 7),
+
     /**
      * An unnamed symbolic constant that can have any value whenever it is
      * used. Has the same semantics as LLVM's undef.
@@ -215,7 +215,7 @@ public:
      * Create a new symbolic array that is filled with a default value.
      *
      * This is mean to be used for malloc and alloca. Constant arrays with
-     * prefilled data should use ConstantArray instead.
+     * prefilled data should use FixedArray instead.
      */
     Alloc = detail::opcode(21, 2, 0),
     /**
@@ -451,24 +451,6 @@ public:
   static ref<Operation> Create(const llvm::APFloat& fconst);
   static ref<Operation> Create(llvm::APFloat&& fconst);
   static ref<Operation> Create(double value);
-
-  static bool classof(const Operation* op);
-};
-
-/**
- * Constant byte array.
- */
-class ConstantArray : public ArrayBase {
-private:
-  ConstantArray(Type t, const SharedArray& array);
-  ConstantArray(Type t, SharedArray&& array);
-
-public:
-  ref<Operation> size() const override;
-  const SharedArray& data() const;
-
-  static ref<Operation> Create(Type index_ty, const SharedArray& array);
-  static ref<Operation> Create(Type index_ty, SharedArray&& array);
 
   static bool classof(const Operation* op);
 };

--- a/include/caffeine/IR/Operation.inl
+++ b/include/caffeine/IR/Operation.inl
@@ -27,7 +27,6 @@ namespace caffeine {
 // All derived operation types should be the same size
 static_assert(sizeof(ConstantInt) == sizeof(Operation));
 static_assert(sizeof(ConstantFloat) == sizeof(Operation));
-static_assert(sizeof(ConstantArray) == sizeof(Operation));
 static_assert(sizeof(Constant) == sizeof(Operation));
 static_assert(sizeof(BinaryOp) == sizeof(Operation));
 static_assert(sizeof(UnaryOp) == sizeof(Operation));
@@ -255,17 +254,6 @@ inline const llvm::APFloat& ConstantFloat::value() const {
 }
 
 /***************************************************
- * ConstantArray                                   *
- ***************************************************/
-inline const SharedArray& ConstantArray::data() const {
-  return std::get<SharedArray>(inner_);
-}
-
-inline ref<Operation> ConstantArray::size() const {
-  return ConstantInt::Create(llvm::APInt(type().bitwidth(), data().size()));
-}
-
-/***************************************************
  * BinaryOp                                        *
  ***************************************************/
 inline const ref<Operation>& BinaryOp::lhs() const {
@@ -426,7 +414,6 @@ inline ref<Operation> FixedArray::size() const {
 
 CAFFEINE_OP_DECL_CLASSOF(ConstantInt, ConstantInt);
 CAFFEINE_OP_DECL_CLASSOF(ConstantFloat, ConstantFloat);
-CAFFEINE_OP_DECL_CLASSOF(ConstantArray, ConstantArray);
 CAFFEINE_OP_DECL_CLASSOF(SelectOp, Select);
 CAFFEINE_OP_DECL_CLASSOF(AllocOp, Alloc);
 CAFFEINE_OP_DECL_CLASSOF(LoadOp, Load);
@@ -453,8 +440,8 @@ inline bool FCmpOp::classof(const Operation* op) {
 }
 
 inline bool ArrayBase::classof(const Operation* op) {
-  return op->opcode() == ConstantArray || op->opcode() == Alloc ||
-         op->opcode() == Store || op->opcode() == FixedArray;
+  return op->opcode() == Alloc || op->opcode() == Store ||
+         op->opcode() == FixedArray;
 }
 
 #undef CAFFEINE_OP_DECL_CLASSOF

--- a/include/caffeine/IR/Visitor.h
+++ b/include/caffeine/IR/Visitor.h
@@ -93,7 +93,6 @@ public:
   RetTy visitConstant     (transform_t<Constant>     & O) { return CAFFEINE_OP_DELEGATE(Operation); }
   RetTy visitConstantInt  (transform_t<ConstantInt>  & O) { return CAFFEINE_OP_DELEGATE(Operation); }
   RetTy visitConstantFloat(transform_t<ConstantFloat>& O) { return CAFFEINE_OP_DELEGATE(Operation); }
-  RetTy visitConstantArray(transform_t<ConstantArray>& O) { return CAFFEINE_OP_DELEGATE(ArrayBase); }
   RetTy visitUndef        (transform_t<Undef>        & O) { return CAFFEINE_OP_DELEGATE(Operation); }
   RetTy visitFixedArray   (transform_t<FixedArray>   & O) { return CAFFEINE_OP_DELEGATE(ArrayBase); }
 

--- a/include/caffeine/IR/Visitor.inl
+++ b/include/caffeine/IR/Visitor.inl
@@ -68,7 +68,6 @@ RetTy OpVisitorBase<Transform, SubClass, RetTy>::visit(
     DELEGATE(Select, SelectOp, SelectOp);
     DELEGATE(ConstantInt, ConstantInt);
     DELEGATE(ConstantFloat, ConstantFloat);
-    DELEGATE(ConstantArray, ConstantArray);
     DELEGATE(Undef, Undef);
     DELEGATE(FixedArray, FixedArray);
 

--- a/src/IR/Operation.cpp
+++ b/src/IR/Operation.cpp
@@ -1210,13 +1210,7 @@ ref<Operation> LoadOp::Create(const ref<Operation>& data,
 
 #ifdef CAFFEINE_IMPLICIT_CONSTANT_FOLDING
   const auto* fixedarray = llvm::dyn_cast<caffeine::FixedArray>(data.get());
-  const auto* constarray = llvm::dyn_cast<caffeine::ConstantArray>(data.get());
   const auto* offset_int = llvm::dyn_cast<caffeine::ConstantInt>(offset.get());
-
-  if (constarray && offset_int) {
-    return ConstantInt::Create(llvm::APInt(
-        8, constarray->data()[offset_int->value().getLimitedValue()]));
-  }
 
   if (fixedarray && offset_int) {
     return fixedarray->data()[offset_int->value().getLimitedValue()];
@@ -1246,18 +1240,7 @@ ref<Operation> StoreOp::Create(const ref<Operation>& data,
 
 #ifdef CAFFEINE_IMPLICIT_CONSTANT_FOLDING
   const auto* offset_cnst = llvm::dyn_cast<caffeine::ConstantInt>(offset.get());
-  const auto* value_cnst = llvm::dyn_cast<caffeine::ConstantInt>(value.get());
-
-  const auto* cnstarray = llvm::dyn_cast<caffeine::ConstantArray>(data.get());
   const auto* fixedarray = llvm::dyn_cast<caffeine::FixedArray>(data.get());
-
-  if (offset_cnst && value_cnst && cnstarray) {
-    auto data = cnstarray->data();
-    data.store(offset_cnst->value().getLimitedValue(),
-               value_cnst->value().getLimitedValue());
-
-    return ConstantArray::Create(offset->type(), std::move(data));
-  }
 
   if (offset_cnst && fixedarray) {
     auto data = fixedarray->data();

--- a/src/IR/Operation.cpp
+++ b/src/IR/Operation.cpp
@@ -1242,6 +1242,9 @@ FixedArray::FixedArray(Type t, const PersistentArray<ref<Operation>>& data)
 ref<Operation> FixedArray::Create(Type index_ty,
                                   const PersistentArray<ref<Operation>>& data) {
   CAFFEINE_ASSERT(index_ty.is_int());
+  CAFFEINE_ASSERT(
+      index_ty.bitwidth() >= ilog2(data.size()),
+      "Index bitwidth is not large enough to address entire constant array");
 
   return ref<Operation>(
       new FixedArray(Type::array_ty(index_ty.bitwidth()), data));

--- a/src/IR/Operation.cpp
+++ b/src/IR/Operation.cpp
@@ -367,35 +367,6 @@ ref<Operation> ConstantFloat::Create(double value) {
 }
 
 /***************************************************
- * ConstantArray                                   *
- ***************************************************/
-ConstantArray::ConstantArray(Type t, const SharedArray& array)
-    : ArrayBase(Opcode::ConstantArray, t, array) {}
-ConstantArray::ConstantArray(Type t, SharedArray&& array)
-    : ArrayBase(Opcode::ConstantArray, t, std::move(array)) {}
-
-ref<Operation> ConstantArray::Create(Type index_ty, const SharedArray& array) {
-  CAFFEINE_ASSERT(index_ty.is_int(),
-                  "Arrays cannot be indexed by non-integer types");
-  CAFFEINE_ASSERT(
-      index_ty.bitwidth() >= ilog2(array.size()),
-      "Index bitwidth is not large enough to address entire constant array");
-
-  return ref<Operation>(
-      new ConstantArray(Type::array_ty(index_ty.bitwidth()), array));
-}
-ref<Operation> ConstantArray::Create(Type index_ty, SharedArray&& array) {
-  CAFFEINE_ASSERT(index_ty.is_int(),
-                  "Arrays cannot be indexed by non-integer types");
-  CAFFEINE_ASSERT(
-      index_ty.bitwidth() >= ilog2(array.size()),
-      "Index bitwidth is not large enough to address entire constant array");
-
-  return ref<Operation>(
-      new ConstantArray(Type::array_ty(index_ty.bitwidth()), std::move(array)));
-}
-
-/***************************************************
  * BinaryOp                                        *
  ***************************************************/
 BinaryOp::BinaryOp(Opcode op, Type t, const ref<Operation>& lhs,

--- a/src/IR/Operation.cpp
+++ b/src/IR/Operation.cpp
@@ -137,7 +137,6 @@ const char* Operation::opcode_name(Opcode op) {
   case ConstantNamed: return "Constant";
   case ConstantInt:   return "ConstantInt";
   case ConstantFloat: return "ConstantFloat";
-  case ConstantArray: return "ConstantArray";
   case Undef:         return "Undef";
 
   case Add:   return "Add";

--- a/src/Interpreter/CtxConstEval.cpp
+++ b/src/Interpreter/CtxConstEval.cpp
@@ -275,7 +275,14 @@ static ref<Operation> evaluate_global_data(ContextType ctx,
     auto raw = data->getRawDataValues();
     auto idxty = Type::int_ty(layout.getPointerSizeInBits());
 
-    return ConstantArray::Create(idxty, SharedArray(raw.data(), raw.size()));
+    std::vector<ref<Operation>> values;
+    values.reserve(raw.size());
+
+    for (size_t i = 0; i < raw.size(); ++i) {
+      values.push_back(ConstantInt::Create(llvm::APInt(8, (uint8_t)raw[i])));
+    }
+
+    return FixedArray::Create(idxty, std::move(values));
   }
 
   if (auto* data = llvm::dyn_cast<llvm::ConstantAggregateZero>(constant)) {

--- a/src/Solver/Solver.cpp
+++ b/src/Solver/Solver.cpp
@@ -27,9 +27,6 @@ public:
   Value visitConstantFloat(const ConstantFloat& op) {
     return op.value();
   }
-  Value visitConstantArray(const ConstantArray& op) {
-    return Value(op.data(), Type::int_ty(op.type().bitwidth()));
-  }
   Value visitFixedArray(const FixedArray& op) {
     auto size_val = op.size();
     uint64_t size = visit(*size_val).apint().getLimitedValue();

--- a/src/Solver/Z3Solver.cpp
+++ b/src/Solver/Z3Solver.cpp
@@ -289,19 +289,6 @@ z3::expr Z3OpVisitor::visitConstantFloat(const ConstantFloat& op) {
   expr.check_error();
   return expr;
 }
-z3::expr Z3OpVisitor::visitConstantArray(const ConstantArray& op) {
-  const SharedArray& data = op.data();
-
-  z3::expr array = next_const(
-      ctx->array_sort(ctx->bv_sort(op.type().bitwidth()), ctx->bv_sort(8)));
-
-  for (size_t i = 0; i < data.size(); ++i) {
-    solver->add(z3::select(array, ctx->bv_val(i, op.type().bitwidth())) ==
-                (uint8_t)data[i]);
-  }
-
-  return array;
-}
 z3::expr Z3OpVisitor::visitUndef(const Undef& op) {
   // TODO: Semantically, we can return absolutely any value when working with
   //       undef. In the future we'll probably want to do something a bit more

--- a/src/Solver/Z3Solver.h
+++ b/src/Solver/Z3Solver.h
@@ -68,7 +68,6 @@ public:
   z3::expr visitConstant     (const Constant& op);
   z3::expr visitConstantInt  (const ConstantInt& op);
   z3::expr visitConstantFloat(const ConstantFloat& op);
-  z3::expr visitConstantArray(const ConstantArray& op);
   z3::expr visitUndef        (const Undef& op);
   z3::expr visitFixedArray   (const FixedArray& op);
 


### PR DESCRIPTION
Reasons for removal:
- Its functionality has been superseded by `FixedArray`
- It doesn't work as well with constant folding as `FixedArray` does.
- It cannot be modified to support operand indexing arrays (`FixedArray` can)

In short, it's a special case that doesn't end up carrying it's weight so it should be removed. I'd also like to have the operation name for denoting symbolic arrays but I think it's worth removing `ConstantArray` either way.