### PR TITLE
Implement operator<< overloads for LLVMValue and LLVMScalar

### DIFF
--- a/include/caffeine/Interpreter/Value.h
+++ b/include/caffeine/Interpreter/Value.h
@@ -190,6 +190,8 @@ template <typename F, typename... Vs>
 ContextValue transform_value(F&& func, const Vs&... values);
 
 std::ostream& operator<<(std::ostream& os, const ContextValue& value);
+std::ostream& operator<<(std::ostream& os, const LLVMScalar& value);
+std::ostream& operator<<(std::ostream& os, const LLVMValue& value);
 
 } // namespace caffeine
 

--- a/src/Interpreter/Value.cpp
+++ b/src/Interpreter/Value.cpp
@@ -137,4 +137,52 @@ std::ostream& operator<<(std::ostream& os, const ContextValue& value) {
   return os << ">";
 }
 
+std::ostream& operator<<(std::ostream& os, const LLVMScalar& value) {
+  if (value.is_pointer()) {
+    const Pointer& ptr = value.pointer();
+
+    if (ptr.is_resolved())
+      return os << "[" << ptr.alloc().first << " offset " << *ptr.offset()
+                << "]";
+    return os << "[" << *ptr.offset() << "]";
+  }
+
+  return os << *value.expr();
+}
+
+std::ostream& operator<<(std::ostream& os, const LLVMValue& value) {
+  if (value.is_scalar())
+    return os << value.scalar();
+
+  if (value.is_vector()) {
+    os << "<";
+    bool is_first = true;
+
+    for (const auto& val : value.elements()) {
+      if (is_first)
+        is_first = false;
+      else
+        os << ",\n ";
+
+      os << val;
+    }
+
+    return os << ">";
+  } else {
+    os << "{";
+    bool is_first = true;
+
+    for (const auto& val : value.members()) {
+      if (is_first)
+        is_first = false;
+      else
+        os << ",\n ";
+
+      os << val;
+    }
+
+    return os << "}";
+  }
+}
+
 } // namespace caffeine


### PR DESCRIPTION
As in title. Should mirror the printing format of `ContextValue`.

Depends on #228 