### PR TITLE
Use magic_enum library to avoid boilerplate switch statements

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,6 +51,8 @@ if (CAFFEINE_ENABLE_BUILD)
   find_package(Boost REQUIRED)
   find_package(fmt REQUIRED)
 
+  include (CaffeineDependencies)
+
   set(IR_USE_BITCODE ${CAFFEINE_BUILD_BITCODE})
 
   include(CaffeineWarnings)

--- a/cmake/CaffeineDependencies.cmake
+++ b/cmake/CaffeineDependencies.cmake
@@ -1,0 +1,14 @@
+
+find_package(magic_enum 0.7.2 QUIET)
+
+if (NOT magic_enum_FOUND)
+  include(FetchContent)
+
+  FetchContent_Declare(
+    magic_enum
+    GIT_REPOSITORY https://github.com/Neargye/magic_enum.git
+    GIT_TAG        v0.7.2
+  )
+
+  FetchContent_MakeAvailable(magic_enum)
+endif()

--- a/include/caffeine/IR/Operation.h
+++ b/include/caffeine/IR/Operation.h
@@ -11,6 +11,7 @@
 #include <llvm/ADT/APInt.h>
 #include <llvm/ADT/iterator_range.h>
 #include <llvm/Support/Casting.h>
+#include <magic_enum.hpp>
 
 #include "caffeine/ADT/PersistentArray.h"
 #include "caffeine/ADT/Ref.h"
@@ -226,6 +227,9 @@ public:
      * Load a byte from a position within an array.
      */
     Load = detail::opcode(21, 2, 2),
+
+    // This one should be last
+    OpLast
   };
 
 protected:
@@ -283,8 +287,8 @@ public:
 
   // Get a static string that contains the opcode name. Returns "Unknown" on
   // unknown opcode.
-  const char* opcode_name() const;
-  static const char* opcode_name(Opcode op);
+  std::string_view opcode_name() const;
+  static std::string_view opcode_name(Opcode op);
 
   // Read-only access to the refcount. If this is 0 then this is not a
   // reference-counted Operation instance.

--- a/include/caffeine/IR/Operation.inl
+++ b/include/caffeine/IR/Operation.inl
@@ -464,4 +464,17 @@ struct hash<caffeine::Operation> {
 
 } // namespace std
 
+namespace magic_enum::customize {
+
+template <>
+struct enum_range<caffeine::Operation::Opcode> {
+  static constexpr int16_t min = 0;
+  static constexpr int16_t max = caffeine::Operation::Opcode::OpLast;
+
+  static_assert(caffeine::Operation::Opcode::OpLast < INT16_MAX,
+                "Opcode max opcode number must be less than INT16_MAX");
+};
+
+} // namespace magic_enum::customize
+
 #endif

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -51,4 +51,4 @@ target_include_directories(caffeine SYSTEM
 )
 
 target_link_options(caffeine PUBLIC ${LINK_FLAGS})
-target_link_libraries(caffeine PUBLIC LLVMCore "${Z3_LIBRARIES}" fmt::fmt)
+target_link_libraries(caffeine PUBLIC LLVMCore "${Z3_LIBRARIES}" fmt::fmt magic_enum)

--- a/src/IR/Operation.cpp
+++ b/src/IR/Operation.cpp
@@ -131,6 +131,7 @@ std::string_view Operation::opcode_name() const {
   return opcode_name(static_cast<Opcode>(opcode()));
 }
 std::string_view Operation::opcode_name(Opcode op) {
+#ifdef MAGIC_ENUM_SUPPORTED
   std::string_view name = magic_enum::enum_name(op);
 
   if (name.empty())
@@ -142,6 +143,9 @@ std::string_view Operation::opcode_name(Opcode op) {
     return "FCmp";
 
   return name;
+#else
+  return "<unsupported>";
+#endif
 }
 
 template <typename T, typename... Ts>

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -9,6 +9,7 @@
     "llvm",
     "fmt",
     "z3",
-    "gtest"
+    "gtest",
+    "magic_enum"
   ]
 }


### PR DESCRIPTION
This replaces the previous error-prone switch statement with a use of the [`magic_enum`](https://github.com/Neargye/magic_enum).

Detailed list of changes:
- Replace giant switch within `Operation.cpp` with magic_enum
- Use FetchContent to automatically get `magic_enum` if it's not available on the local system

It's not supported on all compilers so if not supported then it'll just return `"<usupported>"` as the enum variant name otherwise. We should maybe be emitting a warning in this case but that would take a decent amount of effort to make it work so I haven't done that here.