### PR TITLE
Replace ref<Operation> with OpRef typedef across whole codebase

### DIFF
--- a/include/caffeine/IR/Assertion.h
+++ b/include/caffeine/IR/Assertion.h
@@ -13,16 +13,16 @@ namespace caffeine {
  */
 class Assertion {
 private:
-  ref<Operation> value_;
+  OpRef value_;
 
 public:
   Assertion();
-  Assertion(const ref<Operation>& value);
+  Assertion(const OpRef& value);
 
-  ref<Operation>& value() &;
-  ref<Operation>&& value() &&;
-  const ref<Operation>& value() const&;
-  const ref<Operation>&& value() const&&;
+  OpRef& value() &;
+  OpRef&& value() &&;
+  const OpRef& value() const&;
+  const OpRef&& value() const&&;
 
   bool is_empty() const;
   bool is_constant() const;

--- a/include/caffeine/IR/Assertion.inl
+++ b/include/caffeine/IR/Assertion.inl
@@ -5,16 +5,16 @@
 
 namespace caffeine {
 
-inline ref<Operation>& Assertion::value() & {
+inline OpRef& Assertion::value() & {
   return value_;
 }
-inline ref<Operation>&& Assertion::value() && {
+inline OpRef&& Assertion::value() && {
   return std::move(value_);
 }
-inline const ref<Operation>& Assertion::value() const& {
+inline const OpRef& Assertion::value() const& {
   return value_;
 }
-inline const ref<Operation>&& Assertion::value() const&& {
+inline const OpRef&& Assertion::value() const&& {
   return std::move(value_);
 }
 

--- a/include/caffeine/IR/Matching.h
+++ b/include/caffeine/IR/Matching.h
@@ -242,10 +242,10 @@ namespace matching {
   inline OpClassMatcher<opclass> name() {                                      \
     return OpClassMatcher<opclass>();                                          \
   };                                                                           \
-  inline OpClassMatcher<opclass> name(OpRef& op) {                    \
+  inline OpClassMatcher<opclass> name(OpRef& op) {                             \
     return OpClassMatcher<opclass>(&op);                                       \
   }                                                                            \
-  inline OpClassMatcher<opclass> name(OpRef* op) {                    \
+  inline OpClassMatcher<opclass> name(OpRef* op) {                             \
     return OpClassMatcher<opclass>(op);                                        \
   }                                                                            \
   static_assert(true)
@@ -318,14 +318,12 @@ namespace matching {
    * provided matcher.
    */
   template <typename M>
-  detail::CaptureMatcher<std::decay_t<M>> Capture(OpRef& op,
-                                                  M&& matcher) {
+  detail::CaptureMatcher<std::decay_t<M>> Capture(OpRef& op, M&& matcher) {
     return detail::CaptureMatcher<std::decay_t<M>>(&op,
                                                    std::forward<M>(matcher));
   }
   template <typename M>
-  detail::CaptureMatcher<std::decay_t<M>> Capture(OpRef* op,
-                                                  M&& matcher) {
+  detail::CaptureMatcher<std::decay_t<M>> Capture(OpRef* op, M&& matcher) {
     return detail::CaptureMatcher<std::decay_t<M>>(op,
                                                    std::forward<M>(matcher));
   }
@@ -388,8 +386,7 @@ bool matches(const Assertion& assertion, const Matcher& matcher) {
  * TODO: Make some sort of matching iterator.
  */
 template <typename Matcher>
-OpRef matches_anywhere(const OpRef& op,
-                                const Matcher& matcher) {
+OpRef matches_anywhere(const OpRef& op, const Matcher& matcher) {
   if (matcher.matches(op)) {
     matcher.on_match(op);
     return op;
@@ -406,8 +403,7 @@ OpRef matches_anywhere(const OpRef& op,
   return nullptr;
 }
 template <typename Matcher>
-OpRef matches_anywhere(const Assertion& assertion,
-                                const Matcher& matcher) {
+OpRef matches_anywhere(const Assertion& assertion, const Matcher& matcher) {
   return matches_anywhere(assertion.value(), matcher);
 }
 

--- a/include/caffeine/IR/Operation.h
+++ b/include/caffeine/IR/Operation.h
@@ -49,6 +49,9 @@ namespace detail {
   class double_deref_iterator;
 } // namespace detail
 
+class Operation;
+typedef ref<Operation> OpRef;
+
 enum class ICmpOpcode : uint8_t {
   EQ = 0x8,
   NE = 0x9,

--- a/include/caffeine/IR/Operation.h
+++ b/include/caffeine/IR/Operation.h
@@ -310,10 +310,9 @@ protected:
   Operation(Opcode op, Type t, const OpRef* operands);
 
   Operation(Opcode op, Type t, const OpRef& op0);
-  Operation(Opcode op, Type t, const OpRef& op0,
-            const OpRef& op1);
-  Operation(Opcode op, Type t, const OpRef& op0,
-            const OpRef& op1, const OpRef& op2);
+  Operation(Opcode op, Type t, const OpRef& op0, const OpRef& op1);
+  Operation(Opcode op, Type t, const OpRef& op0, const OpRef& op1,
+            const OpRef& op2);
 
   Operation();
   Operation(Opcode op, Type t);
@@ -361,8 +360,7 @@ public:
   OpRef into_ref() const;
 
   typedef detail::double_deref_iterator<OpRef> operand_iterator;
-  typedef detail::double_deref_iterator<const OpRef>
-      const_operand_iterator;
+  typedef detail::double_deref_iterator<const OpRef> const_operand_iterator;
 
   virtual size_t num_operands() const;
   virtual llvm::iterator_range<operand_iterator> operands();
@@ -385,8 +383,7 @@ public:
    * Create a new operation using the same opcode as the current one but with
    * new operands.
    */
-  virtual OpRef
-  with_new_operands(llvm::ArrayRef<OpRef> operands) const;
+  virtual OpRef with_new_operands(llvm::ArrayRef<OpRef> operands) const;
 
   /**
    * Accessors to operand references.
@@ -520,15 +517,13 @@ public:
 
   const Symbol& symbol() const;
 
-  static OpRef Create(const Symbol& symbol,
-                               const OpRef& size);
+  static OpRef Create(const Symbol& symbol, const OpRef& size);
   static OpRef Create(Symbol&& symbol, const OpRef& size);
 
   llvm::iterator_range<operand_iterator> operands() override;
   llvm::iterator_range<const_operand_iterator> operands() const override;
 
-  OpRef
-  with_new_operands(llvm::ArrayRef<OpRef> operands) const override;
+  OpRef with_new_operands(llvm::ArrayRef<OpRef> operands) const override;
 
   OpRef& operand_at(size_t idx) override;
   const OpRef& operand_at(size_t idx) const override;
@@ -543,8 +538,7 @@ public:
  */
 class BinaryOp : public Operation {
 protected:
-  BinaryOp(Opcode op, Type t, const OpRef& lhs,
-           const OpRef& rhs);
+  BinaryOp(Opcode op, Type t, const OpRef& lhs, const OpRef& rhs);
 
 public:
   const OpRef& lhs() const;
@@ -553,53 +547,34 @@ public:
   OpRef& lhs();
   OpRef& rhs();
 
-  static OpRef Create(Opcode op, const OpRef& lhs,
-                               const OpRef& rhs);
+  static OpRef Create(Opcode op, const OpRef& lhs, const OpRef& rhs);
 
-  static OpRef CreateAdd(const OpRef& lhs,
-                                  const OpRef& rhs);
-  static OpRef CreateSub(const OpRef& lhs,
-                                  const OpRef& rhs);
-  static OpRef CreateMul(const OpRef& lhs,
-                                  const OpRef& rhs);
-  static OpRef CreateUDiv(const OpRef& lhs,
-                                   const OpRef& rhs);
-  static OpRef CreateSDiv(const OpRef& lhs,
-                                   const OpRef& rhs);
-  static OpRef CreateURem(const OpRef& lhs,
-                                   const OpRef& rhs);
-  static OpRef CreateSRem(const OpRef& lhs,
-                                   const OpRef& rhs);
+  static OpRef CreateAdd(const OpRef& lhs, const OpRef& rhs);
+  static OpRef CreateSub(const OpRef& lhs, const OpRef& rhs);
+  static OpRef CreateMul(const OpRef& lhs, const OpRef& rhs);
+  static OpRef CreateUDiv(const OpRef& lhs, const OpRef& rhs);
+  static OpRef CreateSDiv(const OpRef& lhs, const OpRef& rhs);
+  static OpRef CreateURem(const OpRef& lhs, const OpRef& rhs);
+  static OpRef CreateSRem(const OpRef& lhs, const OpRef& rhs);
 
-  static OpRef CreateAnd(const OpRef& lhs,
-                                  const OpRef& rhs);
-  static OpRef CreateOr(const OpRef& lhs,
-                                 const OpRef& rhs);
-  static OpRef CreateXor(const OpRef& lhs,
-                                  const OpRef& rhs);
-  static OpRef CreateShl(const OpRef& lhs,
-                                  const OpRef& rhs);
-  static OpRef CreateLShr(const OpRef& lhs,
-                                   const OpRef& rhs);
-  static OpRef CreateAShr(const OpRef& lhs,
-                                   const OpRef& rhs);
+  static OpRef CreateAnd(const OpRef& lhs, const OpRef& rhs);
+  static OpRef CreateOr(const OpRef& lhs, const OpRef& rhs);
+  static OpRef CreateXor(const OpRef& lhs, const OpRef& rhs);
+  static OpRef CreateShl(const OpRef& lhs, const OpRef& rhs);
+  static OpRef CreateLShr(const OpRef& lhs, const OpRef& rhs);
+  static OpRef CreateAShr(const OpRef& lhs, const OpRef& rhs);
 
-  static OpRef CreateFAdd(const OpRef& lhs,
-                                   const OpRef& rhs);
-  static OpRef CreateFSub(const OpRef& lhs,
-                                   const OpRef& rhs);
-  static OpRef CreateFMul(const OpRef& lhs,
-                                   const OpRef& rhs);
-  static OpRef CreateFDiv(const OpRef& lhs,
-                                   const OpRef& rhs);
-  static OpRef CreateFRem(const OpRef& lhs,
-                                   const OpRef& rhs);
+  static OpRef CreateFAdd(const OpRef& lhs, const OpRef& rhs);
+  static OpRef CreateFSub(const OpRef& lhs, const OpRef& rhs);
+  static OpRef CreateFMul(const OpRef& lhs, const OpRef& rhs);
+  static OpRef CreateFDiv(const OpRef& lhs, const OpRef& rhs);
+  static OpRef CreateFRem(const OpRef& lhs, const OpRef& rhs);
 
   // Utility methods for creating integer arithmetic when one of the operations
   // is a constant.
 
 #define CAFFEINE_DECL_BINOP_INT_CONST(op)                                      \
-  static OpRef Create##op(const OpRef& lhs, int64_t rhs);    \
+  static OpRef Create##op(const OpRef& lhs, int64_t rhs);                      \
   static OpRef Create##op(int64_t lhs, const OpRef& rhs)
 
   CAFFEINE_DECL_BINOP_INT_CONST(Add);
@@ -636,8 +611,7 @@ public:
   const OpRef& operand() const;
 
   static OpRef Create(Opcode op, const OpRef& operand);
-  static OpRef Create(Opcode op, const OpRef& operand,
-                               Type returnType);
+  static OpRef Create(Opcode op, const OpRef& operand, Type returnType);
   static OpRef CreateNot(const OpRef& operand);
   static OpRef CreateFNeg(const OpRef& operand);
   static OpRef CreateFIsNaN(const OpRef& operand);
@@ -655,12 +629,10 @@ public:
 
   /// Create a trunc operation or a zext operation as needed to convert operand
   /// to the required bitwidth. If the bitwidths are the same then does nothing.
-  static OpRef CreateTruncOrZExt(Type tgt,
-                                          const OpRef& operand);
+  static OpRef CreateTruncOrZExt(Type tgt, const OpRef& operand);
   /// Create a trunc operation or a sext operation as needed to convert operand
   /// to the required bitwidth. If the bitwidths are the same then does nothing.
-  static OpRef CreateTruncOrSExt(Type tgt,
-                                          const OpRef& operand);
+  static OpRef CreateTruncOrSExt(Type tgt, const OpRef& operand);
 
   static bool classof(const Operation* op);
 };
@@ -685,9 +657,8 @@ public:
   const OpRef& true_value() const;
   const OpRef& false_value() const;
 
-  static OpRef Create(const OpRef& cond,
-                               const OpRef& true_value,
-                               const OpRef& false_value);
+  static OpRef Create(const OpRef& cond, const OpRef& true_value,
+                      const OpRef& false_value);
 
   static bool classof(const Operation* op);
 };
@@ -697,8 +668,7 @@ public:
  */
 class ICmpOp : public BinaryOp {
 private:
-  ICmpOp(ICmpOpcode cmp, Type t, const OpRef& lhs,
-         const OpRef& rhs);
+  ICmpOp(ICmpOpcode cmp, Type t, const OpRef& lhs, const OpRef& rhs);
 
 public:
   ICmpOpcode comparison() const;
@@ -717,12 +687,9 @@ public:
    */
   bool is_unsigned() const;
 
-  static OpRef CreateICmp(ICmpOpcode cmp, const OpRef& lhs,
-                                   const OpRef& rhs);
-  static OpRef CreateICmp(ICmpOpcode cmp, int64_t lhs,
-                                   const OpRef& rhs);
-  static OpRef CreateICmp(ICmpOpcode cmp, const OpRef& lhs,
-                                   int64_t rhs);
+  static OpRef CreateICmp(ICmpOpcode cmp, const OpRef& lhs, const OpRef& rhs);
+  static OpRef CreateICmp(ICmpOpcode cmp, int64_t lhs, const OpRef& rhs);
+  static OpRef CreateICmp(ICmpOpcode cmp, const OpRef& lhs, int64_t rhs);
 
   static bool classof(const Operation* op);
 };
@@ -732,8 +699,7 @@ public:
  */
 class FCmpOp : public BinaryOp {
 private:
-  FCmpOp(FCmpOpcode cmp, Type t, const OpRef& lhs,
-         const OpRef& rhs);
+  FCmpOp(FCmpOpcode cmp, Type t, const OpRef& lhs, const OpRef& rhs);
 
 public:
   FCmpOpcode comparison() const;
@@ -743,8 +709,7 @@ public:
   // Whether this comparison is an unordered one
   bool is_unordered() const;
 
-  static OpRef CreateFCmp(FCmpOpcode cmp, const OpRef& lhs,
-                                   const OpRef& rhs);
+  static OpRef CreateFCmp(FCmpOpcode cmp, const OpRef& lhs, const OpRef& rhs);
 
   static bool classof(const Operation* op);
 };
@@ -766,8 +731,7 @@ public:
   OpRef& default_value();
   const OpRef& default_value() const;
 
-  static OpRef Create(const OpRef& size,
-                               const OpRef& defaultval);
+  static OpRef Create(const OpRef& size, const OpRef& defaultval);
 
   static bool classof(const Operation* op);
 };
@@ -788,8 +752,7 @@ public:
   OpRef& offset();
   const OpRef& offset() const;
 
-  static OpRef Create(const OpRef& data,
-                               const OpRef& offset);
+  static OpRef Create(const OpRef& data, const OpRef& offset);
 
   static bool classof(const Operation* op);
 };
@@ -802,8 +765,7 @@ public:
  */
 class StoreOp : public ArrayBase {
 private:
-  StoreOp(const OpRef& data, const OpRef& offset,
-          const OpRef& value);
+  StoreOp(const OpRef& data, const OpRef& offset, const OpRef& value);
 
 public:
   OpRef size() const override;
@@ -817,9 +779,8 @@ public:
   OpRef& value();
   const OpRef& value() const;
 
-  static OpRef Create(const OpRef& data,
-                               const OpRef& offset,
-                               const OpRef& value);
+  static OpRef Create(const OpRef& data, const OpRef& offset,
+                      const OpRef& value);
 
   static bool classof(const Operation* op);
 };
@@ -857,16 +818,13 @@ public:
   llvm::iterator_range<operand_iterator> operands() override;
   llvm::iterator_range<const_operand_iterator> operands() const override;
 
-  OpRef
-  with_new_operands(llvm::ArrayRef<OpRef> operands) const override;
+  OpRef with_new_operands(llvm::ArrayRef<OpRef> operands) const override;
 
   OpRef& operand_at(size_t i) override;
   const OpRef& operand_at(size_t i) const override;
 
-  static OpRef Create(Type index_ty,
-                               const PersistentArray<OpRef>& data);
-  static OpRef Create(Type index_ty, const OpRef& value,
-                               size_t size);
+  static OpRef Create(Type index_ty, const PersistentArray<OpRef>& data);
+  static OpRef Create(Type index_ty, const OpRef& value, size_t size);
 
   static bool classof(const Operation* op);
 };

--- a/include/caffeine/IR/Operation.inl
+++ b/include/caffeine/IR/Operation.inl
@@ -152,10 +152,10 @@ inline size_t Operation::num_operands() const {
   return detail::opcode_nargs(opcode_);
 }
 
-inline ref<Operation> Operation::as_ref() {
+inline OpRef Operation::as_ref() {
   CAFFEINE_ASSERT(refcount != 0, "Unable to convert non-refcounted Operation "
                                  "instance to a refcounted one");
-  return ref<Operation>(this);
+  return OpRef(this);
 }
 inline ref<const Operation> Operation::as_ref() const {
   CAFFEINE_ASSERT(refcount != 0, "Unable to convert non-refcounted Operation "
@@ -205,17 +205,17 @@ inline const Operation& Operation::operator[](size_t idx) const {
   return *operand_at(idx);
 }
 
-inline ref<Operation>& Operation::operand_at(size_t idx) {
+inline OpRef& Operation::operand_at(size_t idx) {
   return std::get<OpVec>(inner_)[idx];
 }
-inline const ref<Operation>& Operation::operand_at(size_t idx) const {
+inline const OpRef& Operation::operand_at(size_t idx) const {
   return std::get<OpVec>(inner_)[idx];
 }
 
-inline ref<Operation> Operation::into_ref() const {
+inline OpRef Operation::into_ref() const {
   if (refcnt() == 0)
     return make_ref<Operation>(*this);
-  return ref<Operation>(const_cast<Operation*>(this));
+  return OpRef(const_cast<Operation*>(this));
 }
 
 /***************************************************
@@ -295,7 +295,7 @@ inline const llvm::APFloat& ConstantFloat::value() const {
 /***************************************************
  * ConstantArray                                   *
  ***************************************************/
-inline ref<Operation> ConstantArray::size() const {
+inline OpRef ConstantArray::size() const {
   return operand_at(0);
 }
 
@@ -303,12 +303,12 @@ inline const Symbol& ConstantArray::symbol() const {
   return std::get<ConstantData>(inner_).first;
 }
 
-inline ref<Operation>& ConstantArray::operand_at(size_t idx) {
+inline OpRef& ConstantArray::operand_at(size_t idx) {
   CAFFEINE_ASSERT(idx == 0, "Accessed out of bounds operand index");
   return std::get<ConstantData>(inner_).second;
 }
 
-inline const ref<Operation>& ConstantArray::operand_at(size_t idx) const {
+inline const OpRef& ConstantArray::operand_at(size_t idx) const {
   CAFFEINE_ASSERT(idx == 0, "Accessed out of bounds operand index");
   return std::get<ConstantData>(inner_).second;
 }
@@ -316,50 +316,50 @@ inline const ref<Operation>& ConstantArray::operand_at(size_t idx) const {
 /***************************************************
  * BinaryOp                                        *
  ***************************************************/
-inline const ref<Operation>& BinaryOp::lhs() const {
+inline const OpRef& BinaryOp::lhs() const {
   return operand_at(0);
 }
-inline const ref<Operation>& BinaryOp::rhs() const {
+inline const OpRef& BinaryOp::rhs() const {
   return operand_at(1);
 }
 
-inline ref<Operation>& BinaryOp::lhs() {
+inline OpRef& BinaryOp::lhs() {
   return operand_at(0);
 }
-inline ref<Operation>& BinaryOp::rhs() {
+inline OpRef& BinaryOp::rhs() {
   return operand_at(1);
 }
 
 /***************************************************
  * UnaryOp                                         *
  ***************************************************/
-inline ref<Operation>& UnaryOp::operand() {
+inline OpRef& UnaryOp::operand() {
   return operand_at(0);
 }
-inline const ref<Operation>& UnaryOp::operand() const {
+inline const OpRef& UnaryOp::operand() const {
   return operand_at(0);
 }
 
 /***************************************************
  * SelectOp                                        *
  ***************************************************/
-inline ref<Operation>& SelectOp::condition() {
+inline OpRef& SelectOp::condition() {
   return operand_at(0);
 }
-inline ref<Operation>& SelectOp::true_value() {
+inline OpRef& SelectOp::true_value() {
   return operand_at(1);
 }
-inline ref<Operation>& SelectOp::false_value() {
+inline OpRef& SelectOp::false_value() {
   return operand_at(2);
 }
 
-inline const ref<Operation>& SelectOp::condition() const {
+inline const OpRef& SelectOp::condition() const {
   return operand_at(0);
 }
-inline const ref<Operation>& SelectOp::true_value() const {
+inline const OpRef& SelectOp::true_value() const {
   return operand_at(1);
 }
-inline const ref<Operation>& SelectOp::false_value() const {
+inline const OpRef& SelectOp::false_value() const {
   return operand_at(2);
 }
 
@@ -396,73 +396,73 @@ inline bool FCmpOp::is_unordered() const {
 /***************************************************
  * AllocOp                                         *
  ***************************************************/
-inline ref<Operation> AllocOp::size() const {
+inline OpRef AllocOp::size() const {
   return operand_at(0);
 }
 
-inline ref<Operation>& AllocOp::default_value() {
+inline OpRef& AllocOp::default_value() {
   return operand_at(1);
 }
-inline const ref<Operation>& AllocOp::default_value() const {
+inline const OpRef& AllocOp::default_value() const {
   return operand_at(1);
 }
 
 /***************************************************
  * LoadOp                                          *
  ***************************************************/
-inline ref<Operation>& LoadOp::data() {
+inline OpRef& LoadOp::data() {
   return operand_at(0);
 }
-inline const ref<Operation>& LoadOp::data() const {
+inline const OpRef& LoadOp::data() const {
   return operand_at(0);
 }
 
-inline ref<Operation>& LoadOp::offset() {
+inline OpRef& LoadOp::offset() {
   return operand_at(1);
 }
-inline const ref<Operation>& LoadOp::offset() const {
+inline const OpRef& LoadOp::offset() const {
   return operand_at(1);
 }
 
 /***************************************************
  * StoreOp                                         *
  ***************************************************/
-inline ref<Operation> StoreOp::size() const {
+inline OpRef StoreOp::size() const {
   return llvm::cast<ArrayBase>(*data()).size();
 }
 
-inline ref<Operation>& StoreOp::data() {
+inline OpRef& StoreOp::data() {
   return operand_at(0);
 }
-inline const ref<Operation>& StoreOp::data() const {
+inline const OpRef& StoreOp::data() const {
   return operand_at(0);
 }
 
-inline ref<Operation>& StoreOp::offset() {
+inline OpRef& StoreOp::offset() {
   return operand_at(1);
 }
-inline const ref<Operation>& StoreOp::offset() const {
+inline const OpRef& StoreOp::offset() const {
   return operand_at(1);
 }
 
-inline ref<Operation>& StoreOp::value() {
+inline OpRef& StoreOp::value() {
   return operand_at(2);
 }
-inline const ref<Operation>& StoreOp::value() const {
+inline const OpRef& StoreOp::value() const {
   return operand_at(2);
 }
 
 /***************************************************
  * FixedArray                                      *
  ***************************************************/
-inline PersistentArray<ref<Operation>>& FixedArray::data() {
-  return std::get<PersistentArray<ref<Operation>>>(inner_);
+inline PersistentArray<OpRef>& FixedArray::data() {
+  return std::get<PersistentArray<OpRef>>(inner_);
 }
-inline const PersistentArray<ref<Operation>>& FixedArray::data() const {
-  return std::get<PersistentArray<ref<Operation>>>(inner_);
+inline const PersistentArray<OpRef>& FixedArray::data() const {
+  return std::get<PersistentArray<OpRef>>(inner_);
 }
 
-inline ref<Operation> FixedArray::size() const {
+inline OpRef FixedArray::size() const {
   return ConstantInt::Create(llvm::APInt(type().bitwidth(), data().size()));
 }
 
@@ -470,10 +470,10 @@ inline size_t FixedArray::num_operands() const {
   return data().size();
 }
 
-inline ref<Operation>& FixedArray::operand_at(size_t i) {
-  return std::get<PersistentArray<ref<Operation>>>(inner_).element_reference(i);
+inline OpRef& FixedArray::operand_at(size_t i) {
+  return std::get<PersistentArray<OpRef>>(inner_).element_reference(i);
 }
-inline const ref<Operation>& FixedArray::operand_at(size_t i) const {
+inline const OpRef& FixedArray::operand_at(size_t i) const {
   return data().get(i);
 }
 

--- a/include/caffeine/Interpreter/StackFrame.h
+++ b/include/caffeine/Interpreter/StackFrame.h
@@ -44,7 +44,7 @@ public:
    * Insert a new value into the current stack frame. If that value
    * is already in the current stack frame then it overwrites it.
    */
-  void insert(llvm::Value* value, const ref<Operation>& expr);
+  void insert(llvm::Value* value, const OpRef& expr);
   void insert(llvm::Value* value, const ContextValue& exprs);
 
   /**

--- a/include/caffeine/Interpreter/Value.h
+++ b/include/caffeine/Interpreter/Value.h
@@ -33,11 +33,11 @@ private:
         : data(data), size(size) {}
   };
 
-  std::variant<ref<Operation>, std::vector<ContextValue>, slice, Pointer>
+  std::variant<OpRef, std::vector<ContextValue>, slice, Pointer>
       inner_;
 
 public:
-  explicit ContextValue(const ref<Operation>& op);
+  explicit ContextValue(const OpRef& op);
   explicit ContextValue(const std::vector<ContextValue>& data);
   explicit ContextValue(std::vector<ContextValue>&& data);
   explicit ContextValue(const Pointer& ptr);
@@ -58,13 +58,13 @@ public:
 
   Kind kind() const;
 
-  const ref<Operation>& scalar() const;
+  const OpRef& scalar() const;
   llvm::ArrayRef<ContextValue> vector() const;
   const Pointer& pointer() const;
 };
 
 /**
- * Map the ref<Operation> elements of any number of ContextValues
+ * Map the OpRef elements of any number of ContextValues
  * to form a new ContextValue with the same shape.
  *
  * For this to work all ContextValues must have the same "shape"

--- a/include/caffeine/Interpreter/Value.h
+++ b/include/caffeine/Interpreter/Value.h
@@ -33,8 +33,7 @@ private:
         : data(data), size(size) {}
   };
 
-  std::variant<OpRef, std::vector<ContextValue>, slice, Pointer>
-      inner_;
+  std::variant<OpRef, std::vector<ContextValue>, slice, Pointer> inner_;
 
 public:
   explicit ContextValue(const OpRef& op);

--- a/include/caffeine/Memory/MemHeap.h
+++ b/include/caffeine/Memory/MemHeap.h
@@ -51,10 +51,10 @@ private:
   AllocationKind kind_;
 
 public:
-  Allocation(const OpRef& address, const OpRef& size,
-             const OpRef& data, AllocationKind kind);
-  Allocation(const OpRef& address, const ConstantInt& size,
-             const OpRef& data, AllocationKind kind);
+  Allocation(const OpRef& address, const OpRef& size, const OpRef& data,
+             AllocationKind kind);
+  Allocation(const OpRef& address, const ConstantInt& size, const OpRef& data,
+             AllocationKind kind);
 
   const OpRef& size() const;
   OpRef& size();
@@ -80,8 +80,7 @@ public:
    * given width would be a valid inbounds read.
    */
   Assertion check_inbounds(const OpRef& offset, uint32_t width) const;
-  Assertion check_inbounds(const OpRef& offset,
-                           const OpRef& width) const;
+  Assertion check_inbounds(const OpRef& offset, const OpRef& width) const;
 
   /**
    * Read the specified type from the allocation at the given offset.
@@ -90,7 +89,7 @@ public:
    * check the assertion first.
    */
   OpRef read(const OpRef& offset, const Type& t,
-                      const llvm::DataLayout& layout) const;
+             const llvm::DataLayout& layout) const;
   ContextValue read(const OpRef& offset, llvm::Type* type,
                     const llvm::DataLayout& layout);
 
@@ -102,9 +101,8 @@ public:
    */
   void write(const OpRef& offset, const OpRef& value,
              const llvm::DataLayout& layout);
-  void write(const OpRef& offset, llvm::Type* type,
-             const ContextValue& value, const MemHeap& heap,
-             const llvm::DataLayout& layout);
+  void write(const OpRef& offset, llvm::Type* type, const ContextValue& value,
+             const MemHeap& heap, const llvm::DataLayout& layout);
 };
 
 using AllocId = typename slot_map<Allocation>::key_type;
@@ -191,9 +189,8 @@ public:
    *
    * This will add the corresponding assertions to the context as well.
    */
-  AllocId allocate(const OpRef& size, const OpRef& alignment,
-                   const OpRef& data, AllocationKind kind,
-                   Context& ctx);
+  AllocId allocate(const OpRef& size, const OpRef& alignment, const OpRef& data,
+                   AllocationKind kind, Context& ctx);
 
   /**
    * Deallocate an existing allocation.

--- a/include/caffeine/Memory/MemHeap.h
+++ b/include/caffeine/Memory/MemHeap.h
@@ -44,44 +44,44 @@ enum class AllocationKind { Alloca, Malloc, Global };
  */
 class Allocation {
 private:
-  ref<Operation> address_;
-  ref<Operation> size_;
-  ref<Operation> data_;
+  OpRef address_;
+  OpRef size_;
+  OpRef data_;
 
   AllocationKind kind_;
 
 public:
-  Allocation(const ref<Operation>& address, const ref<Operation>& size,
-             const ref<Operation>& data, AllocationKind kind);
-  Allocation(const ref<Operation>& address, const ConstantInt& size,
-             const ref<Operation>& data, AllocationKind kind);
+  Allocation(const OpRef& address, const OpRef& size,
+             const OpRef& data, AllocationKind kind);
+  Allocation(const OpRef& address, const ConstantInt& size,
+             const OpRef& data, AllocationKind kind);
 
-  const ref<Operation>& size() const;
-  ref<Operation>& size();
+  const OpRef& size() const;
+  OpRef& size();
 
   AllocationKind kind() const;
 
-  const ref<Operation>& data() const;
-  ref<Operation>& data();
+  const OpRef& data() const;
+  OpRef& data();
 
-  const ref<Operation>& address() const;
-  ref<Operation>& address();
+  const OpRef& address() const;
+  OpRef& address();
 
   bool is_constant_size() const;
 
   /**
    * Update the internal data array of this allocation.
    */
-  void overwrite(const ref<Operation>& newdata);
-  void overwrite(ref<Operation>&& newdata);
+  void overwrite(const OpRef& newdata);
+  void overwrite(OpRef&& newdata);
 
   /**
    * Assert that a read from this allocation at the given offset and with the
    * given width would be a valid inbounds read.
    */
-  Assertion check_inbounds(const ref<Operation>& offset, uint32_t width) const;
-  Assertion check_inbounds(const ref<Operation>& offset,
-                           const ref<Operation>& width) const;
+  Assertion check_inbounds(const OpRef& offset, uint32_t width) const;
+  Assertion check_inbounds(const OpRef& offset,
+                           const OpRef& width) const;
 
   /**
    * Read the specified type from the allocation at the given offset.
@@ -89,9 +89,9 @@ public:
    * Does not assert that the read is inbounds. Callers of this method should
    * check the assertion first.
    */
-  ref<Operation> read(const ref<Operation>& offset, const Type& t,
+  OpRef read(const OpRef& offset, const Type& t,
                       const llvm::DataLayout& layout) const;
-  ContextValue read(const ref<Operation>& offset, llvm::Type* type,
+  ContextValue read(const OpRef& offset, llvm::Type* type,
                     const llvm::DataLayout& layout);
 
   /**
@@ -100,9 +100,9 @@ public:
    * Does not assert that the write is inbounds. Callers of this method should
    * add the assertion first.
    */
-  void write(const ref<Operation>& offset, const ref<Operation>& value,
+  void write(const OpRef& offset, const OpRef& value,
              const llvm::DataLayout& layout);
-  void write(const ref<Operation>& offset, llvm::Type* type,
+  void write(const OpRef& offset, llvm::Type* type,
              const ContextValue& value, const MemHeap& heap,
              const llvm::DataLayout& layout);
 };
@@ -143,14 +143,14 @@ using AllocId = typename slot_map<Allocation>::key_type;
 class Pointer {
 private:
   AllocId alloc_;
-  ref<Operation> offset_;
+  OpRef offset_;
 
 public:
-  explicit Pointer(const ref<Operation>& value);
-  Pointer(const AllocId& alloc, const ref<Operation>& offset);
+  explicit Pointer(const OpRef& value);
+  Pointer(const AllocId& alloc, const OpRef& offset);
 
   AllocId alloc() const;
-  const ref<Operation>& offset() const;
+  const OpRef& offset() const;
 
   /**
    * The absolute value of this pointer.
@@ -159,7 +159,7 @@ public:
    * offset pair. This method normalizes it to just the absolute value. Use
    * MemHeap::resolve to go the other way.
    */
-  ref<Operation> value(const MemHeap& heap) const;
+  OpRef value(const MemHeap& heap) const;
 
   /**
    * Whether this pointer has been resolved to a specific allocation.
@@ -191,8 +191,8 @@ public:
    *
    * This will add the corresponding assertions to the context as well.
    */
-  AllocId allocate(const ref<Operation>& size, const ref<Operation>& alignment,
-                   const ref<Operation>& data, AllocationKind kind,
+  AllocId allocate(const OpRef& size, const OpRef& alignment,
+                   const OpRef& data, AllocationKind kind,
                    Context& ctx);
 
   /**
@@ -218,7 +218,7 @@ public:
    * assertion that the pointer points within one of them.
    */
   Assertion check_valid(const Pointer& value, uint32_t width);
-  Assertion check_valid(const Pointer& value, const ref<Operation>& offset);
+  Assertion check_valid(const Pointer& value, const OpRef& offset);
 
   /**
    * Get an assertion that checks whether the provided pointer points to the

--- a/include/caffeine/Memory/MemHeap.inl
+++ b/include/caffeine/Memory/MemHeap.inl
@@ -11,24 +11,24 @@ namespace caffeine {
  * Allocation                                      *
  ***************************************************/
 
-inline const ref<Operation>& Allocation::size() const {
+inline const OpRef& Allocation::size() const {
   return size_;
 }
-inline ref<Operation>& Allocation::size() {
+inline OpRef& Allocation::size() {
   return size_;
 }
 
-inline const ref<Operation>& Allocation::data() const {
+inline const OpRef& Allocation::data() const {
   return data_;
 }
-inline ref<Operation>& Allocation::data() {
+inline OpRef& Allocation::data() {
   return data_;
 }
 
-inline const ref<Operation>& Allocation::address() const {
+inline const OpRef& Allocation::address() const {
   return address_;
 }
-inline ref<Operation>& Allocation::address() {
+inline OpRef& Allocation::address() {
   return address_;
 }
 
@@ -44,7 +44,7 @@ inline AllocId Pointer::alloc() const {
   return alloc_;
 }
 
-inline const ref<Operation>& Pointer::offset() const {
+inline const OpRef& Pointer::offset() const {
   return offset_;
 }
 

--- a/src/IR/Assertion.cpp
+++ b/src/IR/Assertion.cpp
@@ -7,7 +7,7 @@
 namespace caffeine {
 
 Assertion::Assertion() : Assertion(constant(true)) {}
-Assertion::Assertion(const ref<Operation>& value) : value_(value) {
+Assertion::Assertion(const OpRef& value) : value_(value) {
   CAFFEINE_ASSERT(value, "created assertion with null expression");
   CAFFEINE_ASSERT(value->type() == Type::int_ty(1));
 }

--- a/src/IR/Operation.cpp
+++ b/src/IR/Operation.cpp
@@ -49,15 +49,14 @@ Operation::Operation(Opcode op, Type t, const OpRef& op0)
                   "Tried to create a constant with operands");
   CAFFEINE_ASSERT(num_operands() == 1);
 }
-Operation::Operation(Opcode op, Type t, const OpRef& op0,
-                     const OpRef& op1)
+Operation::Operation(Opcode op, Type t, const OpRef& op0, const OpRef& op1)
     : opcode_(static_cast<uint16_t>(op)), type_(t), inner_(OpVec{op0, op1}) {
   CAFFEINE_ASSERT(detail::opcode_base(opcode_) != 1,
                   "Tried to create a constant with operands");
   CAFFEINE_ASSERT(num_operands() == 2);
 }
-Operation::Operation(Opcode op, Type t, const OpRef& op0,
-                     const OpRef& op1, const OpRef& op2)
+Operation::Operation(Opcode op, Type t, const OpRef& op0, const OpRef& op1,
+                     const OpRef& op2)
     : opcode_(static_cast<uint16_t>(op)), type_(t),
       inner_(OpVec{op0, op1, op2}) {
   CAFFEINE_ASSERT(detail::opcode_base(opcode_) != 1,
@@ -114,8 +113,7 @@ bool Operation::operator!=(const Operation& op) const {
   return !(*this == op);
 }
 
-OpRef
-Operation::with_new_operands(llvm::ArrayRef<OpRef> operands) const {
+OpRef Operation::with_new_operands(llvm::ArrayRef<OpRef> operands) const {
   CAFFEINE_ASSERT(operands.size() == num_operands());
 
   if (num_operands() == 0)
@@ -128,8 +126,7 @@ Operation::with_new_operands(llvm::ArrayRef<OpRef> operands) const {
   if (equal)
     return into_ref();
 
-  auto value =
-      OpRef(new Operation((Opcode)opcode(), type(), operands.data()));
+  auto value = OpRef(new Operation((Opcode)opcode(), type(), operands.data()));
   value->copy_vtable(*this);
   return value;
 }
@@ -308,12 +305,10 @@ ConstantArray::ConstantArray(Symbol&& symbol, const OpRef& size)
                 Type::array_ty(size->type().bitwidth()),
                 ConstantData(std::move(symbol), size)) {}
 
-OpRef ConstantArray::Create(const Symbol& symbol,
-                                     const OpRef& size) {
+OpRef ConstantArray::Create(const Symbol& symbol, const OpRef& size) {
   return Create(Symbol(symbol), size);
 }
-OpRef ConstantArray::Create(Symbol&& symbol,
-                                     const OpRef& size) {
+OpRef ConstantArray::Create(Symbol&& symbol, const OpRef& size) {
   CAFFEINE_ASSERT(size->type().is_int());
 
   return OpRef(new ConstantArray(std::move(symbol), size));
@@ -329,8 +324,7 @@ ConstantArray::operands() const {
   return llvm::iterator_range<const_operand_iterator>(&operand, &operand + 1);
 }
 
-OpRef ConstantArray::with_new_operands(
-    llvm::ArrayRef<OpRef> operands) const {
+OpRef ConstantArray::with_new_operands(llvm::ArrayRef<OpRef> operands) const {
   CAFFEINE_ASSERT(operands.size() == 1);
 
   if (size() == operands[0])
@@ -342,12 +336,10 @@ OpRef ConstantArray::with_new_operands(
 /***************************************************
  * BinaryOp                                        *
  ***************************************************/
-BinaryOp::BinaryOp(Opcode op, Type t, const OpRef& lhs,
-                   const OpRef& rhs)
+BinaryOp::BinaryOp(Opcode op, Type t, const OpRef& lhs, const OpRef& rhs)
     : Operation(op, t, lhs, rhs) {}
 
-OpRef BinaryOp::Create(Opcode op, const OpRef& lhs,
-                                const OpRef& rhs) {
+OpRef BinaryOp::Create(Opcode op, const OpRef& lhs, const OpRef& rhs) {
   CAFFEINE_ASSERT((op & 0x3) == 2, "Opcode doesn't have 2 operands");
   CAFFEINE_ASSERT(lhs, "lhs was null");
   CAFFEINE_ASSERT(rhs, "rhs was null");
@@ -366,8 +358,7 @@ OpRef BinaryOp::Create(Opcode op, const OpRef& lhs,
 
 // There's a lot of these so template them out using a macro
 #define DECL_BINOP_CREATE(opcode, assert)                                      \
-  OpRef BinaryOp::Create##opcode(const OpRef& lhs,           \
-                                          const OpRef& rhs) {         \
+  OpRef BinaryOp::Create##opcode(const OpRef& lhs, const OpRef& rhs) {         \
     CAFFEINE_ASSERT(lhs, "lhs was null");                                      \
     CAFFEINE_ASSERT(rhs, "rhs was null");                                      \
     assert(lhs);                                                               \
@@ -377,8 +368,7 @@ OpRef BinaryOp::Create(Opcode op, const OpRef& lhs,
   }                                                                            \
   static_assert(true)
 
-OpRef BinaryOp::CreateAdd(const OpRef& lhs,
-                                   const OpRef& rhs) {
+OpRef BinaryOp::CreateAdd(const OpRef& lhs, const OpRef& rhs) {
   CAFFEINE_ASSERT(lhs, "lhs was null");
   CAFFEINE_ASSERT(rhs, "rhs was null");
   ASSERT_INT(lhs);
@@ -399,8 +389,7 @@ OpRef BinaryOp::CreateAdd(const OpRef& lhs,
 
   return Create(Opcode::Add, lhs, rhs);
 }
-OpRef BinaryOp::CreateSub(const OpRef& lhs,
-                                   const OpRef& rhs) {
+OpRef BinaryOp::CreateSub(const OpRef& lhs, const OpRef& rhs) {
   CAFFEINE_ASSERT(lhs, "lhs was null");
   CAFFEINE_ASSERT(rhs, "rhs was null");
   ASSERT_INT(lhs);
@@ -425,8 +414,7 @@ OpRef BinaryOp::CreateSub(const OpRef& lhs,
 
   return Create(Opcode::Sub, lhs, rhs);
 }
-OpRef BinaryOp::CreateMul(const OpRef& lhs,
-                                   const OpRef& rhs) {
+OpRef BinaryOp::CreateMul(const OpRef& lhs, const OpRef& rhs) {
   CAFFEINE_ASSERT(lhs, "lhs was null");
   CAFFEINE_ASSERT(rhs, "rhs was null");
   ASSERT_INT(lhs);
@@ -446,8 +434,7 @@ OpRef BinaryOp::CreateMul(const OpRef& lhs,
 
   return Create(Opcode::Mul, lhs, rhs);
 }
-OpRef BinaryOp::CreateUDiv(const OpRef& lhs,
-                                    const OpRef& rhs) {
+OpRef BinaryOp::CreateUDiv(const OpRef& lhs, const OpRef& rhs) {
   CAFFEINE_ASSERT(lhs, "lhs was null");
   CAFFEINE_ASSERT(rhs, "rhs was null");
   ASSERT_INT(lhs);
@@ -465,8 +452,7 @@ OpRef BinaryOp::CreateUDiv(const OpRef& lhs,
 
   return Create(Opcode::UDiv, lhs, rhs);
 }
-OpRef BinaryOp::CreateSDiv(const OpRef& lhs,
-                                    const OpRef& rhs) {
+OpRef BinaryOp::CreateSDiv(const OpRef& lhs, const OpRef& rhs) {
   CAFFEINE_ASSERT(lhs, "lhs was null");
   CAFFEINE_ASSERT(rhs, "rhs was null");
   ASSERT_INT(lhs);
@@ -486,8 +472,7 @@ OpRef BinaryOp::CreateSDiv(const OpRef& lhs,
 
   return Create(Opcode::SDiv, lhs, rhs);
 }
-OpRef BinaryOp::CreateURem(const OpRef& lhs,
-                                    const OpRef& rhs) {
+OpRef BinaryOp::CreateURem(const OpRef& lhs, const OpRef& rhs) {
   CAFFEINE_ASSERT(lhs, "lhs was null");
   CAFFEINE_ASSERT(rhs, "rhs was null");
   ASSERT_INT(lhs);
@@ -507,8 +492,7 @@ OpRef BinaryOp::CreateURem(const OpRef& lhs,
 
   return Create(Opcode::URem, lhs, rhs);
 }
-OpRef BinaryOp::CreateSRem(const OpRef& lhs,
-                                    const OpRef& rhs) {
+OpRef BinaryOp::CreateSRem(const OpRef& lhs, const OpRef& rhs) {
   CAFFEINE_ASSERT(lhs, "lhs was null");
   CAFFEINE_ASSERT(rhs, "rhs was null");
   ASSERT_INT(lhs);
@@ -529,8 +513,7 @@ OpRef BinaryOp::CreateSRem(const OpRef& lhs,
   return Create(Opcode::SRem, lhs, rhs);
 }
 
-OpRef BinaryOp::CreateAnd(const OpRef& lhs,
-                                   const OpRef& rhs) {
+OpRef BinaryOp::CreateAnd(const OpRef& lhs, const OpRef& rhs) {
   CAFFEINE_ASSERT(lhs, "lhs was null");
   CAFFEINE_ASSERT(rhs, "rhs was null");
   ASSERT_INT(lhs);
@@ -555,8 +538,7 @@ OpRef BinaryOp::CreateAnd(const OpRef& lhs,
 
   return Create(Opcode::And, lhs, rhs);
 }
-OpRef BinaryOp::CreateOr(const OpRef& lhs,
-                                  const OpRef& rhs) {
+OpRef BinaryOp::CreateOr(const OpRef& lhs, const OpRef& rhs) {
   CAFFEINE_ASSERT(lhs, "lhs was null");
   CAFFEINE_ASSERT(rhs, "rhs was null");
   ASSERT_INT(lhs);
@@ -581,8 +563,7 @@ OpRef BinaryOp::CreateOr(const OpRef& lhs,
 
   return Create(Opcode::Or, lhs, rhs);
 }
-OpRef BinaryOp::CreateXor(const OpRef& lhs,
-                                   const OpRef& rhs) {
+OpRef BinaryOp::CreateXor(const OpRef& lhs, const OpRef& rhs) {
   CAFFEINE_ASSERT(lhs, "lhs was null");
   CAFFEINE_ASSERT(rhs, "rhs was null");
   ASSERT_INT(lhs);
@@ -605,8 +586,7 @@ OpRef BinaryOp::CreateXor(const OpRef& lhs,
 
   return Create(Opcode::Xor, lhs, rhs);
 }
-OpRef BinaryOp::CreateShl(const OpRef& lhs,
-                                   const OpRef& rhs) {
+OpRef BinaryOp::CreateShl(const OpRef& lhs, const OpRef& rhs) {
   CAFFEINE_ASSERT(lhs, "lhs was null");
   CAFFEINE_ASSERT(rhs, "rhs was null");
   ASSERT_INT(lhs);
@@ -624,8 +604,7 @@ OpRef BinaryOp::CreateShl(const OpRef& lhs,
 
   return Create(Opcode::Shl, lhs, rhs);
 }
-OpRef BinaryOp::CreateLShr(const OpRef& lhs,
-                                    const OpRef& rhs) {
+OpRef BinaryOp::CreateLShr(const OpRef& lhs, const OpRef& rhs) {
   CAFFEINE_ASSERT(lhs, "lhs was null");
   CAFFEINE_ASSERT(rhs, "rhs was null");
   ASSERT_INT(lhs);
@@ -643,8 +622,7 @@ OpRef BinaryOp::CreateLShr(const OpRef& lhs,
 
   return Create(Opcode::LShr, lhs, rhs);
 }
-OpRef BinaryOp::CreateAShr(const OpRef& lhs,
-                                    const OpRef& rhs) {
+OpRef BinaryOp::CreateAShr(const OpRef& lhs, const OpRef& rhs) {
   CAFFEINE_ASSERT(lhs, "lhs was null");
   CAFFEINE_ASSERT(rhs, "rhs was null");
   ASSERT_INT(lhs);
@@ -663,8 +641,7 @@ OpRef BinaryOp::CreateAShr(const OpRef& lhs,
   return Create(Opcode::AShr, lhs, rhs);
 }
 
-OpRef BinaryOp::CreateFAdd(const OpRef& lhs,
-                                    const OpRef& rhs) {
+OpRef BinaryOp::CreateFAdd(const OpRef& lhs, const OpRef& rhs) {
   CAFFEINE_ASSERT(lhs, "lhs was null");
   CAFFEINE_ASSERT(rhs, "rhs was null");
   ASSERT_FP(lhs);
@@ -683,8 +660,7 @@ OpRef BinaryOp::CreateFAdd(const OpRef& lhs,
   return Create(Opcode::FAdd, lhs, rhs);
 }
 
-OpRef BinaryOp::CreateFSub(const OpRef& lhs,
-                                    const OpRef& rhs) {
+OpRef BinaryOp::CreateFSub(const OpRef& lhs, const OpRef& rhs) {
   CAFFEINE_ASSERT(lhs, "lhs was null");
   CAFFEINE_ASSERT(rhs, "rhs was null");
   ASSERT_FP(lhs);
@@ -703,8 +679,7 @@ OpRef BinaryOp::CreateFSub(const OpRef& lhs,
   return Create(Opcode::FSub, lhs, rhs);
 }
 
-OpRef BinaryOp::CreateFMul(const OpRef& lhs,
-                                    const OpRef& rhs) {
+OpRef BinaryOp::CreateFMul(const OpRef& lhs, const OpRef& rhs) {
   CAFFEINE_ASSERT(lhs, "lhs was null");
   CAFFEINE_ASSERT(rhs, "rhs was null");
   ASSERT_FP(lhs);
@@ -723,8 +698,7 @@ OpRef BinaryOp::CreateFMul(const OpRef& lhs,
   return Create(Opcode::FMul, lhs, rhs);
 }
 
-OpRef BinaryOp::CreateFDiv(const OpRef& lhs,
-                                    const OpRef& rhs) {
+OpRef BinaryOp::CreateFDiv(const OpRef& lhs, const OpRef& rhs) {
   CAFFEINE_ASSERT(lhs, "lhs was null");
   CAFFEINE_ASSERT(rhs, "rhs was null");
   ASSERT_FP(lhs);
@@ -743,8 +717,7 @@ OpRef BinaryOp::CreateFDiv(const OpRef& lhs,
   return Create(Opcode::FDiv, lhs, rhs);
 }
 
-OpRef BinaryOp::CreateFRem(const OpRef& lhs,
-                                    const OpRef& rhs) {
+OpRef BinaryOp::CreateFRem(const OpRef& lhs, const OpRef& rhs) {
   CAFFEINE_ASSERT(lhs, "lhs was null");
   CAFFEINE_ASSERT(rhs, "rhs was null");
   ASSERT_FP(lhs);
@@ -764,7 +737,7 @@ OpRef BinaryOp::CreateFRem(const OpRef& lhs,
 }
 
 #define DEF_INT_BINOP_CONST_CREATE_DETAIL(opcode, ty, signed)                  \
-  OpRef BinaryOp::Create##opcode(const OpRef& lhs, ty rhs) { \
+  OpRef BinaryOp::Create##opcode(const OpRef& lhs, ty rhs) {                   \
     CAFFEINE_ASSERT(lhs, "lhs is null");                                       \
     CAFFEINE_ASSERT(lhs->type().is_int());                                     \
                                                                                \
@@ -772,7 +745,7 @@ OpRef BinaryOp::CreateFRem(const OpRef& lhs,
         lhs, ConstantInt::Create(                                              \
                  llvm::APInt(lhs->type().bitwidth(), rhs, signed)));           \
   }                                                                            \
-  OpRef BinaryOp::Create##opcode(ty lhs, const OpRef& rhs) { \
+  OpRef BinaryOp::Create##opcode(ty lhs, const OpRef& rhs) {                   \
     CAFFEINE_ASSERT(rhs, "rhs is null");                                       \
     CAFFEINE_ASSERT(rhs->type().is_int());                                     \
                                                                                \
@@ -818,8 +791,7 @@ OpRef UnaryOp::Create(Opcode op, const OpRef& operand) {
   return Create(op, operand, operand->type());
 }
 
-OpRef UnaryOp::Create(Opcode op, const OpRef& operand,
-                               Type returnType) {
+OpRef UnaryOp::Create(Opcode op, const OpRef& operand, Type returnType) {
   CAFFEINE_ASSERT(operand, "operand was null");
   CAFFEINE_ASSERT((op & 0x3) == 1, "Opcode doesn't have 2 operands");
 
@@ -827,7 +799,7 @@ OpRef UnaryOp::Create(Opcode op, const OpRef& operand,
 }
 
 #define DECL_UNOP_CREATE(opcode, assert, return_type)                          \
-  OpRef UnaryOp::Create##opcode(const OpRef& operand) {      \
+  OpRef UnaryOp::Create##opcode(const OpRef& operand) {                        \
     assert(operand);                                                           \
                                                                                \
     return Create(Opcode::opcode, operand, return_type);                       \
@@ -936,8 +908,7 @@ OpRef UnaryOp::CreateBitcast(Type tgt, const OpRef& operand) {
   return OpRef(new UnaryOp(Opcode::Bitcast, tgt, operand));
 }
 
-OpRef UnaryOp::CreateTruncOrZExt(Type tgt,
-                                          const OpRef& operand) {
+OpRef UnaryOp::CreateTruncOrZExt(Type tgt, const OpRef& operand) {
   CAFFEINE_ASSERT(operand->type().is_int());
   CAFFEINE_ASSERT(tgt.is_int());
 
@@ -947,8 +918,7 @@ OpRef UnaryOp::CreateTruncOrZExt(Type tgt,
     return CreateZExt(tgt, operand);
   return operand;
 }
-OpRef UnaryOp::CreateTruncOrSExt(Type tgt,
-                                          const OpRef& operand) {
+OpRef UnaryOp::CreateTruncOrSExt(Type tgt, const OpRef& operand) {
   CAFFEINE_ASSERT(operand->type().is_int());
   CAFFEINE_ASSERT(tgt.is_int());
 
@@ -962,14 +932,12 @@ OpRef UnaryOp::CreateTruncOrSExt(Type tgt,
 /***************************************************
  * SelectOp                                        *
  ***************************************************/
-SelectOp::SelectOp(Type t, const OpRef& cond,
-                   const OpRef& true_val,
+SelectOp::SelectOp(Type t, const OpRef& cond, const OpRef& true_val,
                    const OpRef& false_val)
     : Operation(Opcode::Select, t, cond, true_val, false_val) {}
 
-OpRef SelectOp::Create(const OpRef& cond,
-                                const OpRef& true_value,
-                                const OpRef& false_value) {
+OpRef SelectOp::Create(const OpRef& cond, const OpRef& true_value,
+                       const OpRef& false_value) {
   CAFFEINE_ASSERT(cond, "cond was null");
   CAFFEINE_ASSERT(true_value, "true_value was null");
   CAFFEINE_ASSERT(false_value, "false_value was null");
@@ -986,21 +954,18 @@ OpRef SelectOp::Create(const OpRef& cond,
     return vcond->value() == 1 ? true_value : false_value;
 #endif
 
-  return OpRef(
-      new SelectOp(true_value->type(), cond, true_value, false_value));
+  return OpRef(new SelectOp(true_value->type(), cond, true_value, false_value));
 }
 
 /***************************************************
  * ICmpOp                                          *
  ***************************************************/
-ICmpOp::ICmpOp(ICmpOpcode cmp, Type t, const OpRef& lhs,
-               const OpRef& rhs)
+ICmpOp::ICmpOp(ICmpOpcode cmp, Type t, const OpRef& lhs, const OpRef& rhs)
     : BinaryOp(static_cast<Opcode>(
                    detail::opcode(icmp_base, 2, static_cast<uint16_t>(cmp))),
                t, lhs, rhs) {}
 
-OpRef ICmpOp::CreateICmp(ICmpOpcode cmp, const OpRef& lhs,
-                                  const OpRef& rhs) {
+OpRef ICmpOp::CreateICmp(ICmpOpcode cmp, const OpRef& lhs, const OpRef& rhs) {
   CAFFEINE_ASSERT(rhs, "rhs was null");
   CAFFEINE_ASSERT(lhs, "lhs was null");
   CAFFEINE_ASSERT(
@@ -1040,8 +1005,7 @@ OpRef ICmpOp::CreateICmp(ICmpOpcode cmp, const OpRef& lhs,
 
   return OpRef(new ICmpOp(cmp, Type::int_ty(1), lhs, rhs));
 }
-OpRef ICmpOp::CreateICmp(ICmpOpcode cmp, int64_t lhs,
-                                  const OpRef& rhs) {
+OpRef ICmpOp::CreateICmp(ICmpOpcode cmp, int64_t lhs, const OpRef& rhs) {
   CAFFEINE_ASSERT(rhs, "rhs was null");
   CAFFEINE_ASSERT(rhs->type().is_int(),
                   "icmp can only be created with integer operands");
@@ -1051,8 +1015,7 @@ OpRef ICmpOp::CreateICmp(ICmpOpcode cmp, int64_t lhs,
       cmp, ConstantInt::Create(literal.sextOrTrunc(rhs->type().bitwidth())),
       rhs);
 }
-OpRef ICmpOp::CreateICmp(ICmpOpcode cmp, const OpRef& lhs,
-                                  int64_t rhs) {
+OpRef ICmpOp::CreateICmp(ICmpOpcode cmp, const OpRef& lhs, int64_t rhs) {
   CAFFEINE_ASSERT(lhs, "rhs was null");
   CAFFEINE_ASSERT(lhs->type().is_int(),
                   "icmp can only be created with integer operands");
@@ -1066,14 +1029,12 @@ OpRef ICmpOp::CreateICmp(ICmpOpcode cmp, const OpRef& lhs,
 /***************************************************
  * FCmpOp                                          *
  ***************************************************/
-FCmpOp::FCmpOp(FCmpOpcode cmp, Type t, const OpRef& lhs,
-               const OpRef& rhs)
+FCmpOp::FCmpOp(FCmpOpcode cmp, Type t, const OpRef& lhs, const OpRef& rhs)
     : BinaryOp(static_cast<Opcode>(
                    detail::opcode(fcmp_base, 2, static_cast<uint16_t>(cmp))),
                t, lhs, rhs) {}
 
-OpRef FCmpOp::CreateFCmp(FCmpOpcode cmp, const OpRef& lhs,
-                                  const OpRef& rhs) {
+OpRef FCmpOp::CreateFCmp(FCmpOpcode cmp, const OpRef& lhs, const OpRef& rhs) {
   CAFFEINE_ASSERT(rhs, "rhs was null");
   CAFFEINE_ASSERT(lhs, "lhs was null");
   CAFFEINE_ASSERT(rhs->type() == lhs->type(),
@@ -1116,8 +1077,7 @@ AllocOp::AllocOp(const OpRef& size, const OpRef& defaultval)
     : ArrayBase(Opcode::Alloc, Type::array_ty(size->type().bitwidth()), size,
                 defaultval) {}
 
-OpRef AllocOp::Create(const OpRef& size,
-                               const OpRef& defaultval) {
+OpRef AllocOp::Create(const OpRef& size, const OpRef& defaultval) {
   CAFFEINE_ASSERT(size, "size was null");
   CAFFEINE_ASSERT(defaultval, "defaultval was null");
   // To be fully correct, this should be validating that the bitwidth of size
@@ -1145,8 +1105,7 @@ OpRef AllocOp::Create(const OpRef& size,
 LoadOp::LoadOp(const OpRef& data, const OpRef& offset)
     : Operation(Opcode::Load, Type::int_ty(8), data, offset) {}
 
-OpRef LoadOp::Create(const OpRef& data,
-                              const OpRef& offset) {
+OpRef LoadOp::Create(const OpRef& data, const OpRef& offset) {
   CAFFEINE_ASSERT(data, "data was null");
   CAFFEINE_ASSERT(offset, "offset was null");
   CAFFEINE_ASSERT(offset->type().is_int(),
@@ -1167,13 +1126,11 @@ OpRef LoadOp::Create(const OpRef& data,
 /***************************************************
  * StoreOp                                         *
  ***************************************************/
-StoreOp::StoreOp(const OpRef& data, const OpRef& offset,
-                 const OpRef& value)
+StoreOp::StoreOp(const OpRef& data, const OpRef& offset, const OpRef& value)
     : ArrayBase(Opcode::Store, data->type(), data, offset, value) {}
 
-OpRef StoreOp::Create(const OpRef& data,
-                               const OpRef& offset,
-                               const OpRef& value) {
+OpRef StoreOp::Create(const OpRef& data, const OpRef& offset,
+                      const OpRef& value) {
   CAFFEINE_ASSERT(data, "data was null");
   CAFFEINE_ASSERT(offset, "offset was null");
   CAFFEINE_ASSERT(value, "value was null");
@@ -1229,8 +1186,7 @@ FixedArray::operands() const {
       array.data(), array.data() + array.size());
 }
 
-OpRef
-FixedArray::with_new_operands(llvm::ArrayRef<OpRef> operands) const {
+OpRef FixedArray::with_new_operands(llvm::ArrayRef<OpRef> operands) const {
   CAFFEINE_ASSERT(operands.size() == num_operands());
 
   if (num_operands() == 0)
@@ -1252,21 +1208,17 @@ FixedArray::with_new_operands(llvm::ArrayRef<OpRef> operands) const {
   return OpRef(new FixedArray(type(), array));
 }
 
-OpRef FixedArray::Create(Type index_ty,
-                                  const PersistentArray<OpRef>& data) {
+OpRef FixedArray::Create(Type index_ty, const PersistentArray<OpRef>& data) {
   CAFFEINE_ASSERT(index_ty.is_int());
   CAFFEINE_ASSERT(
       index_ty.bitwidth() >= ilog2(data.size()),
       "Index bitwidth is not large enough to address entire constant array");
 
-  return OpRef(
-      new FixedArray(Type::array_ty(index_ty.bitwidth()), data));
+  return OpRef(new FixedArray(Type::array_ty(index_ty.bitwidth()), data));
 }
-OpRef FixedArray::Create(Type index_ty, const OpRef& value,
-                                  size_t size) {
-  return FixedArray::Create(index_ty,
-                            PersistentArray<OpRef>(
-                                std::vector<OpRef>(size, value)));
+OpRef FixedArray::Create(Type index_ty, const OpRef& value, size_t size) {
+  return FixedArray::Create(
+      index_ty, PersistentArray<OpRef>(std::vector<OpRef>(size, value)));
 }
 
 /***************************************************

--- a/src/IR/Operation.cpp
+++ b/src/IR/Operation.cpp
@@ -31,7 +31,7 @@ Operation::Operation(Opcode op, Type t, Inner&& inner)
 Operation::Operation(Opcode op, Type t)
     : opcode_(static_cast<uint16_t>(op)), type_(t), inner_(std::monostate()) {}
 
-Operation::Operation(Opcode op, Type t, const ref<Operation>* operands)
+Operation::Operation(Opcode op, Type t, const OpRef* operands)
     : opcode_(static_cast<uint16_t>(op)), type_(t),
       inner_(OpVec(operands, operands + detail::opcode_nargs(opcode_))) {
   CAFFEINE_ASSERT(detail::opcode_base(opcode_) != 1,
@@ -43,21 +43,21 @@ Operation::Operation(Opcode op, Type t, const ref<Operation>* operands)
   CAFFEINE_ASSERT(num_operands() <= 3, "Invalid opcode");
 }
 
-Operation::Operation(Opcode op, Type t, const ref<Operation>& op0)
+Operation::Operation(Opcode op, Type t, const OpRef& op0)
     : opcode_(static_cast<uint16_t>(op)), type_(t), inner_(OpVec{op0}) {
   CAFFEINE_ASSERT(detail::opcode_base(opcode_) != 1,
                   "Tried to create a constant with operands");
   CAFFEINE_ASSERT(num_operands() == 1);
 }
-Operation::Operation(Opcode op, Type t, const ref<Operation>& op0,
-                     const ref<Operation>& op1)
+Operation::Operation(Opcode op, Type t, const OpRef& op0,
+                     const OpRef& op1)
     : opcode_(static_cast<uint16_t>(op)), type_(t), inner_(OpVec{op0, op1}) {
   CAFFEINE_ASSERT(detail::opcode_base(opcode_) != 1,
                   "Tried to create a constant with operands");
   CAFFEINE_ASSERT(num_operands() == 2);
 }
-Operation::Operation(Opcode op, Type t, const ref<Operation>& op0,
-                     const ref<Operation>& op1, const ref<Operation>& op2)
+Operation::Operation(Opcode op, Type t, const OpRef& op0,
+                     const OpRef& op1, const OpRef& op2)
     : opcode_(static_cast<uint16_t>(op)), type_(t),
       inner_(OpVec{op0, op1, op2}) {
   CAFFEINE_ASSERT(detail::opcode_base(opcode_) != 1,
@@ -114,8 +114,8 @@ bool Operation::operator!=(const Operation& op) const {
   return !(*this == op);
 }
 
-ref<Operation>
-Operation::with_new_operands(llvm::ArrayRef<ref<Operation>> operands) const {
+OpRef
+Operation::with_new_operands(llvm::ArrayRef<OpRef> operands) const {
   CAFFEINE_ASSERT(operands.size() == num_operands());
 
   if (num_operands() == 0)
@@ -129,7 +129,7 @@ Operation::with_new_operands(llvm::ArrayRef<ref<Operation>> operands) const {
     return into_ref();
 
   auto value =
-      ref<Operation>(new Operation((Opcode)opcode(), type(), operands.data()));
+      OpRef(new Operation((Opcode)opcode(), type(), operands.data()));
   value->copy_vtable(*this);
   return value;
 }
@@ -249,11 +249,11 @@ Constant::Constant(Type t, Symbol&& symbol)
     : Operation(op_for_symbol(symbol), t,
                 ConstantData(std::move(symbol), nullptr)) {}
 
-ref<Operation> Constant::Create(Type t, const Symbol& symbol) {
-  return ref<Operation>(new Constant(t, symbol));
+OpRef Constant::Create(Type t, const Symbol& symbol) {
+  return OpRef(new Constant(t, symbol));
 }
-ref<Operation> Constant::Create(Type t, Symbol&& symbol) {
-  return ref<Operation>(new Constant(t, std::move(symbol)));
+OpRef Constant::Create(Type t, Symbol&& symbol) {
+  return OpRef(new Constant(t, std::move(symbol)));
 }
 
 Operation::Opcode Constant::op_for_symbol(const Symbol& symbol) {
@@ -271,13 +271,13 @@ ConstantInt::ConstantInt(llvm::APInt&& iconst)
     : Operation(Opcode::ConstantInt, Type::type_of(iconst), std::move(iconst)) {
 }
 
-ref<Operation> ConstantInt::Create(const llvm::APInt& iconst) {
-  return ref<Operation>(new ConstantInt(iconst));
+OpRef ConstantInt::Create(const llvm::APInt& iconst) {
+  return OpRef(new ConstantInt(iconst));
 }
-ref<Operation> ConstantInt::Create(llvm::APInt&& iconst) {
-  return ref<Operation>(new ConstantInt(iconst));
+OpRef ConstantInt::Create(llvm::APInt&& iconst) {
+  return OpRef(new ConstantInt(iconst));
 }
-ref<Operation> ConstantInt::Create(bool value) {
+OpRef ConstantInt::Create(bool value) {
   return ConstantInt::Create(llvm::APInt(1, static_cast<uint64_t>(value)));
 }
 
@@ -290,33 +290,33 @@ ConstantFloat::ConstantFloat(llvm::APFloat&& fconst)
     : Operation(Operation::ConstantFloat, Type::type_of(fconst),
                 std::move(fconst)) {}
 
-ref<Operation> ConstantFloat::Create(const llvm::APFloat& fconst) {
-  return ref<Operation>(new ConstantFloat(fconst));
+OpRef ConstantFloat::Create(const llvm::APFloat& fconst) {
+  return OpRef(new ConstantFloat(fconst));
 }
-ref<Operation> ConstantFloat::Create(llvm::APFloat&& fconst) {
-  return ref<Operation>(new ConstantFloat(fconst));
+OpRef ConstantFloat::Create(llvm::APFloat&& fconst) {
+  return OpRef(new ConstantFloat(fconst));
 }
-ref<Operation> ConstantFloat::Create(double value) {
-  return ref<Operation>(new ConstantFloat(llvm::APFloat(value)));
+OpRef ConstantFloat::Create(double value) {
+  return OpRef(new ConstantFloat(llvm::APFloat(value)));
 }
 
 /***************************************************
  * ConstantArray                                   *
  ***************************************************/
-ConstantArray::ConstantArray(Symbol&& symbol, const ref<Operation>& size)
+ConstantArray::ConstantArray(Symbol&& symbol, const OpRef& size)
     : ArrayBase(Operation::ConstantArray,
                 Type::array_ty(size->type().bitwidth()),
                 ConstantData(std::move(symbol), size)) {}
 
-ref<Operation> ConstantArray::Create(const Symbol& symbol,
-                                     const ref<Operation>& size) {
+OpRef ConstantArray::Create(const Symbol& symbol,
+                                     const OpRef& size) {
   return Create(Symbol(symbol), size);
 }
-ref<Operation> ConstantArray::Create(Symbol&& symbol,
-                                     const ref<Operation>& size) {
+OpRef ConstantArray::Create(Symbol&& symbol,
+                                     const OpRef& size) {
   CAFFEINE_ASSERT(size->type().is_int());
 
-  return ref<Operation>(new ConstantArray(std::move(symbol), size));
+  return OpRef(new ConstantArray(std::move(symbol), size));
 }
 
 llvm::iterator_range<Operation::operand_iterator> ConstantArray::operands() {
@@ -329,8 +329,8 @@ ConstantArray::operands() const {
   return llvm::iterator_range<const_operand_iterator>(&operand, &operand + 1);
 }
 
-ref<Operation> ConstantArray::with_new_operands(
-    llvm::ArrayRef<ref<Operation>> operands) const {
+OpRef ConstantArray::with_new_operands(
+    llvm::ArrayRef<OpRef> operands) const {
   CAFFEINE_ASSERT(operands.size() == 1);
 
   if (size() == operands[0])
@@ -342,12 +342,12 @@ ref<Operation> ConstantArray::with_new_operands(
 /***************************************************
  * BinaryOp                                        *
  ***************************************************/
-BinaryOp::BinaryOp(Opcode op, Type t, const ref<Operation>& lhs,
-                   const ref<Operation>& rhs)
+BinaryOp::BinaryOp(Opcode op, Type t, const OpRef& lhs,
+                   const OpRef& rhs)
     : Operation(op, t, lhs, rhs) {}
 
-ref<Operation> BinaryOp::Create(Opcode op, const ref<Operation>& lhs,
-                                const ref<Operation>& rhs) {
+OpRef BinaryOp::Create(Opcode op, const OpRef& lhs,
+                                const OpRef& rhs) {
   CAFFEINE_ASSERT((op & 0x3) == 2, "Opcode doesn't have 2 operands");
   CAFFEINE_ASSERT(lhs, "lhs was null");
   CAFFEINE_ASSERT(rhs, "rhs was null");
@@ -358,7 +358,7 @@ ref<Operation> BinaryOp::Create(Opcode op, const ref<Operation>& lhs,
               "BinaryOp created from operands with different types: {} != {}"),
           lhs->type(), rhs->type()));
 
-  return ref<Operation>(new BinaryOp(op, lhs->type(), lhs, rhs));
+  return OpRef(new BinaryOp(op, lhs->type(), lhs, rhs));
 }
 
 #define ASSERT_INT(op) CAFFEINE_ASSERT((op)->type().is_int())
@@ -366,8 +366,8 @@ ref<Operation> BinaryOp::Create(Opcode op, const ref<Operation>& lhs,
 
 // There's a lot of these so template them out using a macro
 #define DECL_BINOP_CREATE(opcode, assert)                                      \
-  ref<Operation> BinaryOp::Create##opcode(const ref<Operation>& lhs,           \
-                                          const ref<Operation>& rhs) {         \
+  OpRef BinaryOp::Create##opcode(const OpRef& lhs,           \
+                                          const OpRef& rhs) {         \
     CAFFEINE_ASSERT(lhs, "lhs was null");                                      \
     CAFFEINE_ASSERT(rhs, "rhs was null");                                      \
     assert(lhs);                                                               \
@@ -377,8 +377,8 @@ ref<Operation> BinaryOp::Create(Opcode op, const ref<Operation>& lhs,
   }                                                                            \
   static_assert(true)
 
-ref<Operation> BinaryOp::CreateAdd(const ref<Operation>& lhs,
-                                   const ref<Operation>& rhs) {
+OpRef BinaryOp::CreateAdd(const OpRef& lhs,
+                                   const OpRef& rhs) {
   CAFFEINE_ASSERT(lhs, "lhs was null");
   CAFFEINE_ASSERT(rhs, "rhs was null");
   ASSERT_INT(lhs);
@@ -399,8 +399,8 @@ ref<Operation> BinaryOp::CreateAdd(const ref<Operation>& lhs,
 
   return Create(Opcode::Add, lhs, rhs);
 }
-ref<Operation> BinaryOp::CreateSub(const ref<Operation>& lhs,
-                                   const ref<Operation>& rhs) {
+OpRef BinaryOp::CreateSub(const OpRef& lhs,
+                                   const OpRef& rhs) {
   CAFFEINE_ASSERT(lhs, "lhs was null");
   CAFFEINE_ASSERT(rhs, "rhs was null");
   ASSERT_INT(lhs);
@@ -425,8 +425,8 @@ ref<Operation> BinaryOp::CreateSub(const ref<Operation>& lhs,
 
   return Create(Opcode::Sub, lhs, rhs);
 }
-ref<Operation> BinaryOp::CreateMul(const ref<Operation>& lhs,
-                                   const ref<Operation>& rhs) {
+OpRef BinaryOp::CreateMul(const OpRef& lhs,
+                                   const OpRef& rhs) {
   CAFFEINE_ASSERT(lhs, "lhs was null");
   CAFFEINE_ASSERT(rhs, "rhs was null");
   ASSERT_INT(lhs);
@@ -446,8 +446,8 @@ ref<Operation> BinaryOp::CreateMul(const ref<Operation>& lhs,
 
   return Create(Opcode::Mul, lhs, rhs);
 }
-ref<Operation> BinaryOp::CreateUDiv(const ref<Operation>& lhs,
-                                    const ref<Operation>& rhs) {
+OpRef BinaryOp::CreateUDiv(const OpRef& lhs,
+                                    const OpRef& rhs) {
   CAFFEINE_ASSERT(lhs, "lhs was null");
   CAFFEINE_ASSERT(rhs, "rhs was null");
   ASSERT_INT(lhs);
@@ -465,8 +465,8 @@ ref<Operation> BinaryOp::CreateUDiv(const ref<Operation>& lhs,
 
   return Create(Opcode::UDiv, lhs, rhs);
 }
-ref<Operation> BinaryOp::CreateSDiv(const ref<Operation>& lhs,
-                                    const ref<Operation>& rhs) {
+OpRef BinaryOp::CreateSDiv(const OpRef& lhs,
+                                    const OpRef& rhs) {
   CAFFEINE_ASSERT(lhs, "lhs was null");
   CAFFEINE_ASSERT(rhs, "rhs was null");
   ASSERT_INT(lhs);
@@ -486,8 +486,8 @@ ref<Operation> BinaryOp::CreateSDiv(const ref<Operation>& lhs,
 
   return Create(Opcode::SDiv, lhs, rhs);
 }
-ref<Operation> BinaryOp::CreateURem(const ref<Operation>& lhs,
-                                    const ref<Operation>& rhs) {
+OpRef BinaryOp::CreateURem(const OpRef& lhs,
+                                    const OpRef& rhs) {
   CAFFEINE_ASSERT(lhs, "lhs was null");
   CAFFEINE_ASSERT(rhs, "rhs was null");
   ASSERT_INT(lhs);
@@ -507,8 +507,8 @@ ref<Operation> BinaryOp::CreateURem(const ref<Operation>& lhs,
 
   return Create(Opcode::URem, lhs, rhs);
 }
-ref<Operation> BinaryOp::CreateSRem(const ref<Operation>& lhs,
-                                    const ref<Operation>& rhs) {
+OpRef BinaryOp::CreateSRem(const OpRef& lhs,
+                                    const OpRef& rhs) {
   CAFFEINE_ASSERT(lhs, "lhs was null");
   CAFFEINE_ASSERT(rhs, "rhs was null");
   ASSERT_INT(lhs);
@@ -529,8 +529,8 @@ ref<Operation> BinaryOp::CreateSRem(const ref<Operation>& lhs,
   return Create(Opcode::SRem, lhs, rhs);
 }
 
-ref<Operation> BinaryOp::CreateAnd(const ref<Operation>& lhs,
-                                   const ref<Operation>& rhs) {
+OpRef BinaryOp::CreateAnd(const OpRef& lhs,
+                                   const OpRef& rhs) {
   CAFFEINE_ASSERT(lhs, "lhs was null");
   CAFFEINE_ASSERT(rhs, "rhs was null");
   ASSERT_INT(lhs);
@@ -555,8 +555,8 @@ ref<Operation> BinaryOp::CreateAnd(const ref<Operation>& lhs,
 
   return Create(Opcode::And, lhs, rhs);
 }
-ref<Operation> BinaryOp::CreateOr(const ref<Operation>& lhs,
-                                  const ref<Operation>& rhs) {
+OpRef BinaryOp::CreateOr(const OpRef& lhs,
+                                  const OpRef& rhs) {
   CAFFEINE_ASSERT(lhs, "lhs was null");
   CAFFEINE_ASSERT(rhs, "rhs was null");
   ASSERT_INT(lhs);
@@ -581,8 +581,8 @@ ref<Operation> BinaryOp::CreateOr(const ref<Operation>& lhs,
 
   return Create(Opcode::Or, lhs, rhs);
 }
-ref<Operation> BinaryOp::CreateXor(const ref<Operation>& lhs,
-                                   const ref<Operation>& rhs) {
+OpRef BinaryOp::CreateXor(const OpRef& lhs,
+                                   const OpRef& rhs) {
   CAFFEINE_ASSERT(lhs, "lhs was null");
   CAFFEINE_ASSERT(rhs, "rhs was null");
   ASSERT_INT(lhs);
@@ -605,8 +605,8 @@ ref<Operation> BinaryOp::CreateXor(const ref<Operation>& lhs,
 
   return Create(Opcode::Xor, lhs, rhs);
 }
-ref<Operation> BinaryOp::CreateShl(const ref<Operation>& lhs,
-                                   const ref<Operation>& rhs) {
+OpRef BinaryOp::CreateShl(const OpRef& lhs,
+                                   const OpRef& rhs) {
   CAFFEINE_ASSERT(lhs, "lhs was null");
   CAFFEINE_ASSERT(rhs, "rhs was null");
   ASSERT_INT(lhs);
@@ -624,8 +624,8 @@ ref<Operation> BinaryOp::CreateShl(const ref<Operation>& lhs,
 
   return Create(Opcode::Shl, lhs, rhs);
 }
-ref<Operation> BinaryOp::CreateLShr(const ref<Operation>& lhs,
-                                    const ref<Operation>& rhs) {
+OpRef BinaryOp::CreateLShr(const OpRef& lhs,
+                                    const OpRef& rhs) {
   CAFFEINE_ASSERT(lhs, "lhs was null");
   CAFFEINE_ASSERT(rhs, "rhs was null");
   ASSERT_INT(lhs);
@@ -643,8 +643,8 @@ ref<Operation> BinaryOp::CreateLShr(const ref<Operation>& lhs,
 
   return Create(Opcode::LShr, lhs, rhs);
 }
-ref<Operation> BinaryOp::CreateAShr(const ref<Operation>& lhs,
-                                    const ref<Operation>& rhs) {
+OpRef BinaryOp::CreateAShr(const OpRef& lhs,
+                                    const OpRef& rhs) {
   CAFFEINE_ASSERT(lhs, "lhs was null");
   CAFFEINE_ASSERT(rhs, "rhs was null");
   ASSERT_INT(lhs);
@@ -663,8 +663,8 @@ ref<Operation> BinaryOp::CreateAShr(const ref<Operation>& lhs,
   return Create(Opcode::AShr, lhs, rhs);
 }
 
-ref<Operation> BinaryOp::CreateFAdd(const ref<Operation>& lhs,
-                                    const ref<Operation>& rhs) {
+OpRef BinaryOp::CreateFAdd(const OpRef& lhs,
+                                    const OpRef& rhs) {
   CAFFEINE_ASSERT(lhs, "lhs was null");
   CAFFEINE_ASSERT(rhs, "rhs was null");
   ASSERT_FP(lhs);
@@ -683,8 +683,8 @@ ref<Operation> BinaryOp::CreateFAdd(const ref<Operation>& lhs,
   return Create(Opcode::FAdd, lhs, rhs);
 }
 
-ref<Operation> BinaryOp::CreateFSub(const ref<Operation>& lhs,
-                                    const ref<Operation>& rhs) {
+OpRef BinaryOp::CreateFSub(const OpRef& lhs,
+                                    const OpRef& rhs) {
   CAFFEINE_ASSERT(lhs, "lhs was null");
   CAFFEINE_ASSERT(rhs, "rhs was null");
   ASSERT_FP(lhs);
@@ -703,8 +703,8 @@ ref<Operation> BinaryOp::CreateFSub(const ref<Operation>& lhs,
   return Create(Opcode::FSub, lhs, rhs);
 }
 
-ref<Operation> BinaryOp::CreateFMul(const ref<Operation>& lhs,
-                                    const ref<Operation>& rhs) {
+OpRef BinaryOp::CreateFMul(const OpRef& lhs,
+                                    const OpRef& rhs) {
   CAFFEINE_ASSERT(lhs, "lhs was null");
   CAFFEINE_ASSERT(rhs, "rhs was null");
   ASSERT_FP(lhs);
@@ -723,8 +723,8 @@ ref<Operation> BinaryOp::CreateFMul(const ref<Operation>& lhs,
   return Create(Opcode::FMul, lhs, rhs);
 }
 
-ref<Operation> BinaryOp::CreateFDiv(const ref<Operation>& lhs,
-                                    const ref<Operation>& rhs) {
+OpRef BinaryOp::CreateFDiv(const OpRef& lhs,
+                                    const OpRef& rhs) {
   CAFFEINE_ASSERT(lhs, "lhs was null");
   CAFFEINE_ASSERT(rhs, "rhs was null");
   ASSERT_FP(lhs);
@@ -743,8 +743,8 @@ ref<Operation> BinaryOp::CreateFDiv(const ref<Operation>& lhs,
   return Create(Opcode::FDiv, lhs, rhs);
 }
 
-ref<Operation> BinaryOp::CreateFRem(const ref<Operation>& lhs,
-                                    const ref<Operation>& rhs) {
+OpRef BinaryOp::CreateFRem(const OpRef& lhs,
+                                    const OpRef& rhs) {
   CAFFEINE_ASSERT(lhs, "lhs was null");
   CAFFEINE_ASSERT(rhs, "rhs was null");
   ASSERT_FP(lhs);
@@ -764,7 +764,7 @@ ref<Operation> BinaryOp::CreateFRem(const ref<Operation>& lhs,
 }
 
 #define DEF_INT_BINOP_CONST_CREATE_DETAIL(opcode, ty, signed)                  \
-  ref<Operation> BinaryOp::Create##opcode(const ref<Operation>& lhs, ty rhs) { \
+  OpRef BinaryOp::Create##opcode(const OpRef& lhs, ty rhs) { \
     CAFFEINE_ASSERT(lhs, "lhs is null");                                       \
     CAFFEINE_ASSERT(lhs->type().is_int());                                     \
                                                                                \
@@ -772,7 +772,7 @@ ref<Operation> BinaryOp::CreateFRem(const ref<Operation>& lhs,
         lhs, ConstantInt::Create(                                              \
                  llvm::APInt(lhs->type().bitwidth(), rhs, signed)));           \
   }                                                                            \
-  ref<Operation> BinaryOp::Create##opcode(ty lhs, const ref<Operation>& rhs) { \
+  OpRef BinaryOp::Create##opcode(ty lhs, const OpRef& rhs) { \
     CAFFEINE_ASSERT(rhs, "rhs is null");                                       \
     CAFFEINE_ASSERT(rhs->type().is_int());                                     \
                                                                                \
@@ -811,29 +811,29 @@ DEF_INT_BINOP_CONST_CREATE(AShr);
 /***************************************************
  * UnaryOp                                         *
  ***************************************************/
-UnaryOp::UnaryOp(Opcode op, Type t, const ref<Operation>& operand)
+UnaryOp::UnaryOp(Opcode op, Type t, const OpRef& operand)
     : Operation(op, t, operand) {}
 
-ref<Operation> UnaryOp::Create(Opcode op, const ref<Operation>& operand) {
+OpRef UnaryOp::Create(Opcode op, const OpRef& operand) {
   return Create(op, operand, operand->type());
 }
 
-ref<Operation> UnaryOp::Create(Opcode op, const ref<Operation>& operand,
+OpRef UnaryOp::Create(Opcode op, const OpRef& operand,
                                Type returnType) {
   CAFFEINE_ASSERT(operand, "operand was null");
   CAFFEINE_ASSERT((op & 0x3) == 1, "Opcode doesn't have 2 operands");
 
-  return ref<Operation>(new UnaryOp(op, returnType, operand));
+  return OpRef(new UnaryOp(op, returnType, operand));
 }
 
 #define DECL_UNOP_CREATE(opcode, assert, return_type)                          \
-  ref<Operation> UnaryOp::Create##opcode(const ref<Operation>& operand) {      \
+  OpRef UnaryOp::Create##opcode(const OpRef& operand) {      \
     assert(operand);                                                           \
                                                                                \
     return Create(Opcode::opcode, operand, return_type);                       \
   }
 
-ref<Operation> UnaryOp::CreateNot(const ref<Operation>& operand) {
+OpRef UnaryOp::CreateNot(const OpRef& operand) {
   ASSERT_INT(operand);
 
 #ifdef CAFFEINE_IMPLICIT_CONSTANT_FOLDING
@@ -847,7 +847,7 @@ ref<Operation> UnaryOp::CreateNot(const ref<Operation>& operand) {
 DECL_UNOP_CREATE(FNeg, ASSERT_FP, operand->type());
 DECL_UNOP_CREATE(FIsNaN, ASSERT_FP, Type::int_ty(1));
 
-ref<Operation> UnaryOp::CreateTrunc(Type tgt, const ref<Operation>& operand) {
+OpRef UnaryOp::CreateTrunc(Type tgt, const OpRef& operand) {
   CAFFEINE_ASSERT(tgt.is_int());
   CAFFEINE_ASSERT(operand->type().is_int());
   CAFFEINE_ASSERT(tgt.bitwidth() < operand->type().bitwidth());
@@ -860,9 +860,9 @@ ref<Operation> UnaryOp::CreateTrunc(Type tgt, const ref<Operation>& operand) {
     return ConstantInt::Create(op->value().trunc(tgt.bitwidth()));
 #endif
 
-  return ref<Operation>(new UnaryOp(Opcode::Trunc, tgt, operand));
+  return OpRef(new UnaryOp(Opcode::Trunc, tgt, operand));
 }
-ref<Operation> UnaryOp::CreateZExt(Type tgt, const ref<Operation>& operand) {
+OpRef UnaryOp::CreateZExt(Type tgt, const OpRef& operand) {
   CAFFEINE_ASSERT(tgt.is_int());
   CAFFEINE_ASSERT(operand->type().is_int());
   CAFFEINE_ASSERT(tgt.bitwidth() > operand->type().bitwidth());
@@ -872,9 +872,9 @@ ref<Operation> UnaryOp::CreateZExt(Type tgt, const ref<Operation>& operand) {
     return ConstantInt::Create(op->value().zext(tgt.bitwidth()));
 #endif
 
-  return ref<Operation>(new UnaryOp(Opcode::ZExt, tgt, operand));
+  return OpRef(new UnaryOp(Opcode::ZExt, tgt, operand));
 }
-ref<Operation> UnaryOp::CreateSExt(Type tgt, const ref<Operation>& operand) {
+OpRef UnaryOp::CreateSExt(Type tgt, const OpRef& operand) {
   CAFFEINE_ASSERT(tgt.is_int());
   CAFFEINE_ASSERT(operand->type().is_int());
   CAFFEINE_ASSERT(tgt.bitwidth() > operand->type().bitwidth());
@@ -887,57 +887,57 @@ ref<Operation> UnaryOp::CreateSExt(Type tgt, const ref<Operation>& operand) {
     return ConstantInt::Create(op->value().sext(tgt.bitwidth()));
 #endif
 
-  return ref<Operation>(new UnaryOp(Opcode::SExt, tgt, operand));
+  return OpRef(new UnaryOp(Opcode::SExt, tgt, operand));
 }
-ref<Operation> UnaryOp::CreateFpTrunc(Type tgt, const ref<Operation>& operand) {
+OpRef UnaryOp::CreateFpTrunc(Type tgt, const OpRef& operand) {
   CAFFEINE_ASSERT(tgt.is_float());
   CAFFEINE_ASSERT(operand->type().is_float());
   CAFFEINE_ASSERT(tgt.exponent_bits() < operand->type().exponent_bits() &&
                   tgt.mantissa_bits() < operand->type().mantissa_bits());
 
-  return ref<Operation>(new UnaryOp(Opcode::FpTrunc, tgt, operand));
+  return OpRef(new UnaryOp(Opcode::FpTrunc, tgt, operand));
 }
-ref<Operation> UnaryOp::CreateFpExt(Type tgt, const ref<Operation>& operand) {
+OpRef UnaryOp::CreateFpExt(Type tgt, const OpRef& operand) {
   CAFFEINE_ASSERT(tgt.is_float());
   CAFFEINE_ASSERT(operand->type().is_float());
   CAFFEINE_ASSERT(tgt.exponent_bits() > operand->type().exponent_bits() &&
                   tgt.mantissa_bits() > operand->type().mantissa_bits());
 
-  return ref<Operation>(new UnaryOp(Opcode::FpExt, tgt, operand));
+  return OpRef(new UnaryOp(Opcode::FpExt, tgt, operand));
 }
-ref<Operation> UnaryOp::CreateFpToUI(Type tgt, const ref<Operation>& operand) {
+OpRef UnaryOp::CreateFpToUI(Type tgt, const OpRef& operand) {
   CAFFEINE_ASSERT(tgt.is_int());
   CAFFEINE_ASSERT(operand->type().is_float());
 
-  return ref<Operation>(new UnaryOp(Opcode::FpToUI, tgt, operand));
+  return OpRef(new UnaryOp(Opcode::FpToUI, tgt, operand));
 }
-ref<Operation> UnaryOp::CreateFpToSI(Type tgt, const ref<Operation>& operand) {
+OpRef UnaryOp::CreateFpToSI(Type tgt, const OpRef& operand) {
   CAFFEINE_ASSERT(tgt.is_int());
   CAFFEINE_ASSERT(operand->type().is_float());
 
-  return ref<Operation>(new UnaryOp(Opcode::FpToSI, tgt, operand));
+  return OpRef(new UnaryOp(Opcode::FpToSI, tgt, operand));
 }
-ref<Operation> UnaryOp::CreateUIToFp(Type tgt, const ref<Operation>& operand) {
+OpRef UnaryOp::CreateUIToFp(Type tgt, const OpRef& operand) {
   CAFFEINE_ASSERT(tgt.is_float());
   CAFFEINE_ASSERT(operand->type().is_int());
 
-  return ref<Operation>(new UnaryOp(Opcode::UIToFp, tgt, operand));
+  return OpRef(new UnaryOp(Opcode::UIToFp, tgt, operand));
 }
-ref<Operation> UnaryOp::CreateSIToFp(Type tgt, const ref<Operation>& operand) {
+OpRef UnaryOp::CreateSIToFp(Type tgt, const OpRef& operand) {
   CAFFEINE_ASSERT(tgt.is_float());
   CAFFEINE_ASSERT(operand->type().is_int());
 
-  return ref<Operation>(new UnaryOp(Opcode::SIToFp, tgt, operand));
+  return OpRef(new UnaryOp(Opcode::SIToFp, tgt, operand));
 }
-ref<Operation> UnaryOp::CreateBitcast(Type tgt, const ref<Operation>& operand) {
+OpRef UnaryOp::CreateBitcast(Type tgt, const OpRef& operand) {
   // TODO: Validate sizes if possible.
   // CAFFEINE_ASSERT(tgt.byte_size() == operand->type().byte_size());
 
-  return ref<Operation>(new UnaryOp(Opcode::Bitcast, tgt, operand));
+  return OpRef(new UnaryOp(Opcode::Bitcast, tgt, operand));
 }
 
-ref<Operation> UnaryOp::CreateTruncOrZExt(Type tgt,
-                                          const ref<Operation>& operand) {
+OpRef UnaryOp::CreateTruncOrZExt(Type tgt,
+                                          const OpRef& operand) {
   CAFFEINE_ASSERT(operand->type().is_int());
   CAFFEINE_ASSERT(tgt.is_int());
 
@@ -947,8 +947,8 @@ ref<Operation> UnaryOp::CreateTruncOrZExt(Type tgt,
     return CreateZExt(tgt, operand);
   return operand;
 }
-ref<Operation> UnaryOp::CreateTruncOrSExt(Type tgt,
-                                          const ref<Operation>& operand) {
+OpRef UnaryOp::CreateTruncOrSExt(Type tgt,
+                                          const OpRef& operand) {
   CAFFEINE_ASSERT(operand->type().is_int());
   CAFFEINE_ASSERT(tgt.is_int());
 
@@ -962,14 +962,14 @@ ref<Operation> UnaryOp::CreateTruncOrSExt(Type tgt,
 /***************************************************
  * SelectOp                                        *
  ***************************************************/
-SelectOp::SelectOp(Type t, const ref<Operation>& cond,
-                   const ref<Operation>& true_val,
-                   const ref<Operation>& false_val)
+SelectOp::SelectOp(Type t, const OpRef& cond,
+                   const OpRef& true_val,
+                   const OpRef& false_val)
     : Operation(Opcode::Select, t, cond, true_val, false_val) {}
 
-ref<Operation> SelectOp::Create(const ref<Operation>& cond,
-                                const ref<Operation>& true_value,
-                                const ref<Operation>& false_value) {
+OpRef SelectOp::Create(const OpRef& cond,
+                                const OpRef& true_value,
+                                const OpRef& false_value) {
   CAFFEINE_ASSERT(cond, "cond was null");
   CAFFEINE_ASSERT(true_value, "true_value was null");
   CAFFEINE_ASSERT(false_value, "false_value was null");
@@ -986,21 +986,21 @@ ref<Operation> SelectOp::Create(const ref<Operation>& cond,
     return vcond->value() == 1 ? true_value : false_value;
 #endif
 
-  return ref<Operation>(
+  return OpRef(
       new SelectOp(true_value->type(), cond, true_value, false_value));
 }
 
 /***************************************************
  * ICmpOp                                          *
  ***************************************************/
-ICmpOp::ICmpOp(ICmpOpcode cmp, Type t, const ref<Operation>& lhs,
-               const ref<Operation>& rhs)
+ICmpOp::ICmpOp(ICmpOpcode cmp, Type t, const OpRef& lhs,
+               const OpRef& rhs)
     : BinaryOp(static_cast<Opcode>(
                    detail::opcode(icmp_base, 2, static_cast<uint16_t>(cmp))),
                t, lhs, rhs) {}
 
-ref<Operation> ICmpOp::CreateICmp(ICmpOpcode cmp, const ref<Operation>& lhs,
-                                  const ref<Operation>& rhs) {
+OpRef ICmpOp::CreateICmp(ICmpOpcode cmp, const OpRef& lhs,
+                                  const OpRef& rhs) {
   CAFFEINE_ASSERT(rhs, "rhs was null");
   CAFFEINE_ASSERT(lhs, "lhs was null");
   CAFFEINE_ASSERT(
@@ -1038,10 +1038,10 @@ ref<Operation> ICmpOp::CreateICmp(ICmpOpcode cmp, const ref<Operation>& lhs,
   }
 #endif
 
-  return ref<Operation>(new ICmpOp(cmp, Type::int_ty(1), lhs, rhs));
+  return OpRef(new ICmpOp(cmp, Type::int_ty(1), lhs, rhs));
 }
-ref<Operation> ICmpOp::CreateICmp(ICmpOpcode cmp, int64_t lhs,
-                                  const ref<Operation>& rhs) {
+OpRef ICmpOp::CreateICmp(ICmpOpcode cmp, int64_t lhs,
+                                  const OpRef& rhs) {
   CAFFEINE_ASSERT(rhs, "rhs was null");
   CAFFEINE_ASSERT(rhs->type().is_int(),
                   "icmp can only be created with integer operands");
@@ -1051,7 +1051,7 @@ ref<Operation> ICmpOp::CreateICmp(ICmpOpcode cmp, int64_t lhs,
       cmp, ConstantInt::Create(literal.sextOrTrunc(rhs->type().bitwidth())),
       rhs);
 }
-ref<Operation> ICmpOp::CreateICmp(ICmpOpcode cmp, const ref<Operation>& lhs,
+OpRef ICmpOp::CreateICmp(ICmpOpcode cmp, const OpRef& lhs,
                                   int64_t rhs) {
   CAFFEINE_ASSERT(lhs, "rhs was null");
   CAFFEINE_ASSERT(lhs->type().is_int(),
@@ -1066,14 +1066,14 @@ ref<Operation> ICmpOp::CreateICmp(ICmpOpcode cmp, const ref<Operation>& lhs,
 /***************************************************
  * FCmpOp                                          *
  ***************************************************/
-FCmpOp::FCmpOp(FCmpOpcode cmp, Type t, const ref<Operation>& lhs,
-               const ref<Operation>& rhs)
+FCmpOp::FCmpOp(FCmpOpcode cmp, Type t, const OpRef& lhs,
+               const OpRef& rhs)
     : BinaryOp(static_cast<Opcode>(
                    detail::opcode(fcmp_base, 2, static_cast<uint16_t>(cmp))),
                t, lhs, rhs) {}
 
-ref<Operation> FCmpOp::CreateFCmp(FCmpOpcode cmp, const ref<Operation>& lhs,
-                                  const ref<Operation>& rhs) {
+OpRef FCmpOp::CreateFCmp(FCmpOpcode cmp, const OpRef& lhs,
+                                  const OpRef& rhs) {
   CAFFEINE_ASSERT(rhs, "rhs was null");
   CAFFEINE_ASSERT(lhs, "lhs was null");
   CAFFEINE_ASSERT(rhs->type() == lhs->type(),
@@ -1106,18 +1106,18 @@ ref<Operation> FCmpOp::CreateFCmp(FCmpOpcode cmp, const ref<Operation>& lhs,
   }
 #endif
 
-  return ref<Operation>(new FCmpOp(cmp, Type::type_of<bool>(), lhs, rhs));
+  return OpRef(new FCmpOp(cmp, Type::type_of<bool>(), lhs, rhs));
 }
 
 /***************************************************
  * AllocOp                                         *
  ***************************************************/
-AllocOp::AllocOp(const ref<Operation>& size, const ref<Operation>& defaultval)
+AllocOp::AllocOp(const OpRef& size, const OpRef& defaultval)
     : ArrayBase(Opcode::Alloc, Type::array_ty(size->type().bitwidth()), size,
                 defaultval) {}
 
-ref<Operation> AllocOp::Create(const ref<Operation>& size,
-                               const ref<Operation>& defaultval) {
+OpRef AllocOp::Create(const OpRef& size,
+                               const OpRef& defaultval) {
   CAFFEINE_ASSERT(size, "size was null");
   CAFFEINE_ASSERT(defaultval, "defaultval was null");
   // To be fully correct, this should be validating that the bitwidth of size
@@ -1136,17 +1136,17 @@ ref<Operation> AllocOp::Create(const ref<Operation>& size,
   }
 #endif
 
-  return ref<Operation>(new AllocOp(size, defaultval));
+  return OpRef(new AllocOp(size, defaultval));
 }
 
 /***************************************************
  * LoadOp                                          *
  ***************************************************/
-LoadOp::LoadOp(const ref<Operation>& data, const ref<Operation>& offset)
+LoadOp::LoadOp(const OpRef& data, const OpRef& offset)
     : Operation(Opcode::Load, Type::int_ty(8), data, offset) {}
 
-ref<Operation> LoadOp::Create(const ref<Operation>& data,
-                              const ref<Operation>& offset) {
+OpRef LoadOp::Create(const OpRef& data,
+                              const OpRef& offset) {
   CAFFEINE_ASSERT(data, "data was null");
   CAFFEINE_ASSERT(offset, "offset was null");
   CAFFEINE_ASSERT(offset->type().is_int(),
@@ -1161,19 +1161,19 @@ ref<Operation> LoadOp::Create(const ref<Operation>& data,
   }
 #endif
 
-  return ref<Operation>(new LoadOp(data, offset));
+  return OpRef(new LoadOp(data, offset));
 }
 
 /***************************************************
  * StoreOp                                         *
  ***************************************************/
-StoreOp::StoreOp(const ref<Operation>& data, const ref<Operation>& offset,
-                 const ref<Operation>& value)
+StoreOp::StoreOp(const OpRef& data, const OpRef& offset,
+                 const OpRef& value)
     : ArrayBase(Opcode::Store, data->type(), data, offset, value) {}
 
-ref<Operation> StoreOp::Create(const ref<Operation>& data,
-                               const ref<Operation>& offset,
-                               const ref<Operation>& value) {
+OpRef StoreOp::Create(const OpRef& data,
+                               const OpRef& offset,
+                               const OpRef& value) {
   CAFFEINE_ASSERT(data, "data was null");
   CAFFEINE_ASSERT(offset, "offset was null");
   CAFFEINE_ASSERT(value, "value was null");
@@ -1194,7 +1194,7 @@ ref<Operation> StoreOp::Create(const ref<Operation>& data,
 
 #endif
 
-  return ref<Operation>(new StoreOp(data, offset, value));
+  return OpRef(new StoreOp(data, offset, value));
 }
 
 /***************************************************
@@ -1202,14 +1202,14 @@ ref<Operation> StoreOp::Create(const ref<Operation>& data,
  ***************************************************/
 Undef::Undef(const Type& t) : Operation(Opcode::Undef, t) {}
 
-ref<Operation> Undef::Create(const Type& t) {
-  return ref<Operation>(new Undef(t));
+OpRef Undef::Create(const Type& t) {
+  return OpRef(new Undef(t));
 }
 
 /***************************************************
  * FixedArray                                      *
  ***************************************************/
-FixedArray::FixedArray(Type t, const PersistentArray<ref<Operation>>& data)
+FixedArray::FixedArray(Type t, const PersistentArray<OpRef>& data)
     : ArrayBase(Operation::FixedArray, t, data) {}
 
 llvm::iterator_range<Operation::operand_iterator> FixedArray::operands() {
@@ -1217,7 +1217,7 @@ llvm::iterator_range<Operation::operand_iterator> FixedArray::operands() {
   auto range = llvm::iterator_range<operand_iterator>(
       array.data(), array.data() + array.size());
 
-  data() = PersistentArray<ref<Operation>>(std::move(array));
+  data() = PersistentArray<OpRef>(std::move(array));
   return range;
 }
 llvm::iterator_range<Operation::const_operand_iterator>
@@ -1229,8 +1229,8 @@ FixedArray::operands() const {
       array.data(), array.data() + array.size());
 }
 
-ref<Operation>
-FixedArray::with_new_operands(llvm::ArrayRef<ref<Operation>> operands) const {
+OpRef
+FixedArray::with_new_operands(llvm::ArrayRef<OpRef> operands) const {
   CAFFEINE_ASSERT(operands.size() == num_operands());
 
   if (num_operands() == 0)
@@ -1249,31 +1249,31 @@ FixedArray::with_new_operands(llvm::ArrayRef<ref<Operation>> operands) const {
       array.set(i, operands[i]);
   }
 
-  return ref<Operation>(new FixedArray(type(), array));
+  return OpRef(new FixedArray(type(), array));
 }
 
-ref<Operation> FixedArray::Create(Type index_ty,
-                                  const PersistentArray<ref<Operation>>& data) {
+OpRef FixedArray::Create(Type index_ty,
+                                  const PersistentArray<OpRef>& data) {
   CAFFEINE_ASSERT(index_ty.is_int());
   CAFFEINE_ASSERT(
       index_ty.bitwidth() >= ilog2(data.size()),
       "Index bitwidth is not large enough to address entire constant array");
 
-  return ref<Operation>(
+  return OpRef(
       new FixedArray(Type::array_ty(index_ty.bitwidth()), data));
 }
-ref<Operation> FixedArray::Create(Type index_ty, const ref<Operation>& value,
+OpRef FixedArray::Create(Type index_ty, const OpRef& value,
                                   size_t size) {
   return FixedArray::Create(index_ty,
-                            PersistentArray<ref<Operation>>(
-                                std::vector<ref<Operation>>(size, value)));
+                            PersistentArray<OpRef>(
+                                std::vector<OpRef>(size, value)));
 }
 
 /***************************************************
  * hashing implementations                         *
  ***************************************************/
-static llvm::hash_code hash_value(const ref<Operation>& op) {
-  return std::hash<ref<Operation>>()(op);
+static llvm::hash_code hash_value(const OpRef& op) {
+  return std::hash<OpRef>()(op);
 }
 
 llvm::hash_code hash_value(const Operation& op) {

--- a/src/IR/Transforms/decompose.cpp
+++ b/src/IR/Transforms/decompose.cpp
@@ -12,7 +12,7 @@ void decompose(std::vector<Assertion>& assertions) {
   for (size_t i = 0; i < assertions.size(); ++i) {
     // Keep breaking the expression down until it stops working
     while (true) {
-      ref<Operation> lhs, rhs, value;
+      OpRef lhs, rhs, value;
 
       // A & B -> A, B
       if (matches(assertions[i], And(lhs, rhs))) {

--- a/src/Interpreter/CtxConstEval.cpp
+++ b/src/Interpreter/CtxConstEval.cpp
@@ -26,7 +26,7 @@ template <typename ContextType>
 static ContextValue evaluate(ContextType ctx, llvm::Constant* constant);
 
 template <typename ContextType>
-static ref<Operation> evaluate_global_data(ContextType,
+static OpRef evaluate_global_data(ContextType,
                                            llvm::Constant* constant);
 
 static ContextValue evaluate_undef(const Context* ctx,
@@ -91,7 +91,7 @@ static ContextValue evaluate_expr(ContextType ctx, llvm::ConstantExpr* expr) {
 #define CAST_OP(expr_)                                                         \
   transform(                                                                   \
       [=, type = Type::from_llvm(expr->getType())](                            \
-          const ref<Operation>& value) -> ref<Operation> { return (expr_); },  \
+          const OpRef& value) -> OpRef { return (expr_); },  \
       OPERAND(expr, 0))
 
   switch (expr->getOpcode()) {
@@ -262,7 +262,7 @@ ContextValue evaluate_global(ContextType ctx, llvm::GlobalVariable* global) {
  * Evaluate the initializer of a global variable to a byte array.
  */
 template <typename ContextType>
-static ref<Operation> evaluate_global_data(ContextType ctx,
+static OpRef evaluate_global_data(ContextType ctx,
                                            llvm::Constant* constant) {
   static_assert(
       std::is_same_v<std::remove_const_t<std::remove_pointer_t<ContextType>>,
@@ -275,7 +275,7 @@ static ref<Operation> evaluate_global_data(ContextType ctx,
     auto raw = data->getRawDataValues();
     auto idxty = Type::int_ty(layout.getPointerSizeInBits());
 
-    std::vector<ref<Operation>> values;
+    std::vector<OpRef> values;
     values.reserve(raw.size());
 
     for (size_t i = 0; i < raw.size(); ++i) {

--- a/src/Interpreter/CtxConstEval.cpp
+++ b/src/Interpreter/CtxConstEval.cpp
@@ -26,8 +26,7 @@ template <typename ContextType>
 static ContextValue evaluate(ContextType ctx, llvm::Constant* constant);
 
 template <typename ContextType>
-static OpRef evaluate_global_data(ContextType,
-                                           llvm::Constant* constant);
+static OpRef evaluate_global_data(ContextType, llvm::Constant* constant);
 
 static ContextValue evaluate_undef(const Context* ctx,
                                    llvm::UndefValue* undef) {
@@ -89,10 +88,9 @@ static ContextValue evaluate_expr(ContextType ctx, llvm::ConstantExpr* expr) {
   transform([=](const auto& a, const auto& b) { return (expr_)(a, b); },       \
             OPERAND(expr, 0), OPERAND(expr, 1))
 #define CAST_OP(expr_)                                                         \
-  transform(                                                                   \
-      [=, type = Type::from_llvm(expr->getType())](                            \
-          const OpRef& value) -> OpRef { return (expr_); },  \
-      OPERAND(expr, 0))
+  transform([=, type = Type::from_llvm(expr->getType())](                      \
+                const OpRef& value) -> OpRef { return (expr_); },              \
+            OPERAND(expr, 0))
 
   switch (expr->getOpcode()) {
     // clang-format off
@@ -262,8 +260,7 @@ ContextValue evaluate_global(ContextType ctx, llvm::GlobalVariable* global) {
  * Evaluate the initializer of a global variable to a byte array.
  */
 template <typename ContextType>
-static OpRef evaluate_global_data(ContextType ctx,
-                                           llvm::Constant* constant) {
+static OpRef evaluate_global_data(ContextType ctx, llvm::Constant* constant) {
   static_assert(
       std::is_same_v<std::remove_const_t<std::remove_pointer_t<ContextType>>,
                      Context>,

--- a/src/Interpreter/Interpreter.cpp
+++ b/src/Interpreter/Interpreter.cpp
@@ -362,19 +362,18 @@ ExecutionResult Interpreter::visitFCmpInst(llvm::FCmpInst& fcmp) {
 // `result` is the boolean value to return if either the lhs or rhs is a NaN
 #define FCMP_CASE(op, ourOp, result)                                           \
   case FCmpInst::FCMP_##op:                                                    \
-    frame.insert(&fcmp,                                                        \
-                 transform(                                                    \
-                     [](const auto& lhs, const auto& rhs) {                    \
-                       OpRef def = ConstantInt::Create(result);       \
-                       OpRef thenFcmp =                               \
-                           FCmpOp::CreateFCmp(FCmpOpcode::ourOp, lhs, rhs);    \
-                       OpRef neitherIsNaN = SelectOp::Create(         \
-                           UnaryOp::CreateFIsNaN(lhs), def,                    \
-                           SelectOp::Create(UnaryOp::CreateFIsNaN(rhs), def,   \
-                                            thenFcmp));                        \
-                       return neitherIsNaN;                                    \
-                     },                                                        \
-                     lhs, rhs));                                               \
+    frame.insert(&fcmp, transform(                                             \
+                            [](const auto& lhs, const auto& rhs) {             \
+                              OpRef def = ConstantInt::Create(result);         \
+                              OpRef thenFcmp = FCmpOp::CreateFCmp(             \
+                                  FCmpOpcode::ourOp, lhs, rhs);                \
+                              OpRef neitherIsNaN = SelectOp::Create(           \
+                                  UnaryOp::CreateFIsNaN(lhs), def,             \
+                                  SelectOp::Create(UnaryOp::CreateFIsNaN(rhs), \
+                                                   def, thenFcmp));            \
+                              return neitherIsNaN;                             \
+                            },                                                 \
+                            lhs, rhs));                                        \
     return ExecutionResult::Continue;
 
   switch (fcmp.getPredicate()) {

--- a/src/Interpreter/Interpreter.cpp
+++ b/src/Interpreter/Interpreter.cpp
@@ -365,10 +365,10 @@ ExecutionResult Interpreter::visitFCmpInst(llvm::FCmpInst& fcmp) {
     frame.insert(&fcmp,                                                        \
                  transform(                                                    \
                      [](const auto& lhs, const auto& rhs) {                    \
-                       ref<Operation> def = ConstantInt::Create(result);       \
-                       ref<Operation> thenFcmp =                               \
+                       OpRef def = ConstantInt::Create(result);       \
+                       OpRef thenFcmp =                               \
                            FCmpOp::CreateFCmp(FCmpOpcode::ourOp, lhs, rhs);    \
-                       ref<Operation> neitherIsNaN = SelectOp::Create(         \
+                       OpRef neitherIsNaN = SelectOp::Create(         \
                            UnaryOp::CreateFIsNaN(lhs), def,                    \
                            SelectOp::Create(UnaryOp::CreateFIsNaN(rhs), def,   \
                                             thenFcmp));                        \

--- a/src/Interpreter/StackFrame.cpp
+++ b/src/Interpreter/StackFrame.cpp
@@ -18,7 +18,7 @@ void StackFrame::jump_to(llvm::BasicBlock* block) {
   current = block->begin();
 }
 
-void StackFrame::insert(llvm::Value* value, const ref<Operation>& expr) {
+void StackFrame::insert(llvm::Value* value, const OpRef& expr) {
   insert(value, ContextValue{expr});
 }
 void StackFrame::insert(llvm::Value* value, const ContextValue& exprs) {

--- a/src/Interpreter/Value.cpp
+++ b/src/Interpreter/Value.cpp
@@ -5,7 +5,7 @@
 
 namespace caffeine {
 
-ContextValue::ContextValue(const ref<Operation>& op) : inner_(op) {}
+ContextValue::ContextValue(const OpRef& op) : inner_(op) {}
 ContextValue::ContextValue(const Pointer& ptr) : inner_(ptr) {}
 
 ContextValue::ContextValue(const std::vector<ContextValue>& data)
@@ -43,8 +43,8 @@ ContextValue ContextValue::into_owned() && {
   return *this;
 }
 
-const ref<Operation>& ContextValue::scalar() const {
-  const auto* val = std::get_if<ref<Operation>>(&inner_);
+const OpRef& ContextValue::scalar() const {
+  const auto* val = std::get_if<OpRef>(&inner_);
   CAFFEINE_ASSERT(val, "ContextValue was not a scalar");
   return *val;
 }

--- a/src/Memory/MemHeap.cpp
+++ b/src/Memory/MemHeap.cpp
@@ -15,9 +15,8 @@ namespace caffeine {
  * Allocation                                      *
  ***************************************************/
 
-Allocation::Allocation(const OpRef& address,
-                       const OpRef& size, const OpRef& data,
-                       AllocationKind kind)
+Allocation::Allocation(const OpRef& address, const OpRef& size,
+                       const OpRef& data, AllocationKind kind)
     : address_(address), size_(size), data_(data), kind_(kind) {
   CAFFEINE_ASSERT(address->type().is_int());
   CAFFEINE_ASSERT(size->type().is_int());
@@ -57,7 +56,7 @@ Assertion Allocation::check_inbounds(const OpRef& offset,
 }
 
 OpRef Allocation::read(const OpRef& offset, const Type& t,
-                                const llvm::DataLayout& llvm) const {
+                       const llvm::DataLayout& llvm) const {
   /**
    * Reading data here is actually somewhat complex. We need to effectively
    * reconstitute the type from its component bytes after we've read them
@@ -126,8 +125,7 @@ ContextValue Allocation::read(const OpRef& offset, llvm::Type* type,
   return ContextValue(std::move(values));
 }
 
-void Allocation::write(const OpRef& offset,
-                       const OpRef& value_,
+void Allocation::write(const OpRef& offset, const OpRef& value_,
                        const llvm::DataLayout& layout) {
   /**
    * This is essentially the same process as for read but executed in reverse.
@@ -191,8 +189,7 @@ void Allocation::write(const OpRef& offset, llvm::Type* type,
  * Pointer                                         *
  ***************************************************/
 
-Pointer::Pointer(const OpRef& value)
-    : Pointer({SIZE_MAX, SIZE_MAX}, value) {
+Pointer::Pointer(const OpRef& value) : Pointer({SIZE_MAX, SIZE_MAX}, value) {
   CAFFEINE_ASSERT(value->type().is_int());
 }
 Pointer::Pointer(const AllocId& alloc, const OpRef& offset)
@@ -221,8 +218,7 @@ const Allocation& MemHeap::operator[](const AllocId& alloc) const {
   return allocs_.at(alloc);
 }
 
-AllocId MemHeap::allocate(const OpRef& size,
-                          const OpRef& alignment,
+AllocId MemHeap::allocate(const OpRef& size, const OpRef& alignment,
                           const OpRef& data, AllocationKind kind,
                           Context& ctx) {
   CAFFEINE_ASSERT(size->type() == alignment->type());
@@ -287,8 +283,7 @@ Assertion MemHeap::check_valid(const Pointer& ptr, uint32_t width) {
   return check_valid(ptr, ConstantInt::Create(llvm::APInt(
                               ptr.offset()->type().bitwidth(), width)));
 }
-Assertion MemHeap::check_valid(const Pointer& ptr,
-                               const OpRef& width) {
+Assertion MemHeap::check_valid(const Pointer& ptr, const OpRef& width) {
   /**
    * Implementation note: When checking that the end of the read is within the
    * allocation we check ptr < alloc + (size - width) instead of checking ptr +

--- a/test/unit/IR/Matching.cpp
+++ b/test/unit/IR/Matching.cpp
@@ -17,7 +17,7 @@ TEST_F(MatchingTests, match_any) {
 TEST_F(MatchingTests, match_binop) {
   auto add = BinaryOp::CreateAdd(Constant::Create(Type::int_ty(32), 0), 55);
 
-  ref<Operation> first, second;
+  OpRef first, second;
   ASSERT_TRUE(matches(add, Add(first, second)));
 }
 
@@ -26,7 +26,7 @@ TEST_F(MatchingTests, match_nested) {
       BinaryOp::CreateSub(Constant::Create(Type::int_ty(32), 0), 77),
       Constant::Create(Type::int_ty(32), 1));
 
-  ref<Operation> first, second;
+  OpRef first, second;
   ASSERT_TRUE(matches(expr, Add(Sub(&first, second), Any())));
 
   ASSERT_EQ(first->opcode(), Operation::ConstantNumbered);
@@ -36,7 +36,7 @@ TEST_F(MatchingTests, match_nested) {
 TEST_F(MatchingTests, match_unop) {
   auto expr = UnaryOp::CreateNot(Constant::Create(Type::int_ty(32), 0));
 
-  ref<Operation> cnst;
+  OpRef cnst;
   ASSERT_TRUE(matches(expr, Not(cnst)));
   ASSERT_EQ(cnst->opcode(), Operation::ConstantNumbered);
 }
@@ -47,7 +47,7 @@ TEST_F(MatchingTests, replace_double_not) {
   auto expr = UnaryOp::CreateNot(
       UnaryOp::CreateNot(Constant::Create(Type::int_ty(18), 0)));
 
-  ref<Operation> child;
+  OpRef child;
   while (auto parent = matches_anywhere(expr, Not(Not(child))))
     *parent = *child;
 

--- a/test/unit/Memory/MemHeap.cpp
+++ b/test/unit/Memory/MemHeap.cpp
@@ -34,7 +34,7 @@ protected:
   llvm::DataLayout layout{X86_64_LINUX};
   std::unique_ptr<llvm::Function> function = empty_function(llvm);
 
-  ref<Operation> MakeInt(uint64_t value, unsigned AS = 0) {
+  OpRef MakeInt(uint64_t value, unsigned AS = 0) {
     return ConstantInt::Create(
         llvm::APInt(layout.getIndexSizeInBits(AS), value));
   }


### PR DESCRIPTION
In detail, this PR:
- Defines `typedef ref<Operation> OpRef` in `Operation.h`
- Replaces all instances of `ref<Operation>` with `OpRef`
- Formats everything

This is all automated and so shouldn't need to be reviewed line by line (the commits correspond to exactly those steps).

This is meant to be a first step towards making all operations references const throughout the codebase. The next PR will change `OpRef` to be a typedef for `ref<const Operation>` and fix whatever breakage occurs. 