### PR TITLE
Allow libcaffeine to be built as a static or shared library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,8 +17,10 @@ set(CAFFEINE_USE_LINKER ""  CACHE STRING "Add -fuse-ld={name} to the link invoca
 option(CAFFEINE_CI            "Enable options that are inconvenient for normal development but are used in CI" OFF)
 option(CAFFEINE_ENABLE_BUILD  "Enable normal build targets" ON)
 
+option(BUILD_SHARED_LIBS "Build libcaffeine as a shared library" OFF)
+
 # Usually users probably don't want to disable the entirety of the project
-mark_as_advanced(CAFFEINE_ENABLE_BUILD)
+mark_as_advanced(CAFFEINE_ENABLE_BUILD BUILD_SHARED_LIBS)
 
 ###########################################################
 #            Non-option cmake configuration               #

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -35,7 +35,7 @@ file(
   "${CMAKE_SOURCE_DIR}/include/*.inl"
 )
 
-add_library(caffeine STATIC ${sources} ${headers})
+add_library(caffeine ${sources} ${headers})
 
 target_include_directories(caffeine 
   PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}"


### PR DESCRIPTION
There are cases where we'll want this ability - the current one I have is ensuring that debug methods don't get deleted even if they're unused. I've kept the defaults the same as before.