### PR TITLE
Add Capnp to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,4 +23,6 @@ RUN apt-get update \
         python3-distutils \
         libfmt-dev \
         libboost-all-dev \
+        libcapnp-dev \
+        capnproto \
     && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
This PR adds capnp to the Dockerfile because dependant PRs won't pass the CI before this is done