### PR TITLE
[6/N] Interpreter redesign - Implement vector broadcast for LLVMValue

### DIFF
--- a/include/caffeine/Interpreter/Value.h
+++ b/include/caffeine/Interpreter/Value.h
@@ -41,6 +41,9 @@ public:
   const OpRef& expr() const;
   const caffeine::Pointer& pointer() const;
 
+  // Create a vector consisting of n copies of this scalar.
+  LLVMValue broadcast(size_t width) const;
+
 public:
   explicit operator ContextValue() const;
 };

--- a/src/Interpreter/Value.cpp
+++ b/src/Interpreter/Value.cpp
@@ -24,6 +24,10 @@ LLVMValue::operator ContextValue() const {
   return ContextValue(std::move(values));
 }
 
+LLVMValue LLVMScalar::broadcast(size_t width) const {
+  return LLVMValue(LLVMValue::OpVector(width, *this));
+}
+
 ContextValue::operator LLVMScalar() const {
   if (is_scalar())
     return LLVMScalar(scalar());


### PR DESCRIPTION
This PR adds a `broadcast` method to `LLVMScalar` which can be used to create a vector of containing the scalar repeated `n` times.

Depends on #228