### PR TITLE
Allow visitors to be used as function objects

### DIFF
--- a/include/caffeine/IR/Visitor.h
+++ b/include/caffeine/IR/Visitor.h
@@ -146,6 +146,9 @@ public:
 
   RetTy visit(transform_t<Operation>* O);
   RetTy visit(transform_t<Operation>& O);
+
+  RetTy operator()(transform_t<Operation>* O);
+  RetTy operator()(transform_t<Operation>& O);
 };
 
 /**

--- a/include/caffeine/IR/Visitor.inl
+++ b/include/caffeine/IR/Visitor.inl
@@ -98,7 +98,21 @@ template <template <typename T> class Transform, typename SubClass,
           typename RetTy>
 RetTy OpVisitorBase<Transform, SubClass, RetTy>::visit(
     transform_t<Operation>* op) {
-  return visit(*op);
+  return SubClass::visit(*op);
+}
+
+template <template <typename T> class Transform, typename SubClass,
+          typename RetTy>
+RetTy OpVisitorBase<Transform, SubClass, RetTy>::operator()(
+    transform_t<Operation>& op) {
+  return SubClass::visit(op);
+}
+
+template <template <typename T> class Transform, typename SubClass,
+          typename RetTy>
+RetTy OpVisitorBase<Transform, SubClass, RetTy>::operator()(
+    transform_t<Operation>* op) {
+  return SubClass::visit(op);
 }
 
 } // namespace caffeine

--- a/include/caffeine/IR/Visitor.inl
+++ b/include/caffeine/IR/Visitor.inl
@@ -98,21 +98,21 @@ template <template <typename T> class Transform, typename SubClass,
           typename RetTy>
 RetTy OpVisitorBase<Transform, SubClass, RetTy>::visit(
     transform_t<Operation>* op) {
-  return SubClass::visit(*op);
+  return static_cast<SubClass*>(this)->visit(*op);
 }
 
 template <template <typename T> class Transform, typename SubClass,
           typename RetTy>
 RetTy OpVisitorBase<Transform, SubClass, RetTy>::operator()(
     transform_t<Operation>& op) {
-  return SubClass::visit(op);
+  return static_cast<SubClass*>(this)->visit(op);
 }
 
 template <template <typename T> class Transform, typename SubClass,
           typename RetTy>
 RetTy OpVisitorBase<Transform, SubClass, RetTy>::operator()(
     transform_t<Operation>* op) {
-  return SubClass::visit(op);
+  return static_cast<SubClass*>(this)->visit(op);
 }
 
 } // namespace caffeine


### PR DESCRIPTION
As in the title. If we ensure that any generic algorithms that take a visitor use it as a function then we'll also be able to pass lambdas as a visitor which is a nice usability improvement where it's needed.

This is part of the work on #161.