### PR TITLE
Add private utility method to print an expression while in a debugger

### DIFF
--- a/include/caffeine/IR/Operation.h
+++ b/include/caffeine/IR/Operation.h
@@ -408,6 +408,10 @@ protected:
    * however they want.
    */
   uint16_t aux_data() const;
+
+private:
+  // Utility during debugging - should never actually be called by the program.
+  void DebugPrint() const;
 };
 
 std::ostream& operator<<(std::ostream& os, const Operation& op);

--- a/src/IR/Debug.cpp
+++ b/src/IR/Debug.cpp
@@ -1,0 +1,9 @@
+#include "caffeine/IR/Operation.h"
+
+#include <iostream>
+
+namespace caffeine {
+void Operation::DebugPrint() const {
+  std::cout << *this << std::endl;
+}
+} // namespace caffeine


### PR DESCRIPTION
This is a private method which prints a representation of the expression to stdout. It's meant to be used as an aid while debugging so I've left it as a private method.

Note that this only really works when caffeine is built as a shared library as enabled by #209.