### PR TITLE
Refactor constant folding out into a separate visitor

### DIFF
--- a/src/IR/Operation.cpp
+++ b/src/IR/Operation.cpp
@@ -126,9 +126,9 @@ OpRef Operation::with_new_operands(llvm::ArrayRef<OpRef> operands) const {
   if (equal)
     return into_ref();
 
-  auto value = new Operation((Opcode)opcode(), type(), operands.data());
-  value->copy_vtable(*this);
-  return OpRef(value);
+  Operation next{(Opcode)opcode(), type(), operands.data()};
+  next.copy_vtable(*this);
+  return constant_fold(std::move(next));
 }
 
 std::string_view Operation::opcode_name() const {

--- a/src/IR/Operation.h
+++ b/src/IR/Operation.h
@@ -90,8 +90,7 @@ inline uint64_t ilog2(uint64_t x) {
 }
 
 template <bool move_out = false>
-class ConstantFolder
-    : public ConstOpVisitor<ConstantFolder<move_out>, OpRef> {
+class ConstantFolder : public ConstOpVisitor<ConstantFolder<move_out>, OpRef> {
 public:
 #define TRY_CONST_INT(expr)                                                    \
   do {                                                                         \
@@ -411,8 +410,7 @@ public:
 
 private:
   template <typename F>
-  OpRef try_const_int(const OpRef& lhs,
-                               const OpRef& rhs, F&& func) {
+  OpRef try_const_int(const OpRef& lhs, const OpRef& rhs, F&& func) {
     const auto* lhs_int = llvm::dyn_cast<ConstantInt>(lhs.get());
     const auto* rhs_int = llvm::dyn_cast<ConstantInt>(rhs.get());
 
@@ -424,8 +422,7 @@ private:
   }
 
   template <typename F>
-  OpRef try_const_float(const OpRef& lhs,
-                                 const OpRef& rhs, F&& func) {
+  OpRef try_const_float(const OpRef& lhs, const OpRef& rhs, F&& func) {
     const auto* lhs_flt = llvm::dyn_cast<ConstantFloat>(lhs.get());
     const auto* rhs_flt = llvm::dyn_cast<ConstantFloat>(rhs.get());
 

--- a/src/IR/Operation.h
+++ b/src/IR/Operation.h
@@ -1,12 +1,16 @@
 #pragma once
 
 #include "caffeine/IR/Operation.h"
+#include "caffeine/IR/Visitor.h"
 
 #include <llvm/Support/MathExtras.h>
 
 /**
  * This header has a bunch of utility methods for constant folding.
  */
+
+// TODO: We should put this in a config file
+#define CAFFEINE_IMPLICIT_CONSTANT_FOLDING 1
 
 namespace caffeine {
 
@@ -15,11 +19,17 @@ inline bool is_constant_int(const Operation& op, uint64_t value) {
     return constant->value() == value;
   return false;
 }
+inline bool is_constant_int(const OpRef& op, uint64_t value) {
+  return is_constant_int(*op, value);
+}
 
 inline bool is_constant_ones(const Operation& op) {
   if (const auto* constant = llvm::dyn_cast<ConstantInt>(&op))
     return constant->value().isAllOnesValue();
   return false;
+}
+inline bool is_constant_ones(const OpRef& op) {
+  return is_constant_ones(*op);
 }
 
 inline bool constant_int_compare(ICmpOpcode cmp, const llvm::APInt& lhs,
@@ -77,6 +87,370 @@ inline bool constant_float_compare(FCmpOpcode cmp, const llvm::APFloat& lhs,
 inline uint64_t ilog2(uint64_t x) {
   bool ispow2 = (x & (x - 1)) == 0;
   return sizeof(x) * CHAR_BIT - llvm::countLeadingZeros(x) - (ispow2 ? 1 : 0);
+}
+
+template <bool move_out = false>
+class ConstantFolder
+    : public ConstOpVisitor<ConstantFolder<move_out>, OpRef> {
+public:
+#define TRY_CONST_INT(expr)                                                    \
+  do {                                                                         \
+    auto func = [&](const auto& lhs, const auto& rhs) { return (expr); };      \
+    if (auto constval = this->try_const_int(op.lhs(), op.rhs(), func))         \
+      return constval;                                                         \
+  } while (false)
+#define TRY_CONST_FLOAT(expr)                                                  \
+  do {                                                                         \
+    auto func = [&](const auto& lhs, const auto& rhs) { return (expr); };      \
+    if (auto constval = this->try_const_float(op.lhs(), op.rhs(), func))       \
+      return constval;                                                         \
+  } while (false)
+
+  OpRef visit(const Operation& op) {
+#ifdef CAFFEINE_IMPLICIT_CONSTANT_FOLDING
+    return ConstOpVisitor<ConstantFolder<move_out>, OpRef>::visit(op);
+#else
+    if constexpr (move_out) {
+      return make_ref<Operation>(std::move(const_cast<Operation&>(op)));
+    } else {
+      return make_ref<Operation>(op);
+    }
+#endif
+  }
+
+  OpRef visitOperation(const Operation& op) {
+    if constexpr (move_out) {
+      return make_ref<Operation>(std::move(const_cast<Operation&>(op)));
+    } else {
+      return make_ref<Operation>(op);
+    }
+  }
+
+  OpRef visitAdd(const BinaryOp& op) {
+    if (op.lhs()->is<Undef>() || op.rhs()->is<Undef>())
+      return Undef::Create(op.type());
+
+    if (is_constant_int(op.lhs(), 0))
+      return op.rhs();
+    if (is_constant_int(op.rhs(), 0))
+      return op.lhs();
+
+    TRY_CONST_INT(ConstantInt::Create(lhs.value() + rhs.value()));
+
+    return this->visitBinaryOp(op);
+  }
+  OpRef visitSub(const BinaryOp& op) {
+    if (op.lhs()->is<Undef>() || op.rhs()->is<Undef>())
+      return Undef::Create(op.type());
+
+    if (is_constant_int(op.rhs(), 0))
+      return op.lhs();
+
+    if (op.rhs().get() == op.lhs().get())
+      return ConstantInt::Create(llvm::APInt(op.type().bitwidth(), 0));
+
+    TRY_CONST_INT(ConstantInt::Create(lhs.value() - rhs.value()));
+
+    return this->visitBinaryOp(op);
+  }
+  OpRef visitMul(const BinaryOp& op) {
+    if (is_constant_int(op.lhs(), 0))
+      return op.lhs();
+    if (is_constant_int(op.rhs(), 0))
+      return op.rhs();
+
+    TRY_CONST_INT(ConstantInt::Create(lhs.value() * rhs.value()));
+
+    return this->visitBinaryOp(op);
+  }
+
+  OpRef visitUDiv(const BinaryOp& op) {
+    if (is_constant_int(op.lhs(), 0) || is_constant_int(*op.rhs(), 1))
+      return op.lhs();
+
+    TRY_CONST_INT(ConstantInt::Create(lhs.value().udiv(rhs.value())));
+
+    return this->visitBinaryOp(op);
+  }
+  OpRef visitSDiv(const BinaryOp& op) {
+    if (is_constant_int(op.lhs(), 0))
+      return op.lhs();
+    if (is_constant_int(op.rhs(), 1) && op.type().bitwidth() > 1)
+      return op.lhs();
+
+    TRY_CONST_INT(ConstantInt::Create(lhs.value().sdiv(rhs.value())));
+
+    return this->visitBinaryOp(op);
+  }
+  OpRef visitURem(const BinaryOp& op) {
+    if (is_constant_int(op.lhs(), 0))
+      return op.lhs();
+    if (is_constant_int(op.rhs(), 1))
+      return ConstantInt::Create(llvm::APInt(op.type().bitwidth(), 0));
+
+    TRY_CONST_INT(ConstantInt::Create(lhs.value().urem(rhs.value())));
+
+    return this->visitBinaryOp(op);
+  }
+  OpRef visitSRem(const BinaryOp& op) {
+    if (is_constant_int(op.lhs(), 0))
+      return op.lhs();
+    if (is_constant_int(op.rhs(), 1) && op.type().bitwidth() > 1)
+      return ConstantInt::Create(llvm::APInt(op.type().bitwidth(), 0));
+
+    TRY_CONST_INT(ConstantInt::Create(lhs.value().srem(rhs.value())));
+
+    return this->visitBinaryOp(op);
+  }
+
+  OpRef visitAnd(const BinaryOp& op) {
+    if (is_constant_int(op.lhs(), 0))
+      return op.lhs();
+    if (is_constant_int(op.rhs(), 0))
+      return op.rhs();
+
+    if (is_constant_ones(op.lhs()))
+      return op.rhs();
+    if (is_constant_ones(op.rhs()))
+      return op.lhs();
+
+    TRY_CONST_INT(ConstantInt::Create(lhs.value() & rhs.value()));
+
+    return this->visitBinaryOp(op);
+  }
+  OpRef visitOr(const BinaryOp& op) {
+    if (is_constant_int(op.lhs(), 0))
+      return op.rhs();
+    if (is_constant_int(op.rhs(), 0))
+      return op.lhs();
+
+    if (is_constant_ones(op.lhs()))
+      return op.lhs();
+    if (is_constant_ones(op.rhs()))
+      return op.rhs();
+
+    TRY_CONST_INT(ConstantInt::Create(lhs.value() | rhs.value()));
+
+    return this->visitBinaryOp(op);
+  }
+  OpRef visitXor(const BinaryOp& op) {
+    if (op.lhs()->is<Undef>() || op.rhs()->is<Undef>())
+      return Undef::Create(op.type());
+
+    if (is_constant_int(op.lhs(), 0))
+      return op.rhs();
+    if (is_constant_int(op.rhs(), 0))
+      return op.lhs();
+
+    TRY_CONST_INT(ConstantInt::Create(lhs.value() ^ rhs.value()));
+
+    return this->visitBinaryOp(op);
+  }
+  OpRef visitShl(const BinaryOp& op) {
+    if (is_constant_int(op.lhs(), 0) || is_constant_int(op.rhs(), 0))
+      return op.lhs();
+
+    TRY_CONST_INT(ConstantInt::Create(lhs.value() << rhs.value()));
+
+    return this->visitBinaryOp(op);
+  }
+  OpRef visitLShr(const BinaryOp& op) {
+    if (is_constant_int(op.lhs(), 0) || is_constant_int(op.rhs(), 0))
+      return op.lhs();
+
+    TRY_CONST_INT(ConstantInt::Create(lhs.value().lshr(rhs.value())));
+
+    return this->visitBinaryOp(op);
+  }
+  OpRef visitAShr(const BinaryOp& op) {
+    if (is_constant_int(op.lhs(), 0) || is_constant_int(op.rhs(), 0))
+      return op.lhs();
+
+    TRY_CONST_INT(ConstantInt::Create(lhs.value().ashr(rhs.value())));
+
+    return this->visitBinaryOp(op);
+  }
+
+  OpRef visitFAdd(const BinaryOp& op) {
+    TRY_CONST_FLOAT(ConstantFloat::Create(lhs.value() + rhs.value()));
+
+    return this->visitBinaryOp(op);
+  }
+  OpRef visitFSub(const BinaryOp& op) {
+    TRY_CONST_FLOAT(ConstantFloat::Create(lhs.value() - rhs.value()));
+
+    return this->visitBinaryOp(op);
+  }
+  OpRef visitFMul(const BinaryOp& op) {
+    TRY_CONST_FLOAT(ConstantFloat::Create(lhs.value() * rhs.value()));
+
+    return this->visitBinaryOp(op);
+  }
+  OpRef visitFDiv(const BinaryOp& op) {
+    TRY_CONST_FLOAT(ConstantFloat::Create(lhs.value() / rhs.value()));
+
+    return this->visitBinaryOp(op);
+  }
+  OpRef visitFRem(const BinaryOp& op) {
+    TRY_CONST_FLOAT(ConstantFloat::Create(
+        llvm::APFloat(lhs.value()).remainder(rhs.value())));
+
+    return this->visitBinaryOp(op);
+  }
+
+  OpRef visitNot(const UnaryOp& op) {
+    if (const auto* val = llvm::dyn_cast<ConstantInt>(op.operand().get()))
+      return ConstantInt::Create(~val->value());
+
+    return this->visitUnaryOp(op);
+  }
+  OpRef visitTrunc(const UnaryOp& op) {
+    if (const auto* val = llvm::dyn_cast<ConstantInt>(op.operand().get()))
+      return ConstantInt::Create(val->value().trunc(op.type().bitwidth()));
+
+    return this->visitUnaryOp(op);
+  }
+  OpRef visitZExt(const UnaryOp& op) {
+    if (const auto* val = llvm::dyn_cast<ConstantInt>(op.operand().get()))
+      return ConstantInt::Create(val->value().zext(op.type().bitwidth()));
+
+    return this->visitUnaryOp(op);
+  }
+  OpRef visitSExt(const UnaryOp& op) {
+    if (const auto* val = llvm::dyn_cast<ConstantInt>(op.operand().get()))
+      return ConstantInt::Create(val->value().sext(op.type().bitwidth()));
+
+    return this->visitUnaryOp(op);
+  }
+
+  OpRef visitSelectOp(const SelectOp& op) {
+    if (const auto* vcond = llvm::dyn_cast<ConstantInt>(op.condition().get()))
+      return vcond->value() == 1 ? op.true_value() : op.false_value();
+
+    return this->visitOperation(op);
+  }
+
+  OpRef visitICmp(const ICmpOp& op) {
+    TRY_CONST_INT(ConstantInt::Create(
+        constant_int_compare(op.comparison(), lhs.value(), rhs.value())));
+
+    if (op.lhs() == op.rhs()) {
+      if (op.lhs()->is<Undef>())
+        return Undef::Create(Type::int_ty(1));
+
+      switch (op.comparison()) {
+      case ICmpOpcode::EQ:
+      case ICmpOpcode::ULE:
+      case ICmpOpcode::SLE:
+      case ICmpOpcode::UGE:
+      case ICmpOpcode::SGE:
+        return ConstantInt::Create(true);
+      case ICmpOpcode::NE:
+      case ICmpOpcode::ULT:
+      case ICmpOpcode::SLT:
+      case ICmpOpcode::UGT:
+      case ICmpOpcode::SGT:
+        return ConstantInt::Create(false);
+      }
+    }
+
+    return this->visitBinaryOp(op);
+  }
+  OpRef visitFCmp(const FCmpOp& op) {
+    TRY_CONST_FLOAT(ConstantInt::Create(
+        constant_float_compare(op.comparison(), lhs.value(), rhs.value())));
+
+    if (op.lhs() == op.rhs()) {
+      switch (op.comparison()) {
+      case FCmpOpcode::EQ:
+      case FCmpOpcode::LE:
+      case FCmpOpcode::GE:
+        return ConstantInt::Create(true);
+      case FCmpOpcode::NE:
+      case FCmpOpcode::LT:
+      case FCmpOpcode::GT:
+        return ConstantInt::Create(false);
+      }
+    }
+
+    return this->visitBinaryOp(op);
+  }
+
+  OpRef visitAllocOp(const AllocOp& op) {
+    if (const auto* cnst = llvm::dyn_cast<ConstantInt>(op.size().get())) {
+      if (cnst->value().getLimitedValue(SIZE_MAX) < SIZE_MAX) {
+        return FixedArray::Create(cnst->type(), op.default_value(),
+                                  cnst->value().getLimitedValue());
+      }
+    }
+
+    return this->visitArrayBase(op);
+  }
+  OpRef visitLoadOp(const LoadOp& op) {
+    const auto* fixedarray = llvm::dyn_cast<FixedArray>(op.data().get());
+    const auto* offset_int = llvm::dyn_cast<ConstantInt>(op.offset().get());
+
+    if (fixedarray && offset_int) {
+      return fixedarray->data()[offset_int->value().getLimitedValue()];
+    }
+
+    return this->visitOperation(op);
+  }
+  OpRef visitStoreOp(const StoreOp& op) {
+    const auto* offset_cnst = llvm::dyn_cast<ConstantInt>(op.offset().get());
+    const auto* fixedarray = llvm::dyn_cast<FixedArray>(op.data().get());
+
+    if (offset_cnst && fixedarray) {
+      auto data = fixedarray->data();
+      data.set(offset_cnst->value().getLimitedValue(), op.value());
+      return FixedArray::Create(op.offset()->type(), data);
+    }
+
+    return this->visitArrayBase(op);
+  }
+
+private:
+  template <typename F>
+  OpRef try_const_int(const OpRef& lhs,
+                               const OpRef& rhs, F&& func) {
+    const auto* lhs_int = llvm::dyn_cast<ConstantInt>(lhs.get());
+    const auto* rhs_int = llvm::dyn_cast<ConstantInt>(rhs.get());
+
+    if (lhs_int && rhs_int) {
+      return func(*lhs_int, *rhs_int);
+    }
+
+    return nullptr;
+  }
+
+  template <typename F>
+  OpRef try_const_float(const OpRef& lhs,
+                                 const OpRef& rhs, F&& func) {
+    const auto* lhs_flt = llvm::dyn_cast<ConstantFloat>(lhs.get());
+    const auto* rhs_flt = llvm::dyn_cast<ConstantFloat>(rhs.get());
+
+    if (lhs_flt && rhs_flt) {
+      return func(*lhs_flt, *rhs_flt);
+    }
+
+    return nullptr;
+  }
+};
+
+template <typename T>
+OpRef constant_fold(T& value) {
+  ConstantFolder<false> fold;
+  return fold(value);
+}
+template <typename T>
+OpRef constant_fold(const T& value) {
+  ConstantFolder<false> fold;
+  return fold(value);
+}
+template <typename T>
+OpRef constant_fold(T&& value) {
+  ConstantFolder<true> fold;
+  return fold(value);
 }
 
 } // namespace caffeine


### PR DESCRIPTION
We'd like `with_new_operands` to apply constant folding rules when they apply to the expression formed with the new operands. Unfortunately, that's not possible to do with the current design since it's done as part of the `CreateXXX` methods. To allow it to be used more generally this PR moves all the constant-folding related code out into a separate visitor in `src/IR/Operation.h`.

With that change included we can now properly perform constant folding within `with_new_operands` calls. It also simplifies a bunch of the code so we end up getting a net reduction in lines of code!

This is a fairly large PR but it mostly involves copy and pasting code so I'm hoping review should just involve a skim of the changes.