### PR TITLE
Optimize format target by splitting it into multiple internal targets

### DIFF
--- a/cmake/CaffeineFormatting.cmake
+++ b/cmake/CaffeineFormatting.cmake
@@ -46,7 +46,6 @@ foreach(source ${fmt_sources})
     COMMAND ${CMAKE_COMMAND} -E make_directory "${stamp_dir}/${source_dir}"
     COMMAND ${CLANG_FORMAT} -i "${CMAKE_SOURCE_DIR}/${source}"
     COMMAND ${CMAKE_COMMAND} -E touch "${stamp_dir}/${source}"
-    COMMAND diff --color=always -u "${stamp_dir}/${source}" "${stamp_dir}/${source}"
     DEPENDS "${CMAKE_SOURCE_DIR}/${source}"
     COMMENT "Formatting ${source}"
     WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}"


### PR DESCRIPTION
This allows it to run faster when you've only changed a few files.

I don't have hard numbers but previously running a format always took on the order of about 10 seconds for me but now it takes ~2s even with the yarpgen files that I have in my repo (which are usually slower to format).

You still only have to run `make format` but now it can parallelize the individual calls to `clang-format`