### PR TITLE
Fix use of CopyVTable within Operation

### DIFF
--- a/include/caffeine/Support/CopyVTable.h
+++ b/include/caffeine/Support/CopyVTable.h
@@ -20,7 +20,11 @@ namespace caffeine {
  *
  * However, if you know that all dervied classes will have exactly the same size
  * as the base class and you want to have the classes vtable copied along with
- * them then you should take use this class.
+ * them then you should use this class. To actually make use of this class you
+ * will have to call copy_vtable within the copy/move ctors/assigment operators.
+ * This is because the compiler overwrites the vtable during construction of the
+ * derived operation so copy_vtable needs to be called after the object is
+ * initialized (i.e. within the body of the constructor).
  *
  * Limitations
  * ===========
@@ -42,11 +46,12 @@ public:
   CopyVTable() = default;
   virtual ~CopyVTable() = default;
 
-  CopyVTable(const CopyVTable&) noexcept;
-  CopyVTable(CopyVTable&&) noexcept;
+  // Deleted so the user is forced to call copy_vtable
+  CopyVTable(const CopyVTable&) noexcept = delete;
+  CopyVTable(CopyVTable&&) noexcept = delete;
 
-  CopyVTable& operator=(const CopyVTable&) noexcept;
-  CopyVTable& operator=(CopyVTable&&) noexcept;
+  CopyVTable& operator=(const CopyVTable&) noexcept = delete;
+  CopyVTable& operator=(CopyVTable&&) noexcept = delete;
 
   void copy_vtable(const CopyVTable& vtable) noexcept;
 };

--- a/src/IR/Operation.cpp
+++ b/src/IR/Operation.cpp
@@ -66,11 +66,14 @@ Operation::Operation(Opcode op, Type t, const ref<Operation>& op0,
 }
 
 Operation::Operation(const Operation& op)
-    : CopyVTable(op), opcode_(op.opcode_), refcount(0), type_(op.type_),
-      inner_(op.inner_) {}
+    : opcode_(op.opcode_), refcount(0), type_(op.type_), inner_(op.inner_) {
+  copy_vtable(op);
+}
 Operation::Operation(Operation&& op) noexcept
-    : CopyVTable(op), opcode_(op.opcode_), refcount(0), type_(op.type_),
-      inner_(std::move(op.inner_)) {}
+    : opcode_(op.opcode_), refcount(0), type_(op.type_),
+      inner_(std::move(op.inner_)) {
+  copy_vtable(op);
+}
 
 Operation& Operation::operator=(const Operation& op) {
   // Do inner first for exception safety.

--- a/src/Support/CopyVTable.cpp
+++ b/src/Support/CopyVTable.cpp
@@ -9,20 +9,4 @@ void CopyVTable::copy_vtable(const CopyVTable& base) noexcept {
   }
 }
 
-CopyVTable::CopyVTable(const CopyVTable& base) noexcept {
-  copy_vtable(base);
-}
-CopyVTable::CopyVTable(CopyVTable&& base) noexcept {
-  copy_vtable(base);
-}
-
-CopyVTable& CopyVTable::operator=(const CopyVTable& base) noexcept {
-  copy_vtable(base);
-  return *this;
-}
-CopyVTable& CopyVTable::operator=(CopyVTable&& base) noexcept {
-  copy_vtable(base);
-  return *this;
-}
-
 } // namespace caffeine


### PR DESCRIPTION
As it turns out, the copy constructor for CopyVTable runs before the derived class actually initializes the derived vtable. This means that as soon as we actually start copying Operations around the vtable was not being copied around with them. This showed up once the code actually started copying operations around and not just moving refcounted pointers around.

The fix for this is to have Operation call copy_vtable within its ctors. I've prevented the same issue from (hopefully) occurring again by deleting the copy/move ctors of CopyVTable and documenting this footgun in the class documentation.