### PR TITLE
Implement caffeine_make_symbolic

### DIFF
--- a/include/caffeine/Interpreter/Interpreter.h
+++ b/include/caffeine/Interpreter/Interpreter.h
@@ -91,6 +91,7 @@ private:
 
   ExecutionResult visitAssume(llvm::CallInst& inst);
   ExecutionResult visitAssert(llvm::CallInst& inst);
+  ExecutionResult visitSymbolicAlloca(llvm::CallInst& inst);
 
   ExecutionResult visitMalloc(llvm::CallInst& inst);
   ExecutionResult visitCalloc(llvm::CallInst& inst);

--- a/interface/caffeine.h
+++ b/interface/caffeine.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <stdbool.h>
+#include <stddef.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -25,6 +26,15 @@ void caffeine_assert(bool cond);
  * could evaluate to false.
  */
 void caffeine_assume(bool cond);
+
+/**
+ * Make size bytes pointed to by mem into symbolic memory. The resulting
+ * symbolic values will be associated with the provided name.
+ *
+ * The name must not be symbolic. mem should be valid for a write of size or
+ * else a failure will be generated.
+ */
+void caffeine_make_symbolic(void* mem, size_t size, const char* name);
 
 #ifdef __cplusplus
 }

--- a/libraries/builtins/caffeine-builtins.h
+++ b/libraries/builtins/caffeine-builtins.h
@@ -23,6 +23,10 @@ void* caffeine_calloc(size_t size);
 // This is a more limited version of free that expects mem != nullptr
 void caffeine_free(void* mem);
 
+// This creates an allocation with symbolic value and given size and associates
+// it with the provided name
+void* caffeine_builtin_symbolic_alloca(size_t size, const char* name);
+
 /***************************************************
  * Pointer Functions                               *
  ***************************************************/

--- a/libraries/builtins/make_symbolic.c
+++ b/libraries/builtins/make_symbolic.c
@@ -1,0 +1,10 @@
+
+#include "caffeine-builtins.h"
+#include <string.h>
+
+void caffeine_make_symbolic(void* mem, size_t size, const char* name) {
+  caffeine_assert(!!name);
+
+  void* symbolic = caffeine_builtin_symbolic_alloca(size, name);
+  memcpy(mem, symbolic, size);
+}

--- a/test/run-fail/make_symbolic/init-struct.c
+++ b/test/run-fail/make_symbolic/init-struct.c
@@ -1,0 +1,15 @@
+
+#include "caffeine.h"
+#include <stdint.h>
+
+typedef struct {
+  uint32_t x;
+  uint32_t y;
+} test_data;
+
+void test() {
+  test_data data;
+  caffeine_make_symbolic(&data, sizeof(test_data), "test_data");
+
+  caffeine_assert(data.x != data.y);
+}


### PR DESCRIPTION
This PR implements the `caffeine_make_symbolic` builtin. See the docs on the builtin for what it actually does.

I have also added a single test case to help verify printing and whether it actually works.

Closes #134 