### PR TITLE
Implement rebuild transform

### DIFF
--- a/include/caffeine/IR/Transforms.h
+++ b/include/caffeine/IR/Transforms.h
@@ -29,11 +29,12 @@
  *    implementation of a transform algorithm should have to worry about.
  */
 
+#include "caffeine/IR/Operation.h"
 #include <vector>
 
 namespace caffeine {
 class Assertion;
-}
+} // namespace caffeine
 
 namespace caffeine::transforms {
 
@@ -53,4 +54,12 @@ void decompose(std::vector<Assertion>& assertions);
  */
 void canonicalize(std::vector<Assertion>& assertions);
 
+/**
+ * 
+ */
+template <typename Visitor>
+ref<Operation> rebuild(const ref<Operation>& expression, Visitor& visitor);
+
 } // namespace caffeine::transforms
+
+#include "caffeine/IR/Transforms.inl"

--- a/include/caffeine/IR/Transforms.h
+++ b/include/caffeine/IR/Transforms.h
@@ -63,7 +63,7 @@ void canonicalize(std::vector<Assertion>& assertions);
  * transformations.
  */
 template <typename Visitor>
-ref<Operation> rebuild(const ref<Operation>& expression, Visitor& visitor);
+ref<Operation> rebuild(const ref<Operation>& expression, Visitor&& visitor);
 
 } // namespace caffeine::transforms
 

--- a/include/caffeine/IR/Transforms.h
+++ b/include/caffeine/IR/Transforms.h
@@ -63,9 +63,9 @@ void canonicalize(std::vector<Assertion>& assertions);
  * transformations.
  */
 template <typename Visitor>
-ref<Operation> rebuild(const ref<Operation>& expression, Visitor& visitor);
+OpRef rebuild(const OpRef& expression, Visitor& visitor);
 template <typename Visitor>
-ref<Operation> rebuild(const ref<Operation>& expression, Visitor&& visitor);
+OpRef rebuild(const OpRef& expression, Visitor&& visitor);
 
 } // namespace caffeine::transforms
 

--- a/include/caffeine/IR/Transforms.h
+++ b/include/caffeine/IR/Transforms.h
@@ -55,7 +55,12 @@ void decompose(std::vector<Assertion>& assertions);
 void canonicalize(std::vector<Assertion>& assertions);
 
 /**
- * 
+ * Rebuild an expression tree using the transform applied by the visitor. This
+ * will traverse the tree in a depth-first order and apply the transform to each
+ * node. If no changes are made then existing expression nodes will be reused.
+ *
+ * This is primarily useful as a building block towards more advanced
+ * transformations.
  */
 template <typename Visitor>
 ref<Operation> rebuild(const ref<Operation>& expression, Visitor& visitor);

--- a/include/caffeine/IR/Transforms.h
+++ b/include/caffeine/IR/Transforms.h
@@ -63,6 +63,8 @@ void canonicalize(std::vector<Assertion>& assertions);
  * transformations.
  */
 template <typename Visitor>
+ref<Operation> rebuild(const ref<Operation>& expression, Visitor& visitor);
+template <typename Visitor>
 ref<Operation> rebuild(const ref<Operation>& expression, Visitor&& visitor);
 
 } // namespace caffeine::transforms

--- a/include/caffeine/IR/Transforms.inl
+++ b/include/caffeine/IR/Transforms.inl
@@ -11,11 +11,24 @@ ref<Operation> rebuild(const ref<Operation>& expression, Visitor& visitor) {
   llvm::SmallVector<ref<Operation>, 3> ops;
   ops.reserve(nops);
 
+  size_t same_count = 0;
+
   for (size_t i = 0; i < nops; ++i) {
-    ops.push_back(rebuild(expression->operand_at(i), visitor));
+    const ref<Operation>& operand = expression->operand_at(i);
+    ref<Operation> newexpr = rebuild(operand, visitor);
+
+    if (newexpr == operand) {
+      same_count += 1;
+    }
+
+    ops.push_back(std::move(newexpr));
   }
 
-  return visitor(expression->with_new_operands(ops));
+  if (same_count == ops.size()) {
+    return visitor(expression);
+  } else {
+    return visitor(expression->with_new_operands(ops));
+  }
 }
 template <typename Visitor>
 ref<Operation> rebuild(const ref<Operation>& expression, Visitor&& visitor) {

--- a/include/caffeine/IR/Transforms.inl
+++ b/include/caffeine/IR/Transforms.inl
@@ -6,16 +6,16 @@
 namespace caffeine::transforms {
 
 template <typename Visitor>
-ref<Operation> rebuild(const ref<Operation>& expression, Visitor& visitor) {
+OpRef rebuild(const OpRef& expression, Visitor& visitor) {
   size_t nops = expression->num_operands();
-  llvm::SmallVector<ref<Operation>, 3> ops;
+  llvm::SmallVector<OpRef, 3> ops;
   ops.reserve(nops);
 
   size_t same_count = 0;
 
   for (size_t i = 0; i < nops; ++i) {
-    const ref<Operation>& operand = expression->operand_at(i);
-    ref<Operation> newexpr = rebuild(operand, visitor);
+    const OpRef& operand = expression->operand_at(i);
+    OpRef newexpr = rebuild(operand, visitor);
 
     if (newexpr == operand) {
       same_count += 1;
@@ -31,7 +31,7 @@ ref<Operation> rebuild(const ref<Operation>& expression, Visitor& visitor) {
   }
 }
 template <typename Visitor>
-ref<Operation> rebuild(const ref<Operation>& expression, Visitor&& visitor) {
+OpRef rebuild(const OpRef& expression, Visitor&& visitor) {
   return rebuild(expression, visitor);
 }
 

--- a/include/caffeine/IR/Transforms.inl
+++ b/include/caffeine/IR/Transforms.inl
@@ -6,16 +6,20 @@
 namespace caffeine::transforms {
 
 template <typename Visitor>
-ref<Operation> rebuild(const ref<Operation>& expression, Visitor&& visitor) {
+ref<Operation> rebuild(const ref<Operation>& expression, Visitor& visitor) {
   size_t nops = expression->num_operands();
   llvm::SmallVector<ref<Operation>, 3> ops;
   ops.reserve(nops);
 
   for (size_t i = 0; i < nops; ++i) {
-    ops.push_back(rebuild(expression->operand_at(i), std::move(visitor)));
+    ops.push_back(rebuild(expression->operand_at(i), visitor));
   }
 
   return visitor(expression->with_new_operands(ops));
+}
+template <typename Visitor>
+ref<Operation> rebuild(const ref<Operation>& expression, Visitor&& visitor) {
+  return rebuild(expression, visitor);
 }
 
 } // namespace caffeine::transforms

--- a/include/caffeine/IR/Transforms.inl
+++ b/include/caffeine/IR/Transforms.inl
@@ -1,0 +1,20 @@
+#pragma once
+
+#include "caffeine/IR/Transforms.h"
+#include <llvm/ADT/SmallVector.h>
+
+namespace caffeine::transforms {
+
+template <typename Visitor>
+ref<Operation> rebuild(const ref<Operation>& expression, Visitor& visitor) {
+  llvm::SmallVector<ref<Operation>, 3> ops;
+  ops.reserve(expression->num_operands());
+
+  for (size_t i = 0; i < ops.capacity(); ++i) {
+    ops.push_back(rebuild(expression->operand_at(i), visitor));
+  }
+
+  return visitor(expression->with_new_operands(ops));
+}
+
+} // namespace caffeine::transforms

--- a/include/caffeine/IR/Transforms.inl
+++ b/include/caffeine/IR/Transforms.inl
@@ -6,11 +6,12 @@
 namespace caffeine::transforms {
 
 template <typename Visitor>
-ref<Operation> rebuild(const ref<Operation>& expression, Visitor& visitor) {
+ref<Operation> rebuild(const ref<Operation>& expression, Visitor&& visitor) {
+  size_t nops = expression->num_operands();
   llvm::SmallVector<ref<Operation>, 3> ops;
-  ops.reserve(expression->num_operands());
+  ops.reserve(nops);
 
-  for (size_t i = 0; i < ops.capacity(); ++i) {
+  for (size_t i = 0; i < nops; ++i) {
     ops.push_back(rebuild(expression->operand_at(i), visitor));
   }
 

--- a/include/caffeine/IR/Transforms.inl
+++ b/include/caffeine/IR/Transforms.inl
@@ -12,7 +12,7 @@ ref<Operation> rebuild(const ref<Operation>& expression, Visitor&& visitor) {
   ops.reserve(nops);
 
   for (size_t i = 0; i < nops; ++i) {
-    ops.push_back(rebuild(expression->operand_at(i), visitor));
+    ops.push_back(rebuild(expression->operand_at(i), std::move(visitor)));
   }
 
   return visitor(expression->with_new_operands(ops));

--- a/test/unit/IR/Transform/rebuild.cpp
+++ b/test/unit/IR/Transform/rebuild.cpp
@@ -1,0 +1,20 @@
+#include "caffeine/IR/Operation.h"
+#include "caffeine/IR/Transforms.h"
+
+#include <gtest/gtest.h>
+
+namespace caffeine {
+
+TEST(RebuildTransformTest, unchanged_reuses_expressions) {
+  auto expression = BinaryOp::CreateAdd(
+      BinaryOp::CreateSub(Constant::Create(Type::type_of<uint32_t>(), "a"),
+                          Constant::Create(Type::type_of<uint32_t>(), "b")),
+      Constant::Create(Type::type_of<uint32_t>(), 1));
+
+  auto changed =
+      transforms::rebuild(expression, [](const auto& e) { return e; });
+
+  ASSERT_EQ(expression.get(), changed.get());
+}
+
+} // namespace caffeine


### PR DESCRIPTION
This adds a transform which allows a user-provided visitor to perform arbitrary transformations to the expression while rebuilding the modified expression tree. It's not super useful on it's own but it is a necessary building block to build more advanced transforms.

Leaving draft for now since this PR depends on #208.