### PR TITLE
Implement memset intrinsic

### DIFF
--- a/include/caffeine/Interpreter/Interpreter.h
+++ b/include/caffeine/Interpreter/Interpreter.h
@@ -85,6 +85,7 @@ public:
 
   ExecutionResult visitMemCpyInst(llvm::MemCpyInst& memcpy);
   ExecutionResult visitMemMoveInst(llvm::MemMoveInst& memmove);
+  ExecutionResult visitMemSetInst(llvm::MemSetInst& memset);
 
 private:
   ExecutionResult visitExternFunc(llvm::CallInst& inst);

--- a/libraries/builtins/CMakeLists.txt
+++ b/libraries/builtins/CMakeLists.txt
@@ -4,6 +4,7 @@ file(
   CONFIGURE_DEPENDS
   *.c
   *.h
+  *.ll
 )
 
 add_llvm_ir_library(caffeine-builtins

--- a/libraries/builtins/memset.ll
+++ b/libraries/builtins/memset.ll
@@ -1,0 +1,33 @@
+; ModuleID = 'llvm-link'
+source_filename = "llvm-link"
+target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128"
+target triple = "x86_64-pc-linux-gnu"
+
+define dso_local void @caffeine_builtin_memset(
+  i8* %0,
+  i8 signext %byte,
+  i64 %size,
+  i1 %isvolatile
+) local_unnamed_addr  #0 {
+  %dst = tail call i8* @caffeine_builtin_resolve(i8* %0, i64 %size) #1
+  br label %loopstart
+
+loopstart:
+  %ctr = phi i64 [ %size, %1 ], [ %i, %loopbody ]
+  %cond = icmp ne i64 %ctr, 0
+  br i1 %cond, label %loopend, label %loopbody
+
+loopbody:
+  %i = sub i64 %ctr, 1
+  %ptr = getelementptr i8, i8* %dst, i64 %i
+  store i8 %byte, i8* %ptr, align 1
+  br label %loopstart
+
+loopend:
+  ret void
+}
+
+declare dso_local i8* @caffeine_builtin_resolve(i8*, i64) local_unnamed_addr #1
+
+attributes #0 = { nounwind uwtable }
+attributes #1 = { nounwind }

--- a/src/Interpreter/Interpreter.cpp
+++ b/src/Interpreter/Interpreter.cpp
@@ -910,6 +910,15 @@ ExecutionResult Interpreter::visitMemMoveInst(llvm::MemMoveInst& memmove) {
 
   return visitCall(memmove);
 }
+ExecutionResult Interpreter::visitMemSetInst(llvm::MemSetInst& memset) {
+  // memset is implemented by a C function within the builtins library so we
+  // just forward the call to that.
+  auto func = memset.getModule()->getFunction("caffeine_builtin_memset");
+  CAFFEINE_ASSERT(func);
+  memset.setCalledFunction(func);
+
+  return visitCall(memset);
+}
 
 /***************************************************
  * External function                               *

--- a/test/run-pass/mem/memset-basic.c
+++ b/test/run-pass/mem/memset-basic.c
@@ -1,0 +1,19 @@
+
+#include "caffeine.h"
+#include <stdint.h>
+#include <string.h>
+
+struct testdata {
+  uint32_t a;
+  uint64_t b;
+  uint8_t c;
+};
+
+void test() {
+  struct testdata data;
+  memset(&data, 0xCC, sizeof(data));
+
+  caffeine_assert(data.a == 0xCCCCCCCC);
+  caffeine_assert(data.b == 0xCCCCCCCCCCCCCCCC);
+  caffeine_assert(data.c == 0xCC);
+}


### PR DESCRIPTION
This implements the `llvm.memset` intrinsic when `sizeof(void*) == 8`. I was unable to write a version in C which didn't just get optimized down to the memset intrinsic so I had to write it using LLVM IR.

I have also included a simple test to ensure that things work as expected.

Closes #216.