### PR TITLE
Don't catch exceptions when running tests individually

### DIFF
--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -21,5 +21,8 @@ if (${CMAKE_VERSION} VERSION_LESS "3.10.0")
   add_test(NAME unit-tests COMMAND caffeine-unittest)
 else()
   # This lists all the tests individually 
-  gtest_discover_tests(caffeine-unittest TEST_PREFIX unit/)
+  gtest_discover_tests(caffeine-unittest
+    TEST_PREFIX unit/
+    EXTRA_ARGS --gtest_catch_exceptions=0
+  )
 endif()


### PR DESCRIPTION
If gtest catches exceptions thrown from tests then we don't get to see backtraces showing where the exception was thrown. This is normally a good thing since it allows up to keep running tests in the rest of the test suite. However, when running the tests from ctest we run each one individually so if an uncaught exception is thrown we want to just die and print out the backtrace.

This PR changes the default when running ctest.