### PR TITLE
[3/N] Interpreter redesign - Introduce simple expression evaluator

### DIFF
--- a/include/caffeine/Interpreter/ExprEval.h
+++ b/include/caffeine/Interpreter/ExprEval.h
@@ -1,6 +1,8 @@
 #pragma once
 
 #include <llvm/IR/InstVisitor.h>
+#include <optional>
+#include <stdexcept>
 
 namespace caffeine {
 
@@ -34,6 +36,7 @@ public:
   LLVMValue visit(llvm::Value* val);
   LLVMValue visit(llvm::Value& val);
 
+  std::optional<LLVMValue> try_visit(llvm::Value* val);
 
   /*********************************************
    * InstVisitor override methods              *

--- a/include/caffeine/Interpreter/ExprEval.h
+++ b/include/caffeine/Interpreter/ExprEval.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "caffeine/IR/Operation.h"
 #include <llvm/IR/InstVisitor.h>
 #include <optional>
 #include <stdexcept>
@@ -29,6 +30,19 @@ public:
     bool create_allocations = true;
 
     constexpr Options() noexcept {}
+  };
+
+  class Unevaluatable : public std::exception {
+  private:
+    llvm::Value* expr_;
+    const char* context_;
+    mutable std::string msg_cache_;
+
+  public:
+    explicit Unevaluatable(llvm::Value* expr, const char* context = nullptr);
+
+    const char* what() const throw() override;
+    llvm::Value* expr() const;
   };
 
   explicit ExprEvaluator(Context* ctx, Options options = Options());

--- a/include/caffeine/Interpreter/ExprEval.h
+++ b/include/caffeine/Interpreter/ExprEval.h
@@ -1,0 +1,80 @@
+#pragma once
+
+#include <llvm/IR/InstVisitor.h>
+
+namespace caffeine {
+
+class Context;
+class LLVMValue;
+
+/**
+ * LLVM IR expression evaluator.
+ *
+ * This class is designed to evaluate expressions which don't require any
+ * context forking. This makes it suitable for evaluating LLVM constant
+ * expressions and certain simple instructions.
+ *
+ * This class will never insert a value into the context. Depending on
+ * configuration, it may create new allocations if attempting to evaluate a
+ * global allocation.
+ */
+class ExprEvaluator : public llvm::InstVisitor<ExprEvaluator, LLVMValue> {
+private:
+  using BaseType = llvm::InstVisitor<ExprEvaluator, LLVMValue>;
+
+public:
+  struct Options {
+    bool create_allocations = true;
+
+    constexpr Options() noexcept {}
+  };
+
+  explicit ExprEvaluator(Context* ctx, Options options = Options());
+
+  LLVMValue visit(llvm::Value* val);
+
+
+  /*********************************************
+   * InstVisitor override methods              *
+   *********************************************/
+
+  LLVMValue visitInstruction(llvm::Instruction& inst);
+
+  LLVMValue visitAdd(llvm::BinaryOperator& op);
+  LLVMValue visitSub(llvm::BinaryOperator& op);
+  LLVMValue visitMul(llvm::BinaryOperator& op);
+  LLVMValue visitUDiv(llvm::BinaryOperator& op);
+  LLVMValue visitSDiv(llvm::BinaryOperator& op);
+  LLVMValue visitURem(llvm::BinaryOperator& op);
+  LLVMValue visitSRem(llvm::BinaryOperator& op);
+
+  LLVMValue visitShl(llvm::BinaryOperator& op);
+  LLVMValue visitLShr(llvm::BinaryOperator& op);
+  LLVMValue visitAShr(llvm::BinaryOperator& op);
+  LLVMValue visitAnd(llvm::BinaryOperator& op);
+  LLVMValue visitOr(llvm::BinaryOperator& op);
+  LLVMValue visitXor(llvm::BinaryOperator& op);
+
+  LLVMValue visitFAdd(llvm::BinaryOperator& op);
+  LLVMValue visitFSub(llvm::BinaryOperator& op);
+  LLVMValue visitFMul(llvm::BinaryOperator& op);
+  LLVMValue visitFDiv(llvm::BinaryOperator& op);
+
+  LLVMValue visitFNeg(llvm::UnaryOperator& op);
+
+  LLVMValue visitTrunc(llvm::CastInst& op);
+  LLVMValue visitSExt(llvm::CastInst& op);
+  LLVMValue visitZExt(llvm::CastInst& op);
+  LLVMValue visitFPTrunc(llvm::CastInst& op);
+  LLVMValue visitFPExt(llvm::CastInst& op);
+  LLVMValue visitUIToFP(llvm::CastInst& op);
+  LLVMValue visitSIToFP(llvm::CastInst& op);
+  LLVMValue visitFPToUI(llvm::CastInst& op);
+  LLVMValue visitFPToSI(llvm::CastInst& op);
+
+private:
+  Context* ctx;
+  Options options;
+};
+
+} // namespace caffeine

--- a/include/caffeine/Interpreter/ExprEval.h
+++ b/include/caffeine/Interpreter/ExprEval.h
@@ -32,6 +32,7 @@ public:
   explicit ExprEvaluator(Context* ctx, Options options = Options());
 
   LLVMValue visit(llvm::Value* val);
+  LLVMValue visit(llvm::Value& val);
 
 
   /*********************************************

--- a/include/caffeine/Interpreter/StackFrame.h
+++ b/include/caffeine/Interpreter/StackFrame.h
@@ -62,6 +62,9 @@ public:
    * `variables` as it correctly handles constants.
    */
   ContextValue lookup(llvm::Value* value) const;
+
+private:
+  friend class ExprEvaluator;
 };
 
 } // namespace caffeine

--- a/include/caffeine/Interpreter/Value.h
+++ b/include/caffeine/Interpreter/Value.h
@@ -68,93 +68,6 @@ private:
   std::variant<OpVector, std::vector<LLVMValue>> inner_;
 
 public:
-  explicit LLVMValue(const LLVMScalar& value);
-  explicit LLVMValue(OpVector&& values);
-  explicit LLVMValue(llvm::ArrayRef<LLVMScalar> values);
-  explicit LLVMValue(llvm::ArrayRef<LLVMValue> values);
-  explicit LLVMValue(std::vector<LLVMValue>&& values);
-
-  bool is_scalar() const;
-  bool is_vector() const;
-  bool is_aggregate() const;
-
-  const LLVMScalar& scalar() const;
-  llvm::ArrayRef<LLVMScalar> vector() const;
-  llvm::ArrayRef<LLVMValue> aggregate() const;
-
-  size_t num_elements() const;
-  const LLVMScalar& element(size_t idx) const;
-  llvm::ArrayRef<LLVMScalar> elements() const;
-
-  size_t num_members() const;
-  const LLVMValue& member(size_t idx) const;
-  llvm::ArrayRef<LLVMValue> members() const;
-
-public:
-  explicit operator ContextValue() const;
-};
-
-/**
- * Map the elements composing any number of vectors to a new vector with the
- * same length. For this to work all vectors must have the same length otherwise
- * an assertion will fire.
- *
- * This is generally meant to match the semantics needed when implementing LLVM
- * opcodes.
- */
-template <typename F, typename... Vals>
-LLVMValue transform_elements(F&& func, const Vals&... values);
-
-/**
- * A LLVM value that is not an aggregate or a vector.
- *
- * Currently, this can be either
- * - a scalar expression, or
- * - a pointer
- */
-class LLVMScalar {
-public:
-  enum Kind { Expr, Pointer };
-
-private:
-  std::variant<OpRef, caffeine::Pointer> inner_;
-
-public:
-  LLVMScalar(const OpRef& value);
-  LLVMScalar(const caffeine::Pointer& value);
-
-  Kind kind() const;
-
-  bool is_expr() const;
-  bool is_pointer() const;
-
-  const OpRef& expr() const;
-  const caffeine::Pointer& pointer() const;
-};
-
-/**
- * A general LLVM value.
- *
- * This can be any one of:
- * - A scalar or pointer, or
- * - A vector of scalars or pointers, or
- * - An aggregate structure containing nested LLVMValues
- *
- * In terms of implementation, this is implemented by having a vector of either
- * LLVMValues (for aggregates) and LLVMScalars (for vectors and scalars). A
- * scalar is logically a vector of size 1 and this class follows that
- * convention.
- */
-class LLVMValue {
-public:
-  using OpVector = llvm::SmallVector<LLVMScalar, 4>;
-
-private:
-  enum { Vector, Aggregate };
-
-  std::variant<OpVector, std::vector<LLVMValue>> inner_;
-
-public:
   LLVMValue(const LLVMScalar& value);
   LLVMValue(OpVector&& values);
   LLVMValue(llvm::ArrayRef<LLVMScalar> values);
@@ -176,6 +89,9 @@ public:
   size_t num_members() const;
   const LLVMValue& member(size_t idx) const;
   llvm::ArrayRef<LLVMValue> members() const;
+
+public:
+  explicit operator ContextValue() const;
 };
 
 /**

--- a/include/caffeine/Interpreter/Value.h
+++ b/include/caffeine/Interpreter/Value.h
@@ -106,6 +106,90 @@ template <typename F, typename... Vals>
 LLVMValue transform_elements(F&& func, const Vals&... values);
 
 /**
+ * A LLVM value that is not an aggregate or a vector.
+ *
+ * Currently, this can be either
+ * - a scalar expression, or
+ * - a pointer
+ */
+class LLVMScalar {
+public:
+  enum Kind { Expr, Pointer };
+
+private:
+  std::variant<OpRef, caffeine::Pointer> inner_;
+
+public:
+  LLVMScalar(const OpRef& value);
+  LLVMScalar(const caffeine::Pointer& value);
+
+  Kind kind() const;
+
+  bool is_expr() const;
+  bool is_pointer() const;
+
+  const OpRef& expr() const;
+  const caffeine::Pointer& pointer() const;
+};
+
+/**
+ * A general LLVM value.
+ *
+ * This can be any one of:
+ * - A scalar or pointer, or
+ * - A vector of scalars or pointers, or
+ * - An aggregate structure containing nested LLVMValues
+ *
+ * In terms of implementation, this is implemented by having a vector of either
+ * LLVMValues (for aggregates) and LLVMScalars (for vectors and scalars). A
+ * scalar is logically a vector of size 1 and this class follows that
+ * convention.
+ */
+class LLVMValue {
+public:
+  using OpVector = llvm::SmallVector<LLVMScalar, 4>;
+
+private:
+  enum { Vector, Aggregate };
+
+  std::variant<OpVector, std::vector<LLVMValue>> inner_;
+
+public:
+  LLVMValue(const LLVMScalar& value);
+  LLVMValue(OpVector&& values);
+  LLVMValue(llvm::ArrayRef<LLVMScalar> values);
+  LLVMValue(llvm::ArrayRef<LLVMValue> values);
+  LLVMValue(std::vector<LLVMValue>&& values);
+
+  bool is_scalar() const;
+  bool is_vector() const;
+  bool is_aggregate() const;
+
+  const LLVMScalar& scalar() const;
+  llvm::ArrayRef<LLVMScalar> vector() const;
+  llvm::ArrayRef<LLVMValue> aggregate() const;
+
+  size_t num_elements() const;
+  const LLVMScalar& element(size_t idx) const;
+  llvm::ArrayRef<LLVMScalar> elements() const;
+
+  size_t num_members() const;
+  const LLVMValue& member(size_t idx) const;
+  llvm::ArrayRef<LLVMValue> members() const;
+};
+
+/**
+ * Map the elements composing any number of vectors to a new vector with the
+ * same length. For this to work all vectors must have the same length otherwise
+ * an assertion will fire.
+ *
+ * This is generally meant to match the semantics needed when implementing LLVM
+ * opcodes.
+ */
+template <typename F, typename... Vals>
+LLVMValue transform_elements(F&& func, const Vals&... values);
+
+/**
  * An LLVM value as represented within a stack frame.
  *
  * Can be either

--- a/include/caffeine/Interpreter/Value.h
+++ b/include/caffeine/Interpreter/Value.h
@@ -68,11 +68,11 @@ private:
   std::variant<OpVector, std::vector<LLVMValue>> inner_;
 
 public:
-  LLVMValue(const LLVMScalar& value);
-  LLVMValue(OpVector&& values);
-  LLVMValue(llvm::ArrayRef<LLVMScalar> values);
-  LLVMValue(llvm::ArrayRef<LLVMValue> values);
-  LLVMValue(std::vector<LLVMValue>&& values);
+  explicit LLVMValue(const LLVMScalar& value);
+  explicit LLVMValue(OpVector&& values);
+  explicit LLVMValue(llvm::ArrayRef<LLVMScalar> values);
+  explicit LLVMValue(llvm::ArrayRef<LLVMValue> values);
+  explicit LLVMValue(std::vector<LLVMValue>&& values);
 
   bool is_scalar() const;
   bool is_vector() const;

--- a/src/Interpreter/ExprEval.cpp
+++ b/src/Interpreter/ExprEval.cpp
@@ -61,6 +61,18 @@ LLVMValue ExprEvaluator::visit(llvm::Value& val) {
   return visit(&val);
 }
 
+std::optional<LLVMValue> ExprEvaluator::try_visit(llvm::Value* val) {
+  try {
+    return visit(val);
+  } catch (Unevaluatable&) {
+    return std::nullopt;
+  }
+}
+
+/*********************************************
+ * InstVisitor override methods              *
+ *********************************************/
+
 LLVMValue ExprEvaluator::visitInstruction(llvm::Instruction& inst) {
   std::string msg = "";
   llvm::raw_string_ostream os{msg};
@@ -70,10 +82,6 @@ LLVMValue ExprEvaluator::visitInstruction(llvm::Instruction& inst) {
       fmt::format("Instruction '{}' not implemented! Full expression: {}",
                   inst.getOpcodeName(), msg));
 }
-
-/*********************************************
- * InstVisitor override methods              *
- *********************************************/
 
 #define DECL_BINARY_OP_VISIT(opcode)                                           \
   LLVMValue ExprEvaluator::visit##opcode(llvm::BinaryOperator& op) {           \

--- a/src/Interpreter/ExprEval.cpp
+++ b/src/Interpreter/ExprEval.cpp
@@ -2,6 +2,7 @@
 
 #include "caffeine/Interpreter/Context.h"
 #include "caffeine/Interpreter/Value.h"
+#include "caffeine/Memory/MemHeap.h"
 #include <fmt/format.h>
 #include <llvm/IR/Constants.h>
 #include <llvm/IR/Instructions.h>

--- a/src/Interpreter/ExprEval.cpp
+++ b/src/Interpreter/ExprEval.cpp
@@ -35,6 +35,9 @@ LLVMValue ExprEvaluator::visit(llvm::Value* val) {
 
   CAFFEINE_ABORT(msg);
 }
+LLVMValue ExprEvaluator::visit(llvm::Value& val) {
+  return visit(&val);
+}
 
 LLVMValue ExprEvaluator::visitInstruction(llvm::Instruction& inst) {
   std::string msg = "";

--- a/src/Interpreter/ExprEval.cpp
+++ b/src/Interpreter/ExprEval.cpp
@@ -1,0 +1,119 @@
+#include "caffeine/Interpreter/ExprEval.h"
+
+#include "caffeine/Interpreter/Context.h"
+#include "caffeine/Interpreter/Value.h"
+#include <fmt/format.h>
+#include <llvm/IR/Constants.h>
+#include <llvm/IR/Instructions.h>
+#include <llvm/Support/raw_ostream.h>
+
+namespace caffeine {
+
+namespace {
+  OpRef scalarize(const LLVMScalar& scalar, const MemHeap& heap) {
+    if (scalar.is_expr())
+      return scalar.expr();
+    return scalar.pointer().value(heap);
+  }
+} // namespace
+
+ExprEvaluator::ExprEvaluator(Context* ctx, Options options)
+    : ctx(ctx), options(options) {}
+
+LLVMValue ExprEvaluator::visit(llvm::Value* val) {
+  const auto& frame = ctx->stack_top();
+  auto it = frame.variables.find(val);
+  if (it != frame.variables.end())
+    return static_cast<LLVMValue>(it->second);
+
+  if (auto* inst = llvm::dyn_cast<llvm::Instruction>(val))
+    return BaseType::visit(inst);
+
+  std::string msg = "Unsupported expression: ";
+  llvm::raw_string_ostream os{msg};
+  val->print(os, true);
+
+  CAFFEINE_ABORT(msg);
+}
+
+LLVMValue ExprEvaluator::visitInstruction(llvm::Instruction& inst) {
+  std::string msg = "";
+  llvm::raw_string_ostream os{msg};
+  inst.print(os, true);
+
+  CAFFEINE_ABORT(
+      fmt::format("Instruction '{}' not implemented! Full expression: {}",
+                  inst.getOpcodeName(), msg));
+}
+
+/*********************************************
+ * InstVisitor override methods              *
+ *********************************************/
+
+#define DECL_BINARY_OP_VISIT(opcode)                                           \
+  LLVMValue ExprEvaluator::visit##opcode(llvm::BinaryOperator& op) {           \
+    LLVMValue lhs = visit(op.getOperand(0));                                   \
+    LLVMValue rhs = visit(op.getOperand(1));                                   \
+                                                                               \
+    return transform_elements(                                                 \
+        [&](const LLVMScalar& lhs, const LLVMScalar& rhs) -> LLVMScalar {      \
+          const auto& heap = ctx->heap();                                      \
+          return BinaryOp::Create##opcode(scalarize(lhs, heap),                \
+                                          scalarize(rhs, heap));               \
+        },                                                                     \
+        lhs, rhs);                                                             \
+  }                                                                            \
+  static_assert(true)
+
+#define DECL_CAST_OP_VISIT(opcode, castname)                                   \
+  LLVMValue ExprEvaluator::visit##opcode(llvm::CastInst& op) {                 \
+    LLVMValue value = visit(op.getOperand(0));                                 \
+    Type type = Type::from_llvm(op.getType());                                 \
+                                                                               \
+    return transform_elements(                                                 \
+        [&](const LLVMScalar& value) -> LLVMScalar {                           \
+          return UnaryOp::Create##castname(type, value.expr());                \
+        },                                                                     \
+        value);                                                                \
+  }                                                                            \
+  static_assert(true)
+
+DECL_BINARY_OP_VISIT(Add);
+DECL_BINARY_OP_VISIT(Sub);
+DECL_BINARY_OP_VISIT(Mul);
+DECL_BINARY_OP_VISIT(UDiv);
+DECL_BINARY_OP_VISIT(SDiv);
+DECL_BINARY_OP_VISIT(URem);
+DECL_BINARY_OP_VISIT(SRem);
+
+DECL_BINARY_OP_VISIT(Shl);
+DECL_BINARY_OP_VISIT(LShr);
+DECL_BINARY_OP_VISIT(AShr);
+DECL_BINARY_OP_VISIT(And);
+DECL_BINARY_OP_VISIT(Or);
+DECL_BINARY_OP_VISIT(Xor);
+
+DECL_BINARY_OP_VISIT(FAdd);
+DECL_BINARY_OP_VISIT(FSub);
+DECL_BINARY_OP_VISIT(FMul);
+DECL_BINARY_OP_VISIT(FDiv);
+
+DECL_CAST_OP_VISIT(Trunc, Trunc);
+DECL_CAST_OP_VISIT(SExt, SExt);
+DECL_CAST_OP_VISIT(ZExt, ZExt);
+DECL_CAST_OP_VISIT(FPTrunc, FpTrunc);
+DECL_CAST_OP_VISIT(FPExt, FpExt);
+DECL_CAST_OP_VISIT(UIToFP, UIToFp);
+DECL_CAST_OP_VISIT(SIToFP, SIToFp);
+
+LLVMValue ExprEvaluator::visitFNeg(llvm::UnaryOperator& op) {
+  LLVMValue value = visit(op.getOperand(0));
+
+  return transform_elements(
+      [&](const LLVMScalar& value) -> LLVMScalar {
+        return UnaryOp::CreateFNeg(value.expr());
+      },
+      value);
+}
+
+} // namespace caffeine

--- a/src/Interpreter/ExprEval.cpp
+++ b/src/Interpreter/ExprEval.cpp
@@ -65,9 +65,7 @@ LLVMValue ExprEvaluator::visit(llvm::Value& val) {
 std::optional<LLVMValue> ExprEvaluator::try_visit(llvm::Value* val) {
   try {
     return visit(val);
-  } catch (Unevaluatable&) {
-    return std::nullopt;
-  }
+  } catch (Unevaluatable&) { return std::nullopt; }
 }
 
 /*********************************************

--- a/src/Interpreter/ExprEval.cpp
+++ b/src/Interpreter/ExprEval.cpp
@@ -17,6 +17,28 @@ namespace {
   }
 } // namespace
 
+ExprEvaluator::Unevaluatable::Unevaluatable(llvm::Value* expr,
+                                            const char* context)
+    : expr_(expr), context_(context) {
+  CAFFEINE_ASSERT(expr != nullptr);
+}
+
+const char* ExprEvaluator::Unevaluatable::what() const throw() {
+  if (msg_cache_.empty()) {
+    std::string printed;
+    llvm::raw_string_ostream os{printed};
+    expr_->print(os, true);
+
+    msg_cache_ = fmt::format(
+        "Unable to evaluate expression: {}. Expression: {}", context_, printed);
+  }
+
+  return msg_cache_.c_str();
+}
+llvm::Value* ExprEvaluator::Unevaluatable::expr() const {
+  return expr_;
+}
+
 ExprEvaluator::ExprEvaluator(Context* ctx, Options options)
     : ctx(ctx), options(options) {}
 

--- a/src/Interpreter/ExprEval.cpp
+++ b/src/Interpreter/ExprEval.cpp
@@ -138,6 +138,8 @@ DECL_CAST_OP_VISIT(FPTrunc, FpTrunc);
 DECL_CAST_OP_VISIT(FPExt, FpExt);
 DECL_CAST_OP_VISIT(UIToFP, UIToFp);
 DECL_CAST_OP_VISIT(SIToFP, SIToFp);
+DECL_CAST_OP_VISIT(FPToSI, FpToSI);
+DECL_CAST_OP_VISIT(FPToUI, FpToUI);
 
 LLVMValue ExprEvaluator::visitFNeg(llvm::UnaryOperator& op) {
   LLVMValue value = visit(op.getOperand(0));


### PR DESCRIPTION
This PR adds a visitor that generates `LLVMValue`s. It is intended to unify logic between CtxConstEval and Interpreter and eventually replace a decent chunk of both. Currently all that is implemented are some simple LLVM instruction opcodes. The next couple PRs will expand `ExprEvaluator` to support everything currently supported by the constant evaluation code.

This PR is part of the effort to redesign the whole interpreter (#202)

Depends on #228.