### PR TITLE
Add CreateZero utility method to ConstantInt

### DIFF
--- a/include/caffeine/IR/Operation.h
+++ b/include/caffeine/IR/Operation.h
@@ -483,6 +483,8 @@ public:
   // Specialization for creating boolean constants
   static OpRef Create(bool value);
 
+  static OpRef CreateZero(unsigned bitwidth);
+
   static bool classof(const Operation* op);
 };
 

--- a/src/IR/Operation.cpp
+++ b/src/IR/Operation.cpp
@@ -278,6 +278,10 @@ OpRef ConstantInt::Create(bool value) {
   return ConstantInt::Create(llvm::APInt(1, static_cast<uint64_t>(value)));
 }
 
+OpRef ConstantInt::CreateZero(unsigned bitwidth) {
+  return ConstantInt::Create(llvm::APInt::getNullValue(bitwidth));
+}
+
 /***************************************************
  * ConstantFloat                                   *
  ***************************************************/


### PR DESCRIPTION
I got fed up with creating a `ConstantInt` with value zero taking 
```cpp
ConstantInt::Create(llvm::APInt::getNullValue(bitwidth))
```
and added a utility method.