### PR TITLE
[10/N] Interpreter redesign - Clean up Context and StackFrame

### DIFF
--- a/include/caffeine/Interpreter/Context.h
+++ b/include/caffeine/Interpreter/Context.h
@@ -72,10 +72,6 @@ public:
    */
   uint64_t next_constant();
 
-  llvm::Module* llvm_module() const {
-    return mod;
-  }
-
   /**
    * Add a new assertion to this context.
    */

--- a/include/caffeine/Interpreter/Context.h
+++ b/include/caffeine/Interpreter/Context.h
@@ -20,15 +20,17 @@ class GlobalVariable;
 namespace caffeine {
 
 class Context {
+public:
+  std::vector<StackFrame> stack;
+  std::unordered_map<llvm::GlobalVariable*, ContextValue> globals;
+  std::shared_ptr<Solver> solver;
+  MemHeap heap;
+  std::vector<Assertion> assertions;
+
+  llvm::Module* mod;
+
 private:
-  std::vector<StackFrame> stack_;
-  // The current set of invariants for this context
-  std::vector<Assertion> assertions_;
-  std::unordered_map<llvm::GlobalVariable*, ContextValue> globals_;
-  std::shared_ptr<Solver> solver_;
   uint64_t constant_num_ = 0;
-  MemHeap heap_;
-  llvm::Module* module_;
 
 public:
   Context(llvm::Function* func, std::shared_ptr<Solver> solver);
@@ -49,8 +51,6 @@ public:
   const StackFrame& stack_top() const;
   StackFrame& stack_top();
 
-  const std::vector<StackFrame>& stack() const;
-
   // Utility methods for adding/removing stack frames
   /**
    * Note: This method also deallocates all stack-allocated allocations within
@@ -63,11 +63,6 @@ public:
   // Does this context have any stack frames?
   bool empty() const;
 
-  std::shared_ptr<Solver> solver() const;
-
-  llvm::iterator_range<std::vector<Assertion>::const_iterator>
-  assertions() const;
-
   /**
    * Get a unique constant number among all of the ones in this context.
    *
@@ -77,18 +72,8 @@ public:
    */
   uint64_t next_constant();
 
-  /**
-   * Access the context heap.
-   */
-  MemHeap& heap() {
-    return heap_;
-  }
-  const MemHeap& heap() const {
-    return heap_;
-  }
-
   llvm::Module* llvm_module() const {
-    return module_;
+    return mod;
   }
 
   /**

--- a/include/caffeine/Interpreter/StackFrame.h
+++ b/include/caffeine/Interpreter/StackFrame.h
@@ -16,10 +16,9 @@ namespace caffeine {
 class Context;
 
 class StackFrame {
-private:
-  std::unordered_map<llvm::Value*, ContextValue> variables;
-
 public:
+  std::unordered_map<llvm::Value*, LLVMValue> variables;
+
   /**
    * Iterators used by Interpreter::execute
    */
@@ -46,25 +45,7 @@ public:
    */
   void insert(llvm::Value* value, const OpRef& expr);
   void insert(llvm::Value* value, const ContextValue& exprs);
-
-  /**
-   * Lookup a value within the current stack frame.
-   *
-   * There are two main cases here:
-   * 1. `value` is an existing variable
-   * 2. `value` is a constant
-   *
-   * In the first case we just look up the variable the `variables` map
-   * and then return it. In the second case we build an expression
-   * that represents the constant and return that.
-   *
-   * This method should be preferred over directly interacting with
-   * `variables` as it correctly handles constants.
-   */
-  ContextValue lookup(llvm::Value* value) const;
-
-private:
-  friend class ExprEvaluator;
+  void insert(llvm::Value* value, const LLVMValue& exprs);
 };
 
 } // namespace caffeine

--- a/src/Interpreter/ExprEval.cpp
+++ b/src/Interpreter/ExprEval.cpp
@@ -52,7 +52,7 @@ LLVMValue ExprEvaluator::visit(llvm::Value* val) {
   const auto& frame = ctx->stack_top();
   auto it = frame.variables.find(val);
   if (it != frame.variables.end())
-    return static_cast<LLVMValue>(it->second);
+    return it->second;
 
   if (auto* inst = llvm::dyn_cast<llvm::Instruction>(val))
     return BaseType::visit(inst);

--- a/src/Interpreter/ExprEval.cpp
+++ b/src/Interpreter/ExprEval.cpp
@@ -316,8 +316,8 @@ LLVMValue ExprEvaluator::visitConstantVector(llvm::ConstantVector& vec) {
 }
 
 LLVMValue ExprEvaluator::visitGlobalVariable(llvm::GlobalVariable& global) {
-  auto it = ctx->globals_.find(&global);
-  if (it != ctx->globals_.end())
+  auto it = ctx->globals.find(&global);
+  if (it != ctx->globals.end())
     return (LLVMValue)it->second;
 
   if (!options.create_allocations) {
@@ -337,14 +337,14 @@ LLVMValue ExprEvaluator::visitGlobalVariable(llvm::GlobalVariable& global) {
   unsigned bitwidth = layout.getPointerSizeInBits();
   unsigned alignment = global.getAlignment();
 
-  auto alloc = ctx->heap().allocate(
+  auto alloc = ctx->heap.allocate(
       array.size(), ConstantInt::Create(llvm::APInt(bitwidth, alignment)), data,
       AllocationKind::Global, *ctx);
 
   auto pointer = LLVMValue(
       Pointer(alloc, ConstantInt::Create(llvm::APInt::getNullValue(bitwidth))));
 
-  ctx->globals_.emplace(&global, (ContextValue)pointer);
+  ctx->globals.emplace(&global, (ContextValue)pointer);
 
   return pointer;
 }
@@ -361,7 +361,7 @@ OpRef ExprEvaluator::visitGlobalData(llvm::Constant& constant, unsigned AS) {
   Allocation alloc{ConstantInt::CreateZero(bitwidth), size,
                    AllocOp::Create(size, ConstantInt::CreateZero(8)),
                    AllocationKind::Alloca};
-  alloc.write(ConstantInt::CreateZero(bitwidth), type, value, ctx->heap(),
+  alloc.write(ConstantInt::CreateZero(bitwidth), type, value, ctx->heap,
               layout);
 
   return alloc.data();
@@ -391,7 +391,7 @@ LLVMValue ExprEvaluator::visitInstruction(llvm::Instruction& inst) {
                                                                                \
     return transform_elements(                                                 \
         [&](const LLVMScalar& lhs, const LLVMScalar& rhs) -> LLVMScalar {      \
-          const auto& heap = ctx->heap();                                      \
+          const auto& heap = ctx->heap;                                        \
           return BinaryOp::Create##opcode(scalarize(lhs, heap),                \
                                           scalarize(rhs, heap));               \
         },                                                                     \
@@ -457,7 +457,7 @@ LLVMValue ExprEvaluator::visitPtrToInt(llvm::PtrToIntInst& inst) {
       [&](const LLVMScalar& value) {
         return LLVMScalar(
             UnaryOp::CreateTruncOrZExt(Type::from_llvm(inst.getType()),
-                                       value.pointer().value(ctx->heap())));
+                                       value.pointer().value(ctx->heap)));
       },
       visit(inst.getOperand(0)));
 }

--- a/src/Interpreter/ExprEval.cpp
+++ b/src/Interpreter/ExprEval.cpp
@@ -453,20 +453,18 @@ LLVMValue ExprEvaluator::visitFNeg(llvm::UnaryOperator& op) {
 }
 
 LLVMValue ExprEvaluator::visitPtrToInt(llvm::PtrToIntInst& inst) {
-  const auto& layout = ctx->mod->getDataLayout();
   return transform_elements(
       [&](const LLVMScalar& value) {
-        return LLVMScalar(
-            UnaryOp::CreateTruncOrZExt(Type::from_llvm(inst.getType()),
-                                       value.pointer().value(ctx->heap)));
+        return LLVMScalar(UnaryOp::CreateTruncOrZExt(
+            Type::from_llvm(inst.getType()), value.pointer().value(ctx->heap)));
       },
       visit(inst.getOperand(0)));
 }
 LLVMValue ExprEvaluator::visitIntToPtr(llvm::IntToPtrInst& inst) {
-  const auto& layout = ctx->llvm_module()->getDataLayout();
-
+  const auto& layout = ctx->mod->getDataLayout();
   unsigned pointer_size =
       layout.getPointerSizeInBits(inst.getType()->getPointerAddressSpace());
+
   return transform_elements(
       [&](const LLVMScalar& value) {
         return LLVMScalar(Pointer(UnaryOp::CreateTruncOrZExt(
@@ -552,7 +550,7 @@ LLVMValue ExprEvaluator::visitGetElementPtr(llvm::GetElementPtrInst& inst) {
                          BinaryOp::CreateAdd(ptr.offset(), offset.expr()));
         } else {
           return Pointer(
-              BinaryOp::CreateAdd(ptr.value(ctx->heap()), offset.expr()));
+              BinaryOp::CreateAdd(ptr.value(ctx->heap), offset.expr()));
         }
       },
       base, offsets);

--- a/src/Interpreter/ExprEval.cpp
+++ b/src/Interpreter/ExprEval.cpp
@@ -199,7 +199,7 @@ LLVMValue ExprEvaluator::visitConstantFP(llvm::ConstantFP& cnst) {
 
 LLVMValue
 ExprEvaluator::visitConstantPointerNull(llvm::ConstantPointerNull& null) {
-  const auto& layout = ctx->llvm_module()->getDataLayout();
+  const auto& layout = ctx->mod->getDataLayout();
   unsigned bitwidth =
       layout.getPointerSizeInBits(null.getType()->getPointerAddressSpace());
 
@@ -261,7 +261,7 @@ LLVMValue ExprEvaluator::visitUndefValue(llvm::UndefValue& undef) {
   }
 
   if (type->isPointerTy()) {
-    const auto& layout = ctx->llvm_module()->getDataLayout();
+    const auto& layout = ctx->mod->getDataLayout();
     unsigned bitwidth =
         layout.getPointerSizeInBits(type->getPointerAddressSpace());
 
@@ -333,7 +333,7 @@ LLVMValue ExprEvaluator::visitGlobalVariable(llvm::GlobalVariable& global) {
       visitGlobalData(*global.getInitializer(), global.getAddressSpace());
   const auto& array = llvm::cast<ArrayBase>(*data);
 
-  const llvm::DataLayout& layout = ctx->llvm_module()->getDataLayout();
+  const llvm::DataLayout& layout = ctx->mod->getDataLayout();
   unsigned bitwidth = layout.getPointerSizeInBits();
   unsigned alignment = global.getAlignment();
 
@@ -351,7 +351,7 @@ LLVMValue ExprEvaluator::visitGlobalVariable(llvm::GlobalVariable& global) {
 
 OpRef ExprEvaluator::visitGlobalData(llvm::Constant& constant, unsigned AS) {
   llvm::Type* type = constant.getType();
-  const llvm::DataLayout& layout = ctx->llvm_module()->getDataLayout();
+  const llvm::DataLayout& layout = ctx->mod->getDataLayout();
   unsigned bitwidth = layout.getPointerSizeInBits(AS);
 
   LLVMValue value = visit(&constant);
@@ -453,6 +453,7 @@ LLVMValue ExprEvaluator::visitFNeg(llvm::UnaryOperator& op) {
 }
 
 LLVMValue ExprEvaluator::visitPtrToInt(llvm::PtrToIntInst& inst) {
+  const auto& layout = ctx->mod->getDataLayout();
   return transform_elements(
       [&](const LLVMScalar& value) {
         return LLVMScalar(
@@ -479,7 +480,7 @@ LLVMValue ExprEvaluator::visitBitCast(llvm::BitCastInst& inst) {
 }
 
 LLVMValue ExprEvaluator::visitGetElementPtr(llvm::GetElementPtrInst& inst) {
-  const llvm::DataLayout& layout = ctx->llvm_module()->getDataLayout();
+  const llvm::DataLayout& layout = ctx->mod->getDataLayout();
 
   size_t offset_elements = 1;
   for (auto it = llvm::gep_type_begin(inst), end = llvm::gep_type_end(inst);

--- a/src/Interpreter/PrintingFailureLogger.cpp
+++ b/src/Interpreter/PrintingFailureLogger.cpp
@@ -76,7 +76,7 @@ PrintingFailureLogger::PrintingFailureLogger(std::ostream& os) : os(&os) {}
 
 static void print_context_backtrace(std::ostream& os, const Context& ctx) {
   size_t i = 0;
-  const auto& stack = ctx.stack();
+  const auto& stack = ctx.stack;
 
   for (const auto& frame : boost::adaptors::reverse(stack)) {
     llvm::Function* func = frame.current_block->getParent();
@@ -94,7 +94,7 @@ void PrintingFailureLogger::log_failure(const Model& model, const Context& ctx,
 
   *os << "Found assertion failure:\n";
 
-  for (const auto& assertion : ctx.assertions()) {
+  for (const auto& assertion : ctx.assertions) {
     printer.visit(*assertion.value());
   }
   printer.visit(*failure.check.value());

--- a/src/Interpreter/StackFrame.cpp
+++ b/src/Interpreter/StackFrame.cpp
@@ -22,13 +22,10 @@ void StackFrame::insert(llvm::Value* value, const OpRef& expr) {
   insert(value, ContextValue{expr});
 }
 void StackFrame::insert(llvm::Value* value, const ContextValue& exprs) {
-  variables.insert_or_assign(value, exprs);
+  variables.insert_or_assign(value, (LLVMValue)exprs);
 }
-
-ContextValue StackFrame::lookup(llvm::Value* value) const {
-  auto it = variables.find(value);
-  CAFFEINE_ASSERT(it != variables.end(), "Tried to access unknown variable");
-  return it->second;
+void StackFrame::insert(llvm::Value* value, const LLVMValue& exprs) {
+  variables.insert_or_assign(value, exprs);
 }
 
 } // namespace caffeine

--- a/src/Solver/Solver.cpp
+++ b/src/Solver/Solver.cpp
@@ -131,7 +131,7 @@ Value Model::evaluate(const ContextValue& expr, Context& ctx) const {
   if (expr.is_scalar()) {
     return ExprEvaluator(this).visit(*expr.scalar());
   } else if (expr.is_pointer()) {
-    auto ptr_val = expr.pointer().value(ctx.heap());
+    auto ptr_val = expr.pointer().value(ctx.heap);
     return ExprEvaluator(this).visit(*ptr_val);
   } else if (expr.is_vector()) {
     const auto& vec = expr.vector();


### PR DESCRIPTION
This makes a number of members of both `Context` and `StackFrame` and then cleans up the code that needs to be changed because of that.

Note that most of these were already effectively public due to the accessor methods available so this mostly just makes things cleaner.

This PR is part of the effort to redesign the whole interpreter (#202).

/stack #238 