### PR TITLE
Only build with ThinLTO in release mode

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,6 +40,9 @@ else()
   set(CAFFEINE_WARNING WARNING)
 endif()
 
+# Easier string comparisons in the presence of random user casing
+string(TOUPPER "${CAFFEINE_ENABLE_LTO}" CAFFEINE_ENABLE_LTO)
+
 set(CAFFEINE_FMTONLY OFF CACHE BOOL "Avoid building the project itself")
 mark_as_advanced(CAFFEINE_FMTONLY)
 

--- a/cmake/CaffeineLinking.cmake
+++ b/cmake/CaffeineLinking.cmake
@@ -12,8 +12,13 @@ if (CAFFEINE_ENABLE_LTO STREQUAL "ON" OR
   endif()
 elseif(CAFFEINE_ENABLE_LTO STREQUAL "THIN")
   if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
-    add_compile_options(-flto=thin)
-    list(APPEND LINK_FLAGS -flto=thin)
+    # This generator expression only sets up LTO if not building in debug mode
+    set(lto_tmp $<$<NOT:$<CONFIG:Debug>>:-flto=thin>)
+
+    add_compile_options("${lto_tmp}")
+    list(APPEND LINK_FLAGS "${lto_tmp}")
+
+    unset(lto_tmp)
   else()
     message(${CAFFEINE_WARNING} "ThinLTO is only supported when compiling with clang")
   endif()


### PR DESCRIPTION
It doesn't make a lot of sense to use LTO when in debug mode since no optimizations are being done. This PR changes to only be specified when not in debug mode.