### PR TITLE
Implement Symbol type for constant names

### DIFF
--- a/include/caffeine/IR/Operation.h
+++ b/include/caffeine/IR/Operation.h
@@ -9,6 +9,7 @@
 #include <boost/container/static_vector.hpp>
 #include <llvm/ADT/APFloat.h>
 #include <llvm/ADT/APInt.h>
+#include <llvm/ADT/Hashing.h>
 #include <llvm/ADT/iterator_range.h>
 #include <llvm/Support/Casting.h>
 #include <magic_enum.hpp>
@@ -298,7 +299,6 @@ protected:
   friend class ref;
 
   friend llvm::hash_code hash_value(const Operation& op);
-  friend llvm::hash_code hash_value(const ConstantData& op);
 
 protected:
   Operation(Opcode op, Type t, const Inner& inner);

--- a/include/caffeine/IR/Operation.h
+++ b/include/caffeine/IR/Operation.h
@@ -106,6 +106,8 @@ public:
   friend llvm::hash_code hash_value(const Symbol& symbol);
 };
 
+std::ostream& operator<<(std::ostream& os, const Symbol& symbol);
+
 /**
  * An individual expression node.
  *

--- a/include/caffeine/IR/Operation.inl
+++ b/include/caffeine/IR/Operation.inl
@@ -218,15 +218,50 @@ inline ref<Operation> Operation::into_ref() const {
 }
 
 /***************************************************
+ * Symbol                                          *
+ ***************************************************/
+inline Symbol::Symbol(const std::string& name) : value_(name) {}
+inline Symbol::Symbol(std::string&& name) : value_(std::move(name)) {}
+inline Symbol::Symbol(uint64_t number) : value_(number) {}
+
+template <size_t N>
+inline Symbol::Symbol(const char (&name)[N]) : value_(std::string(name)) {}
+
+inline bool Symbol::is_named() const {
+  return value_.index() == Named;
+}
+inline bool Symbol::is_numbered() const {
+  return value_.index() == Numbered;
+}
+
+inline std::string_view Symbol::name() const {
+  return std::get<Named>(value_);
+}
+inline uint64_t Symbol::number() const {
+  return std::get<Numbered>(value_);
+}
+
+inline bool Symbol::operator==(const Symbol& symbol) const {
+  return value_ == symbol.value_;
+}
+inline bool Symbol::operator!=(const Symbol& symbol) const {
+  return !(*this == symbol);
+}
+
+/***************************************************
  * Constant                                        *
  ***************************************************/
+inline const Symbol& Constant::symbol() const {
+  return std::get<ConstantData>(inner_).first;
+}
+
 inline std::string_view Constant::name() const {
   CAFFEINE_ASSERT(is_named(), "tried to access name of unnamed constant");
-  return std::get<std::string>(inner_);
+  return symbol().name();
 }
 inline uint64_t Constant::number() const {
   CAFFEINE_ASSERT(is_numbered(), "tried to access number of named constant");
-  return std::get<uint64_t>(inner_);
+  return symbol().number();
 }
 
 inline bool Constant::is_numbered() const {
@@ -467,6 +502,7 @@ inline bool ArrayBase::classof(const Operation* op) {
  * hashing implementations                         *
  ***************************************************/
 llvm::hash_code hash_value(const Operation& op);
+llvm::hash_code hash_value(const Symbol& symbol);
 
 } // namespace caffeine
 

--- a/src/IR/Operation.cpp
+++ b/src/IR/Operation.cpp
@@ -232,6 +232,15 @@ std::ostream& operator<<(std::ostream& os, const Operation& op) {
 }
 
 /***************************************************
+ * Symbol                                          *
+ ***************************************************/
+std::ostream& operator<<(std::ostream& os, const Symbol& symbol) {
+  if (symbol.is_named())
+    return os << symbol.name();
+  return os << symbol.number();
+}
+
+/***************************************************
  * Constant                                        *
  ***************************************************/
 Constant::Constant(Type t, const Symbol& symbol)


### PR DESCRIPTION
This is meant to make it easier to write code that just wants to deal with identifier of a constant without caring if it's a string or a number. I haven't changed any of the downstream callsites yet but new code should use `Symbol` if it doesn't need to care about the string vs number divide.