### PR TITLE
Handle the case where this is null in DebugPrint

### DIFF
--- a/src/IR/Debug.cpp
+++ b/src/IR/Debug.cpp
@@ -3,8 +3,16 @@
 #include <iostream>
 
 namespace caffeine {
+
+namespace {
+  // Separate method to silence warnings
+  bool is_nonnull(const void* x) {
+    return x;
+  }
+} // namespace
+
 void Operation::DebugPrint() const {
-  if ((void*)this) {
+  if (is_nonnull(this)) {
     std::cout << *this << std::endl;
   } else {
     std::cout << "NULL" << std::endl;

--- a/src/IR/Debug.cpp
+++ b/src/IR/Debug.cpp
@@ -4,6 +4,10 @@
 
 namespace caffeine {
 void Operation::DebugPrint() const {
-  std::cout << *this << std::endl;
+  if ((void*)this) {
+    std::cout << *this << std::endl;
+  } else {
+    std::cout << "NULL" << std::endl;
+  }
 }
 } // namespace caffeine


### PR DESCRIPTION
It should never be possible to have this happen in C++ but it's more useful to have DebugPrint print NULL when calling it in the debugger than causing a segfault in the middle of your debug session.

I ran into this while debugging and figured I'd fix it for good.