### PR TITLE
[2/N] Interpreter redesign - Implement Allocation::write overloads for LLVMValue and LLVMScalar

### DIFF
--- a/include/caffeine/Memory/MemHeap.h
+++ b/include/caffeine/Memory/MemHeap.h
@@ -15,6 +15,8 @@ class Context;
 class ContextValue;
 class Assertion;
 class MemHeap;
+class LLVMScalar;
+class LLVMValue;
 
 /**
  * An allocation category.
@@ -102,6 +104,10 @@ public:
   void write(const OpRef& offset, const OpRef& value,
              const llvm::DataLayout& layout);
   void write(const OpRef& offset, llvm::Type* type, const ContextValue& value,
+             const MemHeap& heap, const llvm::DataLayout& layout);
+  void write(const OpRef& offset, const LLVMScalar& value, const MemHeap& heap,
+             const llvm::DataLayout& layout);
+  void write(const OpRef& offset, llvm::Type* type, const LLVMValue& value,
              const MemHeap& heap, const llvm::DataLayout& layout);
 };
 


### PR DESCRIPTION
Basically as in the title. The new overloads also properly handle struct and array values.

This PR is part of the effort to redesign the whole interpreter (#202)

Depends on #228.