### PR TITLE
Implement expression simplification solver

### DIFF
--- a/include/caffeine/IR/Matching.h
+++ b/include/caffeine/IR/Matching.h
@@ -340,7 +340,7 @@ namespace matching {
       ICmpMatcher(T1&& lhs, T2&& rhs)
           : lhs(std::forward<T1>(lhs)), rhs(std::forward<T2>(rhs)) {}
 
-      bool matches(const ref<Operation>& op) const {
+      bool matches(const OpRef& op) const {
         const auto* icmp = llvm::dyn_cast<ICmpOp>(op.get());
         if (!icmp)
           return false;
@@ -350,7 +350,7 @@ namespace matching {
 
         return lhs.matches(icmp->lhs()) && rhs.matches(icmp->rhs());
       }
-      void on_match(const ref<Operation>& op) const {
+      void on_match(const OpRef& op) const {
         lhs.on_match(op->operand_at(0));
         rhs.on_match(op->operand_at(1));
       }

--- a/include/caffeine/IR/Transforms.h
+++ b/include/caffeine/IR/Transforms.h
@@ -55,6 +55,11 @@ void decompose(std::vector<Assertion>& assertions);
 void canonicalize(std::vector<Assertion>& assertions);
 
 /**
+ * Generic simplication transform.
+ */
+void simplify(std::vector<Assertion>& assertions);
+
+/**
  * Rebuild an expression tree using the transform applied by the visitor. This
  * will traverse the tree in a depth-first order and apply the transform to each
  * node. If no changes are made then existing expression nodes will be reused.

--- a/include/caffeine/Solver/SequenceSolver.h
+++ b/include/caffeine/Solver/SequenceSolver.h
@@ -3,7 +3,9 @@
 
 #include "caffeine/Solver/Solver.h"
 
+#include <memory>
 #include <tuple>
+#include <type_traits>
 
 namespace caffeine {
 
@@ -66,6 +68,13 @@ private:
   static_assert(sizeof...(Ts) != 0);
   static_assert((... && std::is_base_of_v<Solver, Ts>));
 };
+
+template <typename... Ts>
+std::shared_ptr<SequenceSolver<std::decay_t<Ts>...>>
+make_sequence_solver(Ts&&... solvers) {
+  return std::make_shared<SequenceSolver<std::decay_t<Ts>...>>(
+      std::forward<Ts>(solvers)...);
+}
 
 } // namespace caffeine
 

--- a/include/caffeine/Solver/SimplifyingSolver.h
+++ b/include/caffeine/Solver/SimplifyingSolver.h
@@ -1,0 +1,28 @@
+#pragma once
+
+#include "caffeine/Solver/Solver.h"
+
+namespace caffeine {
+
+/**
+ * Solver that attempts to convert expressions to a canonical form.
+ *
+ * What exactly the canonical form for expressions are hasn't been defined yet
+ * but currently there are two guarantees from this solver:
+ *  - There will be no unevaluated constant subexpressions (e.g. 3 + 4)
+ *  - There will be no repeated duplicate assertions
+ *
+ * Always returns unknown.
+ */
+class SimplifyingSolver final : public Solver {
+public:
+  SimplifyingSolver() = default;
+
+  SolverResult check(std::vector<Assertion>& assertions,
+                     const Assertion& extra) override;
+
+  std::unique_ptr<Model> resolve(std::vector<Assertion>& assertions,
+                                 const Assertion& extra) override;
+};
+
+} // namespace caffeine

--- a/src/IR/Transforms/simplify.cpp
+++ b/src/IR/Transforms/simplify.cpp
@@ -1,0 +1,61 @@
+#include "caffeine/IR/Assertion.h"
+#include "caffeine/IR/Matching.h"
+#include "caffeine/IR/Transforms.h"
+
+namespace caffeine::transforms {
+namespace m = caffeine::matching;
+
+namespace {
+
+  bool is_equality_expr(const Assertion& assertion, ref<Operation>& constant,
+                        ref<Operation>& value) {
+    using namespace caffeine::matching;
+
+    if (matches(assertion, ICmpEq(Capture(constant, m::Constant()),
+                                  Capture(value, m::ConstantInt())))) {
+      return true;
+    }
+
+    if (matches(assertion, ICmpEq(Capture(value, m::ConstantInt()),
+                                  Capture(constant, m::Constant())))) {
+      return true;
+    }
+
+    return false;
+  }
+
+} // namespace
+
+void simplify(std::vector<Assertion>& assertions) {
+
+  decompose(assertions);
+
+  for (size_t i = 0; i < assertions.size(); ++i) {
+    ref<Operation> constant_, value;
+    if (!is_equality_expr(assertions[i], constant_, value))
+      continue;
+
+    const auto* constant = llvm::cast<Constant>(constant_.get());
+
+    for (size_t j = 0; j < assertions.size(); ++j) {
+      if (j == i)
+        continue;
+
+      auto changed =
+          rebuild(assertions[i].value(), [&](const ref<Operation>& op) {
+            const auto* cnst = llvm::dyn_cast<Constant>(op.get());
+            if (!cnst)
+              return op;
+
+            if (cnst->symbol() != constant->symbol())
+              return op;
+
+            return value;
+          });
+
+      assertions[i].value() = changed;
+    }
+  }
+}
+
+} // namespace caffeine::transforms

--- a/src/IR/Transforms/simplify.cpp
+++ b/src/IR/Transforms/simplify.cpp
@@ -41,7 +41,7 @@ void simplify(std::vector<Assertion>& assertions) {
       if (j == i)
         continue;
 
-      auto changed = rebuild(assertions[i].value(), [&](const OpRef& op) {
+      auto changed = rebuild(assertions[j].value(), [&](const OpRef& op) {
         const auto* cnst = llvm::dyn_cast<Constant>(op.get());
         if (!cnst)
           return op;
@@ -52,7 +52,7 @@ void simplify(std::vector<Assertion>& assertions) {
         return value;
       });
 
-      assertions[i].value() = changed;
+      assertions[j].value() = changed;
     }
   }
 }

--- a/src/Solver/SimplifyingSolver.cpp
+++ b/src/Solver/SimplifyingSolver.cpp
@@ -1,0 +1,25 @@
+#include "caffeine/Solver/SimplifyingSolver.h"
+
+#include "caffeine/IR/Assertion.h"
+#include "caffeine/IR/Operation.h"
+#include "caffeine/IR/Transforms.h"
+
+#include <llvm/ADT/SmallVector.h>
+
+#include <unordered_set>
+
+namespace caffeine {
+
+SolverResult SimplifyingSolver::check(std::vector<Assertion>& assertions,
+                                      const Assertion&) {
+  transforms::simplify(assertions);
+  return SolverResult::Unknown;
+}
+std::unique_ptr<Model>
+SimplifyingSolver::resolve(std::vector<Assertion>& assertions,
+                           const Assertion&) {
+  transforms::simplify(assertions);
+  return std::make_unique<EmptyModel>(SolverResult::Unknown);
+}
+
+} // namespace caffeine

--- a/src/bin/caffeine.cpp
+++ b/src/bin/caffeine.cpp
@@ -1,5 +1,8 @@
 
 #include "caffeine/Interpreter/Interpreter.h"
+#include "caffeine/Solver/CanonicalizingSolver.h"
+#include "caffeine/Solver/SequenceSolver.h"
+#include "caffeine/Solver/SimplifyingSolver.h"
 #include "caffeine/Solver/Z3Solver.h"
 
 #include <boost/core/demangle.hpp>
@@ -161,8 +164,9 @@ int main(int argc, char** argv) {
   // Print out exception messages in std::terminate
   llvm_handler = std::set_terminate(custom_terminate_handler);
 
-  std::shared_ptr<caffeine::Solver> solver =
-      std::make_shared<caffeine::Z3Solver>();
+  std::shared_ptr<caffeine::Solver> solver = caffeine::make_sequence_solver(
+      caffeine::SimplifyingSolver(), caffeine::CanonicalizingSolver(),
+      caffeine::Z3Solver());
   auto logger = CountingFailureLogger{std::cout, function};
 
   Executor exec;


### PR DESCRIPTION
This PR implements the start of a generic expression simplification solver. Currently all it is able to do is run the decomposition transform and replace with constants when it finds an `x == <const>` constraint within the assertions. In the future this should be expanded as needed.

Closes #161.