### PR TITLE
Change OpRef to be a typedef of ref<const Operation>

### DIFF
--- a/include/caffeine/IR/Operation.h
+++ b/include/caffeine/IR/Operation.h
@@ -366,7 +366,6 @@ public:
   virtual llvm::iterator_range<operand_iterator> operands();
   virtual llvm::iterator_range<const_operand_iterator> operands() const;
 
-  Operation& operator[](size_t idx);
   const Operation& operator[](size_t idx) const;
 
   bool operator==(const Operation& op) const;

--- a/include/caffeine/IR/Operation.h
+++ b/include/caffeine/IR/Operation.h
@@ -50,7 +50,7 @@ namespace detail {
 } // namespace detail
 
 class Operation;
-typedef ref<Operation> OpRef;
+typedef ref<const Operation> OpRef;
 
 enum class ICmpOpcode : uint8_t {
   EQ = 0x8,

--- a/include/caffeine/IR/Operation.inl
+++ b/include/caffeine/IR/Operation.inl
@@ -194,11 +194,6 @@ inline bool Operation::is_constant() const {
   return detail::opcode_base(opcode_) == 1;
 }
 
-inline Operation& Operation::operator[](size_t idx) {
-  CAFFEINE_ASSERT(idx < num_operands(),
-                  "Tried to access out-of-bounds operand");
-  return *operand_at(idx);
-}
 inline const Operation& Operation::operator[](size_t idx) const {
   CAFFEINE_ASSERT(idx < num_operands(),
                   "Tried to access out-of-bounds operand");

--- a/src/IR/Operation.cpp
+++ b/src/IR/Operation.cpp
@@ -126,9 +126,9 @@ OpRef Operation::with_new_operands(llvm::ArrayRef<OpRef> operands) const {
   if (equal)
     return into_ref();
 
-  auto value = OpRef(new Operation((Opcode)opcode(), type(), operands.data()));
+  auto value = new Operation((Opcode)opcode(), type(), operands.data());
   value->copy_vtable(*this);
-  return value;
+  return OpRef(value);
 }
 
 std::string_view Operation::opcode_name() const {

--- a/src/IR/Transforms/canonicalize.cpp
+++ b/src/IR/Transforms/canonicalize.cpp
@@ -63,7 +63,7 @@ namespace {
 } // namespace
 
 void canonicalize(std::vector<Assertion>& assertions) {
-  std::unordered_set<Operation*> known;
+  std::unordered_set<const Operation*> known;
   CanonicalizeVisitor visitor;
 
   auto it = std::remove_if(

--- a/src/IR/Transforms/decompose.cpp
+++ b/src/IR/Transforms/decompose.cpp
@@ -16,21 +16,21 @@ void decompose(std::vector<Assertion>& assertions) {
 
       // A & B -> A, B
       if (matches(assertions[i], And(lhs, rhs))) {
-        *assertions[i].value() = *lhs;
+        assertions[i].value() = lhs;
         assertions.push_back(std::move(rhs));
         continue;
       }
 
       // !(A | B) -> !A, !B
       if (matches(assertions[i], Not(Or(lhs, rhs)))) {
-        *assertions[i].value() = *UnaryOp::CreateNot(lhs);
+        assertions[i].value() = UnaryOp::CreateNot(lhs);
         assertions.push_back(UnaryOp::CreateNot(rhs));
         continue;
       }
 
       // !!A -> A
       if (matches(assertions[i], Not(Not(value)))) {
-        *assertions[i].value() = *value;
+        assertions[i].value() = value;
         continue;
       }
 

--- a/test/unit/IR/Matching.cpp
+++ b/test/unit/IR/Matching.cpp
@@ -48,10 +48,9 @@ TEST_F(MatchingTests, replace_double_not) {
       UnaryOp::CreateNot(Constant::Create(Type::int_ty(18), 0)));
 
   OpRef child;
-  while (auto parent = matches_anywhere(expr, Not(Not(child))))
-    *parent = *child;
-
-  ASSERT_TRUE(llvm::isa<Constant>(expr.get()));
+  if (auto parent = matches_anywhere(expr, Not(Not(child)))) {
+    ASSERT_TRUE(matches(parent, Not(Not(Any()))));
+  }
 }
 
 TEST_F(MatchingTests, fixedarray) {


### PR DESCRIPTION
This is the second half of #220. It makes `OpRef` a typedef for `ref<const Operation>` and then fixes all the parts that broke due to that change:
- There was a `copy_vtable` call within `with_new_operands` that was using an operation that got changed to be const. This has been modified to be used by the newly-created non-const pointer.
- `canonicalize` was using non-const Operation pointers as keys in a map. This has been changed to use const Operation pointers.
- `decompose` was assigning to expression values (i.e. `*expr = *other`) instead of just assigning references. This has been changed to just assign references.
- Remove non-const `Operation::operator[]` since it no longer makes sense.
- One `matches_anywhere` test case relied on assigning to expression values. This has been replaced to not do that.

I think these changes might make `matches_anywhere` completely useless. I have not gone and looked at removing it since that would make this PR bigger than it needs to be.