### PR TITLE
Remove special-casing for FixedArray

### DIFF
--- a/include/caffeine/IR/Matching.h
+++ b/include/caffeine/IR/Matching.h
@@ -397,17 +397,10 @@ ref<Operation> matches_anywhere(const ref<Operation>& op,
 
   // Special case for FixedArray since its elements aren't reported in
   // num_operands.
-  if (const auto* array = llvm::dyn_cast<FixedArray>(op.get())) {
-    for (const auto& elem : array->data()) {
-      if (auto match = matches_anywhere(elem, matcher))
-        return match;
-    }
-  } else {
-    size_t nops = op->num_operands();
-    for (size_t i = 0; i < nops; ++i) {
-      if (auto match = matches_anywhere(op->operand_at(i), matcher))
-        return match;
-    }
+  size_t nops = op->num_operands();
+  for (size_t i = 0; i < nops; ++i) {
+    if (auto match = matches_anywhere(op->operand_at(i), matcher))
+      return match;
   }
 
   return nullptr;

--- a/include/caffeine/IR/Operation.h
+++ b/include/caffeine/IR/Operation.h
@@ -270,6 +270,8 @@ protected:
   Operation();
   Operation(Opcode op, Type t);
 
+  using CopyVTable::copy_vtable;
+
 public:
   /**
    * Indicate whether this Operation instance is valid.

--- a/include/caffeine/IR/Operation.h
+++ b/include/caffeine/IR/Operation.h
@@ -17,6 +17,7 @@
 #include "caffeine/ADT/SharedArray.h"
 #include "caffeine/IR/Type.h"
 #include "caffeine/Support/Assert.h"
+#include "caffeine/Support/CopyVTable.h"
 
 namespace caffeine {
 
@@ -44,22 +45,6 @@ namespace detail {
 
   template <typename T>
   class double_deref_iterator;
-
-  // Inner class used to make sure that the derived vtable is copied.
-  class CopyVTablePtr {
-  public:
-    CopyVTablePtr() = default;
-    virtual ~CopyVTablePtr() = default;
-
-    CopyVTablePtr(const CopyVTablePtr&) noexcept;
-    CopyVTablePtr(CopyVTablePtr&&) noexcept;
-
-    CopyVTablePtr& operator=(const CopyVTablePtr&) noexcept;
-    CopyVTablePtr& operator=(CopyVTablePtr&&) noexcept;
-
-  private:
-    void copy_from(const CopyVTablePtr&) noexcept;
-  };
 } // namespace detail
 
 enum class ICmpOpcode : uint8_t {
@@ -119,7 +104,7 @@ enum class FCmpOpcode : uint8_t {
  *    Visitor.cpp. This may also require adding new built-in methods to the
  *    Value type.
  */
-class Operation : private detail::CopyVTablePtr {
+class Operation : private CopyVTable {
 protected:
   // Base opcode used for FCmp opcodes
   static constexpr uint16_t fcmp_base = 4;

--- a/include/caffeine/IR/Operation.h
+++ b/include/caffeine/IR/Operation.h
@@ -44,6 +44,22 @@ namespace detail {
 
   template <typename T>
   class double_deref_iterator;
+
+  // Inner class used to make sure that the derived vtable is copied.
+  class CopyVTablePtr {
+  public:
+    CopyVTablePtr() = default;
+    virtual ~CopyVTablePtr() = default;
+
+    CopyVTablePtr(const CopyVTablePtr&) noexcept;
+    CopyVTablePtr(CopyVTablePtr&&) noexcept;
+
+    CopyVTablePtr& operator=(const CopyVTablePtr&) noexcept;
+    CopyVTablePtr& operator=(CopyVTablePtr&&) noexcept;
+
+  private:
+    void copy_from(const CopyVTablePtr&) noexcept;
+  };
 } // namespace detail
 
 enum class ICmpOpcode : uint8_t {
@@ -103,7 +119,7 @@ enum class FCmpOpcode : uint8_t {
  *    Visitor.cpp. This may also require adding new built-in methods to the
  *    Value type.
  */
-class Operation {
+class Operation /* : private detail::CopyVTablePtr */ {
 protected:
   // Base opcode used for FCmp opcodes
   static constexpr uint16_t fcmp_base = 4;

--- a/include/caffeine/IR/Operation.h
+++ b/include/caffeine/IR/Operation.h
@@ -313,9 +313,9 @@ public:
   typedef detail::double_deref_iterator<const ref<Operation>>
       const_operand_iterator;
 
-  size_t num_operands() const;
-  llvm::iterator_range<operand_iterator> operands();
-  llvm::iterator_range<const_operand_iterator> operands() const;
+  virtual size_t num_operands() const;
+  virtual llvm::iterator_range<operand_iterator> operands();
+  virtual llvm::iterator_range<const_operand_iterator> operands() const;
 
   Operation& operator[](size_t idx);
   const Operation& operator[](size_t idx) const;
@@ -334,14 +334,14 @@ public:
    * Create a new operation using the same opcode as the current one but with
    * new operands.
    */
-  ref<Operation>
+  virtual ref<Operation>
   with_new_operands(llvm::ArrayRef<ref<Operation>> operands) const;
 
   /**
    * Accessors to operand references.
    */
-  ref<Operation>& operand_at(size_t idx);
-  const ref<Operation>& operand_at(size_t idx) const;
+  virtual ref<Operation>& operand_at(size_t idx);
+  virtual const ref<Operation>& operand_at(size_t idx) const;
 
   // Need to define this since refcount shouldn't be copied/moved.
   Operation(const Operation& op);
@@ -763,13 +763,24 @@ public:
 /**
  * An array with symbolic contents but a fixed size.
  */
-class FixedArray : public ArrayBase {
+class FixedArray final : public ArrayBase {
 private:
   FixedArray(Type t, const PersistentArray<ref<Operation>>& data);
 
 public:
+  PersistentArray<ref<Operation>>& data();
   const PersistentArray<ref<Operation>>& data() const;
   ref<Operation> size() const override;
+
+  size_t num_operands() const override;
+  llvm::iterator_range<operand_iterator> operands() override;
+  llvm::iterator_range<const_operand_iterator> operands() const override;
+
+  ref<Operation>
+  with_new_operands(llvm::ArrayRef<ref<Operation>> operands) const override;
+
+  ref<Operation>& operand_at(size_t i) override;
+  const ref<Operation>& operand_at(size_t i) const override;
 
   static ref<Operation> Create(Type index_ty,
                                const PersistentArray<ref<Operation>>& data);

--- a/include/caffeine/IR/Operation.h
+++ b/include/caffeine/IR/Operation.h
@@ -119,7 +119,7 @@ enum class FCmpOpcode : uint8_t {
  *    Visitor.cpp. This may also require adding new built-in methods to the
  *    Value type.
  */
-class Operation /* : private detail::CopyVTablePtr */ {
+class Operation : private detail::CopyVTablePtr {
 protected:
   // Base opcode used for FCmp opcodes
   static constexpr uint16_t fcmp_base = 4;

--- a/include/caffeine/Support/CopyVTable.h
+++ b/include/caffeine/Support/CopyVTable.h
@@ -1,0 +1,54 @@
+#pragma once
+
+namespace caffeine {
+
+/**
+ * Copy the vtable of all derived classes.
+ *
+ * Usage
+ * =====
+ * Have whatever class is at the base of your object hierarchy derive
+ * CopyVTable.
+ *
+ * Explanation
+ * ===========
+ * By default, when you copy a potentially-derived instance of a base class in
+ * C++ it doesn't copy the vtable of the object along with the rest of it (as
+ * the destination has a new destination object). In most cases the behaviour
+ * that you want is either the above behaviour or to disable copies entirely so
+ * most of the time this serves as a fine default.
+ *
+ * However, if you know that all dervied classes will have exactly the same size
+ * as the base class and you want to have the classes vtable copied along with
+ * them then you should take use this class.
+ *
+ * Limitations
+ * ===========
+ * There are a few limitations in how well this class can work:
+ * 1. Compilers will elide virtual calls when the class instance is present on
+ *    the stack. This means that the requisite calls should always be done
+ *    through a reference or pointer.
+ * 2. CopyVTable must be used at the base of the inheritance heirarchy and is
+ *    not compatible with multiple inheritance. It needs the vtable pointer to
+ *    be stored within the CopyVTable instance in order for it to be copied
+ *    between class instances.
+ * 3. It is theoretically possible for a compiler to implement virtual function
+ *    calls through something other than a vtable pointer. However, all current
+ *    compilers have used a vtable pointer so this is more of a theoretical
+ *    issue.
+ */
+class CopyVTable {
+public:
+  CopyVTable() = default;
+  virtual ~CopyVTable() = default;
+
+  CopyVTable(const CopyVTable&) noexcept;
+  CopyVTable(CopyVTable&&) noexcept;
+
+  CopyVTable& operator=(const CopyVTable&) noexcept;
+  CopyVTable& operator=(CopyVTable&&) noexcept;
+
+  void copy_vtable(const CopyVTable& vtable) noexcept;
+};
+
+} // namespace caffeine

--- a/src/IR/Operation.cpp
+++ b/src/IR/Operation.cpp
@@ -15,6 +15,28 @@
 
 namespace caffeine {
 
+namespace detail {
+  void CopyVTablePtr::copy_from(const CopyVTablePtr& base) noexcept {
+    std::memcpy((void*)this, (const void*)&base, sizeof(*this));
+  }
+
+  CopyVTablePtr::CopyVTablePtr(const CopyVTablePtr& base) noexcept {
+    copy_from(base);
+  }
+  CopyVTablePtr::CopyVTablePtr(CopyVTablePtr&& base) noexcept {
+    copy_from(base);
+  }
+
+  CopyVTablePtr& CopyVTablePtr::operator=(const CopyVTablePtr& base) noexcept {
+    copy_from(base);
+    return *this;
+  }
+  CopyVTablePtr& CopyVTablePtr::operator=(CopyVTablePtr&& base) noexcept {
+    copy_from(base);
+    return *this;
+  }
+} // namespace detail
+
 #define ASSERT_SAME_TYPES(v1, v2)                                              \
   CAFFEINE_ASSERT((v1)->type() == (v2)->type(),                                \
                   fmt::format("arguments had different types: {} != {}",       \

--- a/src/IR/Operation.cpp
+++ b/src/IR/Operation.cpp
@@ -1290,7 +1290,14 @@ FixedArray::with_new_operands(llvm::ArrayRef<ref<Operation>> operands) const {
   if (equal)
     return into_ref();
 
-  return ref<Operation>(new FixedArray(type(), operands.vec()));
+  auto array = data();
+  array.reroot();
+  for (size_t i = 0; i < operands.size(); ++i) {
+    if (array[i] != operands[i])
+      array.set(i, operands[i]);
+  }
+
+  return ref<Operation>(new FixedArray(type(), array));
 }
 
 ref<Operation> FixedArray::Create(Type index_ty,

--- a/src/IR/Operation.cpp
+++ b/src/IR/Operation.cpp
@@ -15,28 +15,6 @@
 
 namespace caffeine {
 
-namespace detail {
-  void CopyVTablePtr::copy_from(const CopyVTablePtr& base) noexcept {
-    std::memcpy((void*)this, (const void*)&base, sizeof(*this));
-  }
-
-  CopyVTablePtr::CopyVTablePtr(const CopyVTablePtr& base) noexcept {
-    copy_from(base);
-  }
-  CopyVTablePtr::CopyVTablePtr(CopyVTablePtr&& base) noexcept {
-    copy_from(base);
-  }
-
-  CopyVTablePtr& CopyVTablePtr::operator=(const CopyVTablePtr& base) noexcept {
-    copy_from(base);
-    return *this;
-  }
-  CopyVTablePtr& CopyVTablePtr::operator=(CopyVTablePtr&& base) noexcept {
-    copy_from(base);
-    return *this;
-  }
-} // namespace detail
-
 #define ASSERT_SAME_TYPES(v1, v2)                                              \
   CAFFEINE_ASSERT((v1)->type() == (v2)->type(),                                \
                   fmt::format("arguments had different types: {} != {}",       \
@@ -144,8 +122,10 @@ Operation::with_new_operands(llvm::ArrayRef<ref<Operation>> operands) const {
   if (equal)
     return into_ref();
 
-  return ref<Operation>(
-      new Operation((Opcode)opcode(), type(), operands.data()));
+  auto value =
+      ref<Operation>(new Operation((Opcode)opcode(), type(), operands.data()));
+  value->copy_vtable(*this);
+  return value;
 }
 
 const char* Operation::opcode_name() const {

--- a/src/IR/Operation.cpp
+++ b/src/IR/Operation.cpp
@@ -65,9 +65,10 @@ Operation::Operation(Opcode op, Type t, const ref<Operation>& op0,
 }
 
 Operation::Operation(const Operation& op)
-    : opcode_(op.opcode_), refcount(0), type_(op.type_), inner_(op.inner_) {}
+    : CopyVTable(op), opcode_(op.opcode_), refcount(0), type_(op.type_),
+      inner_(op.inner_) {}
 Operation::Operation(Operation&& op) noexcept
-    : opcode_(op.opcode_), refcount(0), type_(op.type_),
+    : CopyVTable(op), opcode_(op.opcode_), refcount(0), type_(op.type_),
       inner_(std::move(op.inner_)) {}
 
 Operation& Operation::operator=(const Operation& op) {
@@ -76,12 +77,16 @@ Operation& Operation::operator=(const Operation& op) {
   type_ = op.type_;
   opcode_ = op.opcode_;
 
+  copy_vtable(op);
+
   return *this;
 }
 Operation& Operation::operator=(Operation&& op) noexcept {
   inner_ = std::move(op.inner_);
   type_ = op.type_;
   opcode_ = op.opcode_;
+
+  copy_vtable(op);
 
   return *this;
 }

--- a/src/Solver/Solver.cpp
+++ b/src/Solver/Solver.cpp
@@ -32,6 +32,8 @@ public:
     uint64_t size = visit(*size_val).apint().getLimitedValue();
     uint32_t bitwidth = size_val->type().bitwidth();
 
+    CAFFEINE_ASSERT(size <= (uint64_t)SIZE_MAX);
+
     std::vector<char> bytes;
     bytes.reserve(size);
 

--- a/src/Support/CopyVTable.cpp
+++ b/src/Support/CopyVTable.cpp
@@ -4,7 +4,9 @@
 namespace caffeine {
 
 void CopyVTable::copy_vtable(const CopyVTable& base) noexcept {
-  std::memcpy((void*)this, (const void*)&base, sizeof(*this));
+  if (this != &base) {
+    std::memcpy((void*)this, (const void*)&base, sizeof(*this));
+  }
 }
 
 CopyVTable::CopyVTable(const CopyVTable& base) noexcept {

--- a/src/Support/CopyVTable.cpp
+++ b/src/Support/CopyVTable.cpp
@@ -1,0 +1,26 @@
+#include "caffeine/Support/CopyVTable.h"
+#include <cstring>
+
+namespace caffeine {
+
+void CopyVTable::copy_vtable(const CopyVTable& base) noexcept {
+  std::memcpy((void*)this, (const void*)&base, sizeof(*this));
+}
+
+CopyVTable::CopyVTable(const CopyVTable& base) noexcept {
+  copy_vtable(base);
+}
+CopyVTable::CopyVTable(CopyVTable&& base) noexcept {
+  copy_vtable(base);
+}
+
+CopyVTable& CopyVTable::operator=(const CopyVTable& base) noexcept {
+  copy_vtable(base);
+  return *this;
+}
+CopyVTable& CopyVTable::operator=(CopyVTable&& base) noexcept {
+  copy_vtable(base);
+  return *this;
+}
+
+} // namespace caffeine

--- a/test/unit/IR/Operation.cpp
+++ b/test/unit/IR/Operation.cpp
@@ -1,0 +1,16 @@
+
+#include "caffeine/IR/Operation.h"
+#include <gtest/gtest.h>
+
+using namespace caffeine;
+
+TEST(OperationTests, vtable_is_copied) {
+  auto fixed_array = FixedArray::Create(Type::int_ty(32),
+                                        {Constant::Create(Type::int_ty(1), 0)});
+
+  auto copy =
+      fixed_array->with_new_operands({Constant::Create(Type::int_ty(1), 1)});
+
+  ASSERT_EQ(fixed_array->num_operands(), 1);
+  ASSERT_EQ(copy->num_operands(), fixed_array->num_operands());
+}


### PR DESCRIPTION
In current master FixedArray doesn't behave like any of the other operation classes. This PR changes it to align with the way other classes are used and removes special casing elsewhere within the code.

Detailed list of changes:
- Add code to copy the class vtable pointer when an `Operation` instance is copied
- Override a number of member functions within `Operation` so that they work when the derived type is a `FixedArray` instance.
- Ensure that the vtable is copied when calling `with_new_operands`
- Expose some new methods on `PersistentArray` to support the operations that `FixedArray` needs

See the docs on `CopyVTable` for some of the restrictions on using it properly.