### PR TITLE
[11/N] Interpreter redesign - Use ExprEvaluator to implement simple operations within Interpreter

### DIFF
--- a/include/caffeine/Interpreter/ExprEval.h
+++ b/include/caffeine/Interpreter/ExprEval.h
@@ -50,6 +50,9 @@ public:
   LLVMValue visit(llvm::Value* val);
   LLVMValue visit(llvm::Value& val);
 
+  LLVMValue evaluate(llvm::Value* val);
+  LLVMValue evaluate(llvm::Value& val);
+
   std::optional<LLVMValue> try_visit(llvm::Value* val);
 
   /*********************************************

--- a/include/caffeine/Interpreter/Interpreter.h
+++ b/include/caffeine/Interpreter/Interpreter.h
@@ -34,38 +34,17 @@ public:
 
   ExecutionResult visitInstruction(llvm::Instruction& inst);
 
-  ExecutionResult visitAdd(llvm::BinaryOperator& op);
-  ExecutionResult visitSub(llvm::BinaryOperator& op);
-  ExecutionResult visitMul(llvm::BinaryOperator& op);
+  ExecutionResult visitBinaryOperator(llvm::BinaryOperator& op);
+  ExecutionResult visitUnaryOperator(llvm::UnaryOperator& op);
+  ExecutionResult visitCastInst(llvm::CastInst& op);
+
   ExecutionResult visitUDiv(llvm::BinaryOperator& op);
   ExecutionResult visitSDiv(llvm::BinaryOperator& op);
   ExecutionResult visitURem(llvm::BinaryOperator& op);
   ExecutionResult visitSRem(llvm::BinaryOperator& op);
 
-  ExecutionResult visitShl(llvm::BinaryOperator& op);
-  ExecutionResult visitLShr(llvm::BinaryOperator& op);
-  ExecutionResult visitAShr(llvm::BinaryOperator& op);
-  ExecutionResult visitAnd(llvm::BinaryOperator& op);
-  ExecutionResult visitOr(llvm::BinaryOperator& op);
-  ExecutionResult visitXor(llvm::BinaryOperator& op);
-  ExecutionResult visitNot(llvm::BinaryOperator& op);
-
-  ExecutionResult visitFAdd(llvm::BinaryOperator& op);
-  ExecutionResult visitFSub(llvm::BinaryOperator& op);
-  ExecutionResult visitFMul(llvm::BinaryOperator& op);
-  ExecutionResult visitFDiv(llvm::BinaryOperator& op);
-
   ExecutionResult visitICmpInst(llvm::ICmpInst& icmp);
   ExecutionResult visitFCmpInst(llvm::FCmpInst& fcmp);
-
-  ExecutionResult visitTrunc(llvm::TruncInst& trunc);
-
-  ExecutionResult visitSExt(llvm::SExtInst& sext);
-  ExecutionResult visitZExt(llvm::ZExtInst& zext);
-  ExecutionResult visitIntToPtrInst(llvm::IntToPtrInst& inttoptr);
-  ExecutionResult visitPtrToIntInst(llvm::PtrToIntInst& ptrtoint);
-
-  ExecutionResult visitBitCastInst(llvm::BitCastInst& bitcast);
 
   ExecutionResult visitPHINode(llvm::PHINode& node);
   ExecutionResult visitBranchInst(llvm::BranchInst& inst);

--- a/src/Interpreter/ExprEval.cpp
+++ b/src/Interpreter/ExprEval.cpp
@@ -447,7 +447,6 @@ LLVMValue ExprEvaluator::visitFNeg(llvm::UnaryOperator& op) {
 }
 
 LLVMValue ExprEvaluator::visitPtrToInt(llvm::PtrToIntInst& inst) {
-  const auto& layout = ctx->mod->getDataLayout();
   return transform_elements(
       [&](const LLVMScalar& value) {
         return LLVMScalar(UnaryOp::CreateTruncOrZExt(

--- a/src/Interpreter/ExprEval.cpp
+++ b/src/Interpreter/ExprEval.cpp
@@ -453,7 +453,6 @@ LLVMValue ExprEvaluator::visitFNeg(llvm::UnaryOperator& op) {
 }
 
 LLVMValue ExprEvaluator::visitPtrToInt(llvm::PtrToIntInst& inst) {
-  const auto& layout = ctx->mod->getDataLayout();
   return transform_elements(
       [&](const LLVMScalar& value) {
         return LLVMScalar(UnaryOp::CreateTruncOrZExt(

--- a/src/Interpreter/ExprEval.cpp
+++ b/src/Interpreter/ExprEval.cpp
@@ -3,7 +3,9 @@
 #include "caffeine/Interpreter/Context.h"
 #include "caffeine/Interpreter/Value.h"
 #include "caffeine/Memory/MemHeap.h"
+#include "caffeine/Support/LLVMFmt.h"
 #include <fmt/format.h>
+#include <fmt/ostream.h>
 #include <llvm/IR/Constants.h>
 #include <llvm/IR/GetElementPtrTypeIterator.h>
 #include <llvm/IR/GlobalVariable.h>
@@ -31,12 +33,9 @@ ExprEvaluator::Unevaluatable::Unevaluatable(llvm::Value* expr,
 
 const char* ExprEvaluator::Unevaluatable::what() const throw() {
   if (msg_cache_.empty()) {
-    std::string printed;
-    llvm::raw_string_ostream os{printed};
-    expr_->print(os, true);
-
     msg_cache_ = fmt::format(
-        "Unable to evaluate expression: {}. Expression: {}", context_, printed);
+        FMT_STRING("Unable to evaluate expression: {}. Expression: {}"),
+        context_, *expr_);
   }
 
   return msg_cache_.c_str();
@@ -95,14 +94,10 @@ LLVMValue ExprEvaluator::evaluate(llvm::Value* val) {
   if (auto* cnst = llvm::dyn_cast<llvm::GlobalVariable>(val))
     return visitGlobalVariable(*cnst);
 
-  std::string msg = "Unsupported expression: ";
-  llvm::raw_string_ostream os{msg};
-  val->print(os, true);
-
   std::cout << magic_enum::enum_name((llvm::Value::ValueTy)val->getValueID())
             << std::endl;
 
-  CAFFEINE_ABORT(msg);
+  CAFFEINE_ABORT(fmt::format("Unsupported expression: {}", *val));
 }
 LLVMValue ExprEvaluator::evaluate(llvm::Value& val) {
   return evaluate(&val);
@@ -119,12 +114,8 @@ std::optional<LLVMValue> ExprEvaluator::try_visit(llvm::Value* val) {
  *********************************************/
 
 LLVMValue ExprEvaluator::visitConstant(llvm::Constant& cnst) {
-  std::string msg = "";
-  llvm::raw_string_ostream os{msg};
-  cnst.print(os, true);
-
   CAFFEINE_ABORT(
-      fmt::format("Unable to evaluate constant expression: {}", msg));
+      fmt::format("Unable to evaluate constant expression: {}", cnst));
 }
 
 LLVMValue
@@ -382,13 +373,9 @@ LLVMValue ExprEvaluator::visitConstantExpr(llvm::ConstantExpr& expr) {
  *********************************************/
 
 LLVMValue ExprEvaluator::visitInstruction(llvm::Instruction& inst) {
-  std::string msg = "";
-  llvm::raw_string_ostream os{msg};
-  inst.print(os, true);
-
   CAFFEINE_ABORT(
       fmt::format("Instruction '{}' not implemented! Full expression: {}",
-                  inst.getOpcodeName(), msg));
+                  inst.getOpcodeName(), inst));
 }
 
 #define DECL_BINARY_OP_VISIT(opcode)                                           \

--- a/src/Interpreter/ExprEval.cpp
+++ b/src/Interpreter/ExprEval.cpp
@@ -54,6 +54,13 @@ LLVMValue ExprEvaluator::visit(llvm::Value* val) {
   if (it != frame.variables.end())
     return it->second;
 
+  return evaluate(val);
+}
+LLVMValue ExprEvaluator::visit(llvm::Value& val) {
+  return visit(&val);
+}
+
+LLVMValue ExprEvaluator::evaluate(llvm::Value* val) {
   if (auto* inst = llvm::dyn_cast<llvm::Instruction>(val))
     return BaseType::visit(inst);
 
@@ -97,8 +104,8 @@ LLVMValue ExprEvaluator::visit(llvm::Value* val) {
 
   CAFFEINE_ABORT(msg);
 }
-LLVMValue ExprEvaluator::visit(llvm::Value& val) {
-  return visit(&val);
+LLVMValue ExprEvaluator::evaluate(llvm::Value& val) {
+  return evaluate(&val);
 }
 
 std::optional<LLVMValue> ExprEvaluator::try_visit(llvm::Value* val) {

--- a/src/Interpreter/ExprEval.cpp
+++ b/src/Interpreter/ExprEval.cpp
@@ -453,6 +453,7 @@ LLVMValue ExprEvaluator::visitFNeg(llvm::UnaryOperator& op) {
 }
 
 LLVMValue ExprEvaluator::visitPtrToInt(llvm::PtrToIntInst& inst) {
+  const auto& layout = ctx->mod->getDataLayout();
   return transform_elements(
       [&](const LLVMScalar& value) {
         return LLVMScalar(UnaryOp::CreateTruncOrZExt(

--- a/src/Interpreter/Interpreter.cpp
+++ b/src/Interpreter/Interpreter.cpp
@@ -67,28 +67,9 @@ ExecutionResult Interpreter::visitInstruction(llvm::Instruction& inst) {
   }                                                                            \
   static_assert(true)
 
-DEF_SIMPLE_OP(Add, BinaryOperator);
-DEF_SIMPLE_OP(Sub, BinaryOperator);
-DEF_SIMPLE_OP(Mul, BinaryOperator);
-
-DEF_SIMPLE_OP(Shl, BinaryOperator);
-DEF_SIMPLE_OP(LShr, BinaryOperator);
-DEF_SIMPLE_OP(AShr, BinaryOperator);
-DEF_SIMPLE_OP(And, BinaryOperator);
-DEF_SIMPLE_OP(Or, BinaryOperator);
-DEF_SIMPLE_OP(Xor, BinaryOperator);
-
-DEF_SIMPLE_OP(FAdd, BinaryOperator);
-DEF_SIMPLE_OP(FSub, BinaryOperator);
-DEF_SIMPLE_OP(FMul, BinaryOperator);
-DEF_SIMPLE_OP(FDiv, BinaryOperator);
-
-DEF_SIMPLE_OP(Trunc, TruncInst);
-DEF_SIMPLE_OP(SExt, SExtInst);
-DEF_SIMPLE_OP(ZExt, ZExtInst);
-DEF_SIMPLE_OP(IntToPtrInst, IntToPtrInst);
-DEF_SIMPLE_OP(PtrToIntInst, PtrToIntInst);
-DEF_SIMPLE_OP(BitCastInst, BitCastInst);
+DEF_SIMPLE_OP(BinaryOperator, BinaryOperator);
+DEF_SIMPLE_OP(UnaryOperator, UnaryOperator);
+DEF_SIMPLE_OP(CastInst, CastInst);
 
 DEF_SIMPLE_OP(GetElementPtrInst, GetElementPtrInst);
 
@@ -195,16 +176,6 @@ ExecutionResult Interpreter::visitURem(llvm::BinaryOperator& op) {
       lhs, rhs);
 
   frame.insert(&op, std::move(result));
-
-  return ExecutionResult::Continue;
-}
-
-ExecutionResult Interpreter::visitNot(llvm::BinaryOperator& op) {
-  StackFrame& frame = ctx->stack_top();
-
-  auto operand = ctx->lookup(op.getOperand(0));
-
-  frame.insert(&op, transform(WRAP_FUNC(UnaryOp::CreateNot), operand));
 
   return ExecutionResult::Continue;
 }


### PR DESCRIPTION
This lets us delete a large amount of code within Interpreter and instead use the common code within ExprEvaluator.

/stack #240 