### PR TITLE
Optimize cmake configure step

### DIFF
--- a/cmake/CaffeineDependencies.cmake
+++ b/cmake/CaffeineDependencies.cmake
@@ -1,5 +1,7 @@
 
-find_package(magic_enum 0.7.2 QUIET)
+if (NOT magic_enum_NO_PACKAGE_FOUND)
+  find_package(magic_enum 0.7.2 QUIET)
+endif()
 
 if (NOT magic_enum_FOUND)
   include(FetchContent)
@@ -12,4 +14,6 @@ if (NOT magic_enum_FOUND)
   )
 
   FetchContent_MakeAvailable(magic_enum)
+
+  set(magic_enum_NO_PACKAGE_FOUND TRUE CACHE INTERNAL "")
 endif()

--- a/cmake/FindZ3.cmake
+++ b/cmake/FindZ3.cmake
@@ -1,136 +1,89 @@
 
 include(FindPackageHandleStandardArgs)
 
-# First check for an existing Z3 installation with a working
-# config file. If we can find that then we don't need to do
-# the rest of this.
-find_package(Z3 ${Z3_FIND_VERSION} QUIET CONFIG)
+if (NOT Z3_SEARCH_NO_FOUND_MODULE)
+  find_package(Z3 QUIET NO_MODULE)
+endif()
 
-if(Z3_FOUND)
+if (Z3_FOUND)
+  find_package_handle_standard_args(Z3 CONFIG_MODE)
+
+  set(Z3_LIBRARIES    z3::libz3)
   set(Z3_INCLUDE_DIRS "${Z3_C_INCLUDE_DIR}" "${Z3_CXX_INCLUDE_DIR}")
+  list(REMOVE_DUPLICATES Z3_INCLUDE_DIRS)
 
   target_include_directories(z3::libz3 INTERFACE "${Z3_INCLUDE_DIRS}")
-  
-  # Z3_LIBRARY doesn't seem to get set. We'll use our own status message
-  # instead.
-  if(NOT Z3_FIND_QUIETLY)
-    message(STATUS "Found Z3: version \"${Z3_VERSION}\"")
-  endif()
-
-  return()
-else()
-  unset(Z3_FOUND)
-endif()
-
-# The default Z3 config has separate C and C++ include directories.
-# I've duplicated that here.
-if(Z3_DIR)
-  find_path(Z3_C_INCLUDE_DIR   NAMES z3.h   PATHS "${Z3_DIR}/include" NO_DEFAULT_PATH)
-  find_path(Z3_CXX_INCLUDE_DIR NAMES z3++.h PATHS "${Z3_DIR}/include" NO_DEFAULT_PATH)
-else()
-  find_path(Z3_C_INCLUDE_DIR   NAMES z3.h)
-  find_path(Z3_CXX_INCLUDE_DIR NAMES z3++.h)
-endif()
-
-if(Z3_DIR)
-  find_library(Z3_LIBRARY NAMES z3 PATHS "${Z3_DIR}/lib" NO_DEFAULT_PATH)
-else()
-  find_library(Z3_LIBRARY NAMES z3)
-endif()
-
-if(NOT (Z3_C_INCLUDE_DIR AND Z3_CXX_INCLUDE_DIR AND Z3_LIBRARY))
-  unset(Z3_C_INCLUDE_DIR   CACHE)
-  unset(Z3_CXX_INCLUDE_DIR CACHE)
-  unset(Z3_LIBRARY         CACHE)
-
-  find_package_handle_standard_args(
-    Z3
-    DEFAULT_MSG
-    Z3_LIBRARY Z3_C_INCLUDE_DIR Z3_CXX_INCLUDE_DIR
-  )
-  return()
-endif()
-
-# We need to somehow check the Z3 version. The easiest way to do this
-# is to just get it from Z3 itself.
-#
-# Unfortunately, this means that we need to actually run a program.
-# If we want to cross-compile anything then it'll be necessary to
-# revisit this and figure out some alternate way to do this.
-# It might be practical to parse out the version numbers from the
-# Z3 headers in that case.
-file(WRITE "${CMAKE_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/CMakeTmp/z3.c" "
-  #include <stdio.h>
-  #include \"z3.h\"
-  int main() {
-    unsigned major, minor, build_number, revision_number;
-    Z3_get_version(&major, &minor, &build_number, &revision_number);
-    printf(\"%u.%u.%u.%u\\n\", major, minor, build_number, revision_number);
-    return 0;
-  }
-")
-
-try_run(
-  VERSION_TEST_EXITCODE
-  VERSION_TEST_COMPILED
-  "${CMAKE_BINARY_DIR}/CMakeTmp/"
-  "${CMAKE_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/CMakeTmp/z3.c"
-  COMPILE_DEFINITIONS "-I${Z3_C_INCLUDE_DIR}"
-  LINK_LIBRARIES "${Z3_LIBRARY}" "${GMP_LIBRARY}"
-  CMAKE_FLAGS -DCMAKE_SKIP_RPATH:BOOL=${CMAKE_SKIP_RPATH}
-  RUN_OUTPUT_VARIABLE VERSION_TEST_RUN_OUTPUT
-)
-
-if ((NOT VERSION_TEST_COMPILED) OR NOT ("${VERSION_TEST_EXITCODE}" EQUAL 0))
-  unset(Z3_C_INCLUDE_DIR   CACHE)
-  unset(Z3_CXX_INCLUDE_DIR CACHE)
-  unset(Z3_LIBRARY         CACHE)
-  
-  find_package_handle_standard_args(
-    Z3
-    DEFAULT_MSG
-    Z3_LIBRARY Z3_C_INCLUDE_DIR Z3_CXX_INCLUDE_DIR
-  )
 
   return()
 endif()
 
-if ("${VERSION_TEST_RUN_OUTPUT}" MATCHES "([0-9]+\\.[0-9]+\\.[0-9]+\\.[0-9]+)")
-  set(Z3_VERSION "${CMAKE_MATCH_1}")
-else()
-  set(Z3_VERSION "0.0.0.0")
-endif()
+find_path(Z3_C_INCLUDE_DIR   NAMES z3.h)
+find_path(Z3_CXX_INCLUDE_DIR NAMES z3++.h)
+find_library(Z3_LIBRARY      NAMES z3)
 
-if (
-  ("${Z3_VERSION}" VERSION_LESS "${Z3_FIND_VERSION}") OR
-  (Z3_FIND_VERSION_EXACT AND NOT "${Z3_VERSON}" VERSION_EQUAL "${Z3_FIND_VERSION}")
-)
-  unset(Z3_C_INCLUDE_DIR   CACHE)
-  unset(Z3_CXX_INCLUDE_DIR CACHE)
-  unset(Z3_LIBRARY         CACHE)
+mark_as_advanced(Z3_C_INCLUDE_DIR Z3_CXX_INCLUDE_DIR Z3_LIBRARY)
 
+if (NOT (Z3_C_INCLUDE_DIR AND Z3_CXX_INCLUDE_DIR AND Z3_LIBRARY))
   find_package_handle_standard_args(
     Z3
     REQUIRED_VARS Z3_LIBRARY Z3_C_INCLUDE_DIR Z3_CXX_INCLUDE_DIR
-    VERSION_VAR Z3_VERSION
   )
 endif()
 
-set(Z3_LIBRARIES z3::libz3)
+set(Z3_LIBRARIES    z3::libz3)
 set(Z3_INCLUDE_DIRS "${Z3_C_INCLUDE_DIR}" "${Z3_CXX_INCLUDE_DIR}")
+list(REMOVE_DUPLICATES Z3_INCLUDE_DIRS)
 
-add_library(z3::libz3 UNKNOWN IMPORTED)
-set_target_properties(z3::libz3 PROPERTIES
-  IMPORTED_LOCATION "${Z3_LIBRARY}"
-  INTERFACE_INCLUDE_DIRECTORIES "${Z3_INCLUDE_DIRS}"
-)
+if (NOT Z3_VERSION)
+  # We need to somehow check the Z3 version. The easiest way to do this
+  # is to just get it from Z3 itself.
+  #
+  # Unfortunately, this means that we need to actually run a program.
+  # If we want to cross-compile anything then it'll be necessary to
+  # revisit this and figure out some alternate way to do this.
+  # It might be practical to parse out the version numbers from the
+  # Z3 headers in that case.
+  file(WRITE "${CMAKE_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/CMakeTmp/z3.c" "
+    #include <stdio.h>
+    #include \"z3.h\"
+    int main() {
+      unsigned major, minor, build_number, revision_number;
+      Z3_get_version(&major, &minor, &build_number, &revision_number);
+      printf(\"%u.%u.%u.%u\\n\", major, minor, build_number, revision_number);
+      return 0;
+    }
+  ")
+
+  try_run(
+    VERSION_TEST_EXITCODE
+    VERSION_TEST_COMPILED
+    "${CMAKE_BINARY_DIR}/CMakeTmp/"
+    "${CMAKE_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/CMakeTmp/z3.c"
+    COMPILE_DEFINITIONS "-I${Z3_C_INCLUDE_DIR}"
+    LINK_LIBRARIES "${Z3_LIBRARY}" "${GMP_LIBRARY}"
+    CMAKE_FLAGS -DCMAKE_SKIP_RPATH:BOOL=${CMAKE_SKIP_RPATH}
+    RUN_OUTPUT_VARIABLE VERSION_TEST_RUN_OUTPUT
+  )
+
+  if ("${VERSION_TEST_RUN_OUTPUT}" MATCHES "([0-9]+\\.[0-9]+\\.[0-9]+\\.[0-9]+)")
+    set(Z3_VERSION "${CMAKE_MATCH_1}" CACHE INTERNAL "")
+  else()
+    set(Z3_VERSION "0.0.0.0" CACHE INTERNAL "")
+  endif()
+endif()
 
 find_package_handle_standard_args(
   Z3
-  REQUIRED_VARS Z3_INCLUDE_DIRS Z3_LIBRARIES
+  REQUIRED_VARS Z3_INCLUDE_DIRS
   VERSION_VAR Z3_VERSION
 )
 
-mark_as_advanced(
-  Z3_LIBRARY Z3_LIBRARIES Z3_C_INCLUDE_DIR Z3_CXX_INCLUDE_DIR
-)
+if (Z3_FOUND)
+  add_library(z3::libz3 UNKNOWN IMPORTED)
+  set_target_properties(z3::libz3 PROPERTIES
+    IMPORTED_LOCATION "${Z3_LIBRARY}"
+    INTERFACE_INCLUDE_DIRECTORIES "${Z3_INCLUDE_DIRS}"
+  )
+
+  set(Z3_SEARCH_NO_FOUND_MODULE TRUE CACHE INTERNAL "")
+endif()


### PR DESCRIPTION
The main contributors that I found to cmake configure being slow were two different non-required calls to find_package that didn't succeed. These took on the order of a few hundred milliseconds which noticably slowed down the configure step.

To remedy this I cached the failure value in cases where the find_package calls failed but we were able to successfully find the library somewhere else. This seems to have halved the time we spend on running cmake configures when I try it locally.

This was annoying me so I decided to go and fix it.