### PR TITLE
[1/N] Interpreter redesign - Redesign ContextValue

### DIFF
--- a/include/caffeine/Interpreter/Value.h
+++ b/include/caffeine/Interpreter/Value.h
@@ -13,6 +13,90 @@
 namespace caffeine {
 
 /**
+ * A LLVM value that is not an aggregate or a vector.
+ *
+ * Currently, this can be either
+ * - a scalar expression, or
+ * - a pointer
+ */
+class LLVMScalar {
+public:
+  enum Kind { Expr, Pointer };
+
+private:
+  std::variant<OpRef, caffeine::Pointer> inner_;
+
+public:
+  LLVMScalar(const OpRef& value);
+  LLVMScalar(const caffeine::Pointer& value);
+
+  Kind kind() const;
+
+  bool is_expr() const;
+  bool is_pointer() const;
+
+  const OpRef& expr() const;
+  const caffeine::Pointer& pointer() const;
+};
+
+/**
+ * A general LLVM value.
+ *
+ * This can be any one of:
+ * - A scalar or pointer, or
+ * - A vector of scalars or pointers, or
+ * - An aggregate structure containing nested LLVMValues
+ *
+ * In terms of implementation, this is implemented by having a vector of either
+ * LLVMValues (for aggregates) and LLVMScalars (for vectors and scalars). A
+ * scalar is logically a vector of size 1 and this class follows that
+ * convention.
+ */
+class LLVMValue {
+public:
+  using OpVector = llvm::SmallVector<LLVMScalar, 4>;
+
+private:
+  enum { Vector, Aggregate };
+
+  std::variant<OpVector, std::vector<LLVMValue>> inner_;
+
+public:
+  LLVMValue(const LLVMScalar& value);
+  LLVMValue(OpVector&& values);
+  LLVMValue(llvm::ArrayRef<LLVMScalar> values);
+  LLVMValue(llvm::ArrayRef<LLVMValue> values);
+  LLVMValue(std::vector<LLVMValue>&& values);
+
+  bool is_scalar() const;
+  bool is_vector() const;
+  bool is_aggregate() const;
+
+  const LLVMScalar& scalar() const;
+  llvm::ArrayRef<LLVMScalar> vector() const;
+  llvm::ArrayRef<LLVMValue> aggregate() const;
+
+  size_t num_elements() const;
+  const LLVMScalar& element(size_t idx) const;
+  llvm::ArrayRef<LLVMScalar> elements() const;
+
+  size_t num_members() const;
+  const LLVMValue& member(size_t idx) const;
+  llvm::ArrayRef<LLVMValue> members() const;
+};
+
+/**
+ * Map the elements composing any number of vectors to a new vector with the
+ * same length. For this to work all vectors must have the same length otherwise
+ * an assertion will fire.
+ *
+ * This is generally meant to match the semantics needed when implementing LLVM
+ * opcodes.
+ */
+template <typename F, typename... Vals>
+LLVMValue transform_elements(F&& func, const Vals&... values);
+
+/**
  * An LLVM value as represented within a stack frame.
  *
  * Can be either

--- a/include/caffeine/Interpreter/Value.h
+++ b/include/caffeine/Interpreter/Value.h
@@ -68,11 +68,11 @@ private:
   std::variant<OpVector, std::vector<LLVMValue>> inner_;
 
 public:
-  LLVMValue(const LLVMScalar& value);
-  LLVMValue(OpVector&& values);
-  LLVMValue(llvm::ArrayRef<LLVMScalar> values);
-  LLVMValue(llvm::ArrayRef<LLVMValue> values);
-  LLVMValue(std::vector<LLVMValue>&& values);
+  explicit LLVMValue(const LLVMScalar& value);
+  explicit LLVMValue(OpVector&& values);
+  explicit LLVMValue(llvm::ArrayRef<LLVMScalar> values);
+  explicit LLVMValue(llvm::ArrayRef<LLVMValue> values);
+  explicit LLVMValue(std::vector<LLVMValue>&& values);
 
   bool is_scalar() const;
   bool is_vector() const;

--- a/include/caffeine/Interpreter/Value.h
+++ b/include/caffeine/Interpreter/Value.h
@@ -12,6 +12,9 @@
 
 namespace caffeine {
 
+class ContextValue;
+class LLVMValue;
+
 /**
  * A LLVM value that is not an aggregate or a vector.
  *
@@ -37,6 +40,9 @@ public:
 
   const OpRef& expr() const;
   const caffeine::Pointer& pointer() const;
+
+public:
+  explicit operator ContextValue() const;
 };
 
 /**
@@ -83,6 +89,9 @@ public:
   size_t num_members() const;
   const LLVMValue& member(size_t idx) const;
   llvm::ArrayRef<LLVMValue> members() const;
+
+public:
+  explicit operator ContextValue() const;
 };
 
 /**
@@ -103,7 +112,7 @@ LLVMValue transform_elements(F&& func, const Vals&... values);
  * - a single value (scalar), or
  * - a recursive array of values (vector)
  */
-class ContextValue {
+class /* [[deprecated]] */ ContextValue {
 public:
   enum Kind { Scalar, Vector, Ptr };
 
@@ -144,6 +153,10 @@ public:
   const OpRef& scalar() const;
   llvm::ArrayRef<ContextValue> vector() const;
   const Pointer& pointer() const;
+
+public:
+  explicit operator LLVMScalar() const;
+  explicit operator LLVMValue() const;
 };
 
 /**

--- a/include/caffeine/Interpreter/Value.inl
+++ b/include/caffeine/Interpreter/Value.inl
@@ -7,6 +7,90 @@
 
 namespace caffeine {
 
+/***************************************************
+ * LLVMScalar                                      *
+ ***************************************************/
+
+inline LLVMScalar::LLVMScalar(const OpRef& value) : inner_(value) {}
+inline LLVMScalar::LLVMScalar(const caffeine::Pointer& value) : inner_(value) {}
+
+inline LLVMScalar::Kind LLVMScalar::kind() const {
+  return static_cast<Kind>(inner_.index());
+}
+
+inline bool LLVMScalar::is_expr() const {
+  return kind() == Expr;
+}
+inline bool LLVMScalar::is_pointer() const {
+  return kind() == Pointer;
+}
+
+inline const OpRef& LLVMScalar::expr() const {
+  CAFFEINE_ASSERT(is_expr());
+  return std::get<Expr>(inner_);
+}
+inline const Pointer& LLVMScalar::pointer() const {
+  CAFFEINE_ASSERT(is_pointer());
+  return std::get<Pointer>(inner_);
+}
+
+/***************************************************
+ * LLVMValue                                       *
+ ***************************************************/
+
+inline LLVMValue::LLVMValue(const LLVMScalar& value)
+    : LLVMValue(OpVector{value}) {}
+inline LLVMValue::LLVMValue(OpVector&& values) : inner_(std::move(values)) {}
+inline LLVMValue::LLVMValue(llvm::ArrayRef<LLVMScalar> values)
+    : LLVMValue(OpVector(values.begin(), values.end())) {}
+inline LLVMValue::LLVMValue(llvm::ArrayRef<LLVMValue> values)
+    : LLVMValue(values.vec()) {}
+inline LLVMValue::LLVMValue(std::vector<LLVMValue>&& values)
+    : inner_(std::move(values)) {}
+
+inline bool LLVMValue::is_scalar() const {
+  return is_vector() && vector().size() == 1;
+}
+inline bool LLVMValue::is_vector() const {
+  return inner_.index() == Vector;
+}
+inline bool LLVMValue::is_aggregate() const {
+  return inner_.index() == Aggregate;
+}
+
+inline const LLVMScalar& LLVMValue::scalar() const {
+  CAFFEINE_ASSERT(is_scalar());
+  return vector()[0];
+}
+inline llvm::ArrayRef<LLVMScalar> LLVMValue::vector() const {
+  CAFFEINE_ASSERT(is_vector());
+  return std::get<Vector>(inner_);
+}
+inline llvm::ArrayRef<LLVMValue> LLVMValue::aggregate() const {
+  CAFFEINE_ASSERT(is_aggregate());
+  return std::get<Aggregate>(inner_);
+}
+
+inline size_t LLVMValue::num_elements() const {
+  return vector().size();
+}
+inline const LLVMScalar& LLVMValue::element(size_t idx) const {
+  return vector()[idx];
+}
+inline llvm::ArrayRef<LLVMScalar> LLVMValue::elements() const {
+  return vector();
+}
+
+inline size_t LLVMValue::num_members() const {
+  return aggregate().size();
+}
+inline const LLVMValue& LLVMValue::member(size_t idx) const {
+  return aggregate()[idx];
+}
+inline llvm::ArrayRef<LLVMValue> LLVMValue::members() const {
+  return aggregate();
+}
+
 inline bool ContextValue::is_vector() const {
   return kind() == Vector;
 }
@@ -55,6 +139,39 @@ namespace detail {
     return first;
   }
 } // namespace detail
+
+template <typename F, typename... Vs>
+inline LLVMValue transform_elements(F&& func, const Vs&... values) {
+  static_assert((... && std::is_same_v<Vs, LLVMValue>),
+                "transform_elements may only be called with LLVMValue");
+  static_assert(
+      sizeof...(Vs) > 0,
+      "transform_elements must be called with at least one LLVMValue");
+
+  const LLVMValue& v1 = detail::first(values...);
+
+  CAFFEINE_ASSERT((... && values.is_vector()));
+  CAFFEINE_ASSERT((... && (v1.num_elements() == values.num_elements())));
+
+  auto its = std::make_tuple(std::begin(values.elements())...);
+  auto ends = std::make_tuple(std::end(values.elements())...);
+
+  LLVMValue::OpVector results;
+  results.reserve(v1.num_elements());
+
+  while (std::apply(
+      [](auto... v) { return (... && v); },
+      detail::tuple_combine([](const auto& a, const auto& b) { return a != b; },
+                            its, ends))) {
+
+    results.push_back(std::apply(
+        func, detail::tuple_foreach([](auto& it) { return *it; }, its)));
+
+    detail::tuple_foreach([](auto& it) { return ++it, 0; }, its);
+  }
+
+  return LLVMValue(std::move(results));
+}
 
 template <typename F, typename... Vs>
 inline ContextValue transform_value(F&& func, const Vs&... values) {


### PR DESCRIPTION
This PR introduces a new value type (`LLVMValue`) for use within the interpreter. For now, it isn't used anywhere but future changes will expand it's use throughout the codebase until all uses of `ContextValue` have been replaced and we can delete `ContextValue`.

The main differences between `ContextValue` and `LLVMValue` are:
- `LLVMValue` only allows vectors to have scalar (either an operation or a pointer) values.
- `LLVMValue` treats scalars as a vector of length 1 which makes transformations over them much easier.
- `LLVMValue` has support for aggregates (struct and array)

To help with the incremental conversion I have also added conversion operators between `LLVMValue`, `LLVMScalar`, and `ContextValue` so that we can easily convert between them at boundaries.

This PR is part of the effort to redesign the whole interpreter (#202)
