### PR TITLE
Update solver API to use the Symbol type

### DIFF
--- a/include/caffeine/Solver/Solver.h
+++ b/include/caffeine/Solver/Solver.h
@@ -13,6 +13,7 @@ namespace caffeine {
 class Assertion;
 class Operation;
 class Constant;
+class Symbol;
 
 enum SolverResult { UNSAT, SAT, Unknown };
 
@@ -50,7 +51,8 @@ public:
 protected:
   /**
    * Look up the value of a symbolic constant in this model. Returns an
-   * appropriate constant expression with the value of said constant.
+   * appropriate constant expression with the value of said constant. If the
+   * lookup is for an array constant then size will have a value.
    *
    * If there are no constants with the given name then returns a null pointer.
    *
@@ -61,7 +63,8 @@ protected:
    * performs the appropriate operations on the expression tree to evaluate it
    * (it uses `lookup` under the hood).
    */
-  virtual Value lookup(const Constant& constant) const = 0;
+  virtual Value lookup(const Symbol& symbol,
+                       std::optional<size_t> size = std::nullopt) const = 0;
 
   Model(const Model&) = default;
   Model(Model&&) = default;
@@ -148,7 +151,7 @@ class EmptyModel final : public Model {
 public:
   EmptyModel(SolverResult result);
 
-  Value lookup(const Constant&) const override;
+  Value lookup(const Symbol& symbol, std::optional<size_t> size) const override;
 };
 
 } // namespace caffeine

--- a/src/Solver/Solver.cpp
+++ b/src/Solver/Solver.cpp
@@ -158,7 +158,7 @@ EmptyModel::EmptyModel(SolverResult result) : Model(result) {
   CAFFEINE_ASSERT(result != SolverResult::SAT);
 }
 
-Value EmptyModel::lookup(const Constant&) const {
+Value EmptyModel::lookup(const Symbol&, std::optional<size_t>) const {
   CAFFEINE_ABORT("Model was empty");
 }
 

--- a/src/Solver/Solver.cpp
+++ b/src/Solver/Solver.cpp
@@ -17,7 +17,7 @@ public:
   }
 
   Value visitConstant(const Constant& op) {
-    auto value = model_->lookup(op);
+    auto value = model_->lookup(op.symbol());
     CAFFEINE_ASSERT(value.type() != Type::void_ty());
     return value;
   }

--- a/src/Solver/Z3Solver.cpp
+++ b/src/Solver/Z3Solver.cpp
@@ -158,7 +158,7 @@ Z3Model::Z3Model(SolverResult result, const z3::model& model,
 Z3Model::Z3Model(SolverResult result, const z3::model& model, ConstMap&& map)
     : Model(result), model(model), constants(std::move(map)) {}
 
-Value Z3Model::lookup(const Symbol& symbol, std::optional<size_t> size) const {
+Value Z3Model::lookup(const Symbol& symbol, std::optional<size_t>) const {
   CAFFEINE_ASSERT(result() == SolverResult::SAT, "Model is not SAT");
 
   auto it = constants.find(op_name(symbol));

--- a/src/Solver/Z3Solver.cpp
+++ b/src/Solver/Z3Solver.cpp
@@ -108,12 +108,12 @@ static z3::expr normalize_to_bv(const z3::expr& expr) {
   return expr;
 }
 
-static Z3Model::SymbolName op_name(const Constant& constant) {
-  if (constant.is_numbered()) {
-    return constant.number();
+static Z3Model::SymbolName op_name(const Symbol& symbol) {
+  if (symbol.is_numbered()) {
+    return symbol.number();
   }
 
-  return std::string(constant.name());
+  return std::string(symbol.name());
 }
 
 static z3::symbol name_to_symbol(z3::context& ctx,
@@ -158,10 +158,10 @@ Z3Model::Z3Model(SolverResult result, const z3::model& model,
 Z3Model::Z3Model(SolverResult result, const z3::model& model, ConstMap&& map)
     : Model(result), model(model), constants(std::move(map)) {}
 
-Value Z3Model::lookup(const Constant& constant) const {
+Value Z3Model::lookup(const Symbol& symbol, std::optional<size_t> size) const {
   CAFFEINE_ASSERT(result() == SolverResult::SAT, "Model is not SAT");
 
-  auto it = constants.find(op_name(constant));
+  auto it = constants.find(op_name(symbol));
   if (it == constants.end()) {
     return Value();
   }
@@ -248,7 +248,7 @@ z3::expr Z3OpVisitor::visitOperation(const Operation& op) {
 
 z3::expr Z3OpVisitor::visitConstant(const Constant& op) {
   auto type = op.type();
-  auto name = op_name(op);
+  auto name = op_name(op.symbol());
 
   // Reuse already created constants (otherwise Z3 will view them as different?)
   auto it = constMap.find(name);

--- a/src/Solver/Z3Solver.h
+++ b/src/Solver/Z3Solver.h
@@ -30,15 +30,7 @@ public:
   Z3Model(SolverResult result, const z3::model& model, const ConstMap& map);
   Z3Model(SolverResult result, const z3::model& model, ConstMap&& map);
 
-  /**
-   * Look up the value of a symbolic constant in this model. Returns an
-   * appropriate constant expression with the value of said constant.
-   *
-   * If there are no constants with the given name then returns a null pointer.
-   *
-   * It is invalid to call this method if the model is not SAT.
-   */
-  Value lookup(const Constant& constant) const;
+  Value lookup(const Symbol& symbol, std::optional<size_t> size) const override;
 };
 
 class Z3OpVisitor : public ConstOpVisitor<Z3OpVisitor, z3::expr> {


### PR DESCRIPTION
Now that we have a common type for constant identifiers we should be using it anywhere we would previously take a symbol name or number. This updates `Model::lookup` to use `Symbol` (and also adds a size parameter to support the upcoming ConstantArray operation).