### PR TITLE
Move vector insert, extract, and shuffle to ExprEvaluator

### DIFF
--- a/include/caffeine/Interpreter/ExprEval.h
+++ b/include/caffeine/Interpreter/ExprEval.h
@@ -129,6 +129,10 @@ public:
 
   LLVMValue visitSelectInst(llvm::SelectInst& op);
 
+  LLVMValue visitInsertElement(llvm::InsertElementInst& inst);
+  LLVMValue visitExtractElement(llvm::ExtractElementInst& inst);
+  LLVMValue visitShuffleVector(llvm::ShuffleVectorInst& inst);
+
 private:
   OpRef scalarize(const LLVMScalar& scalar) const;
 

--- a/src/Interpreter/ExprEval.cpp
+++ b/src/Interpreter/ExprEval.cpp
@@ -558,4 +558,80 @@ LLVMValue ExprEvaluator::visitSelectInst(llvm::SelectInst& op) {
       cond, t_val, f_val);
 }
 
+LLVMValue ExprEvaluator::visitInsertElement(llvm::InsertElementInst& inst) {
+  auto vec_ = visit(inst.getOperand(0));
+  auto vec = vec_.vector();
+
+  auto elt = scalarize(visit(inst.getOperand(1)).scalar());
+  auto idx = visit(inst.getOperand(2)).scalar().expr();
+
+  LLVMValue::OpVector result;
+  result.reserve(vec.size());
+  for (size_t i = 0; i < vec.size(); ++i) {
+    result.emplace_back(SelectOp::Create(
+        ICmpOp::CreateICmp(ICmpOpcode::EQ, idx, i), elt, scalarize(vec[i])));
+  }
+
+  return LLVMValue(std::move(result));
+}
+LLVMValue ExprEvaluator::visitExtractElement(llvm::ExtractElementInst& inst) {
+  auto vec_ = visit(inst.getOperand(0));
+  auto vec = vec_.vector();
+
+  auto idx = visit(inst.getOperand(1)).scalar().expr();
+
+  OpRef result = Undef::Create(Type::from_llvm(inst.getType()));
+  for (size_t i = 0; i < vec.size(); ++i) {
+    result = SelectOp::Create(ICmpOp::CreateICmp(ICmpOpcode::EQ, idx, i),
+                              scalarize(vec[i]), result);
+  }
+
+  return LLVMValue(result);
+}
+LLVMValue ExprEvaluator::visitShuffleVector(llvm::ShuffleVectorInst& inst) {
+  auto vec1_ = visit(inst.getOperand(0));
+  auto vec2_ = visit(inst.getOperand(1));
+  auto mask_ = visit(inst.getOperand(2));
+
+  auto vec1 = vec1_.vector();
+  auto vec2 = vec2_.vector();
+  auto mask = mask_.vector();
+
+  auto type = inst.getType();
+  auto elem_type = type->getVectorElementType();
+
+  LLVMValue::OpVector results;
+  results.reserve(vec1.size());
+
+  /**
+   * The semantics of shufflevector end up basically being an array lookup.
+   * Given two vectors x, y and a mask m, we form one big vector z by
+   * concatenating z = x||y. Then the values in m are used as indices in z
+   * to get the final vector value.
+   *
+   * We emulate these semantics by creating nested select chains. All masks are
+   * either constant or undef so we rely on constant-folding to produce the
+   * correct set of efficient expressions.
+   */
+  for (size_t i = 0; i < mask.size(); ++i) {
+    OpRef value = Undef::Create(Type::from_llvm(elem_type));
+
+    for (size_t j = 0; j < mask.size(); ++j) {
+      value = SelectOp::Create(
+          ICmpOp::CreateICmp(ICmpOpcode::EQ, mask[i].expr(), j),
+          scalarize(vec1[j]), value);
+    }
+
+    for (size_t j = 0; j < mask.size(); ++j) {
+      value = SelectOp::Create(
+          ICmpOp::CreateICmp(ICmpOpcode::EQ, mask[i].expr(), j + mask.size()),
+          scalarize(vec2[j]), value);
+    }
+
+    results.push_back(value);
+  }
+
+  return LLVMValue(std::move(results));
+}
+
 } // namespace caffeine

--- a/src/Interpreter/Interpreter.cpp
+++ b/src/Interpreter/Interpreter.cpp
@@ -93,6 +93,10 @@ DEF_SIMPLE_OP(BitCastInst, BitCastInst);
 DEF_SIMPLE_OP(SelectInst, SelectInst);
 DEF_SIMPLE_OP(GetElementPtrInst, GetElementPtrInst);
 
+DEF_SIMPLE_OP(InsertElementInst, InsertElementInst);
+DEF_SIMPLE_OP(ExtractElementInst, ExtractElementInst);
+DEF_SIMPLE_OP(ShuffleVectorInst, ShuffleVectorInst);
+
 ExecutionResult Interpreter::visitUDiv(llvm::BinaryOperator& op) {
   StackFrame& frame = ctx->stack_top();
 
@@ -438,116 +442,6 @@ ExecutionResult Interpreter::visitIntrinsicInst(llvm::IntrinsicInst& intrin) {
 
   CAFFEINE_ABORT(fmt::format("Intrinsic function '{}' is not supported",
                              intrin.getCalledFunction()->getName().str()));
-}
-
-ExecutionResult
-Interpreter::visitInsertElementInst(llvm::InsertElementInst& inst) {
-  auto& frame = ctx->stack_top();
-
-  auto vec_ = ctx->lookup(inst.getOperand(0));
-  auto vec = vec_.vector();
-  auto elt = ctx->lookup(inst.getOperand(1)).scalar();
-  auto idx = ctx->lookup(inst.getOperand(2)).scalar();
-
-  std::vector<ContextValue> result;
-  result.reserve(vec.size());
-
-  for (size_t i = 0; i < vec.size(); ++i) {
-    result.push_back(transform(
-        [&](const auto& op) {
-          return SelectOp::Create(ICmpOp::CreateICmp(ICmpOpcode::EQ, idx, i),
-                                  elt, op);
-        },
-        vec[i]));
-  }
-
-  frame.insert(&inst, ContextValue(std::move(result)));
-
-  return ExecutionResult::Continue;
-}
-ExecutionResult
-Interpreter::visitExtractElementInst(llvm::ExtractElementInst& inst) {
-  auto& frame = ctx->stack_top();
-
-  auto vec_ = ctx->lookup(inst.getOperand(0));
-  auto vec = vec_.vector();
-  auto idx = ctx->lookup(inst.getOperand(1)).scalar();
-
-  CAFFEINE_ASSERT(vec.size() != 0);
-
-  ContextValue result =
-      transform([](const auto& v) { return Undef::Create(v->type()); }, vec[0]);
-
-  for (size_t i = 0; i < vec.size(); ++i) {
-    result = transform(
-        [&](const auto& r, const auto& v) {
-          return SelectOp::Create(ICmpOp::CreateICmp(ICmpOpcode::EQ, idx, i), v,
-                                  r);
-        },
-        result, vec[i]);
-  }
-
-  frame.insert(&inst, std::move(result));
-
-  return ExecutionResult::Continue;
-}
-ExecutionResult
-Interpreter::visitShuffleVectorInst(llvm::ShuffleVectorInst& inst) {
-  auto& frame = ctx->stack_top();
-
-  auto vec1_ = ctx->lookup(inst.getOperand(0));
-  auto vec2_ = ctx->lookup(inst.getOperand(1));
-  auto mask_ = ctx->lookup(inst.getOperand(2));
-
-  auto vec1 = vec1_.vector();
-  auto vec2 = vec2_.vector();
-  auto mask = mask_.vector();
-
-  std::vector<ContextValue> result;
-  result.reserve(vec1.size());
-
-  /**
-   * The semantics of shufflevector end up basically being an array lookup.
-   * Given two vectors x, y and a mask m, we form one big vector z by
-   * concatenating z = x||y. Then the values in m are used as indices in z
-   * to get the final vector value.
-   *
-   * We emulate these semantics by creating nested select chains. For constant
-   * masks we rely on constant-folding to make these more efficient.
-   */
-  for (size_t i = 0; i < mask.size(); ++i) {
-    // Any non-specified index is undef
-    ContextValue value = transform(
-        [&](const auto& v1, const auto& v2) {
-          CAFFEINE_ASSERT(v1->type() == v2->type());
-          return Undef::Create(v1->type());
-        },
-        vec1[i], vec2[i]);
-
-    for (size_t j = 0; j < mask.size(); ++j) {
-      value = transform(
-          [&](const auto& r, const auto& v, const auto& m) {
-            return SelectOp::Create(ICmpOp::CreateICmp(ICmpOpcode::EQ, m, j), v,
-                                    r);
-          },
-          value, vec1[j], mask[i]);
-    }
-
-    for (size_t j = 0; j < mask.size(); ++j) {
-      value = transform(
-          [&](const auto& r, const auto& v, const auto& m) {
-            return SelectOp::Create(
-                ICmpOp::CreateICmp(ICmpOpcode::EQ, m, j + mask.size()), v, r);
-          },
-          value, vec2[j], mask[i]);
-    }
-
-    result.push_back(value);
-  }
-
-  frame.insert(&inst, ContextValue(std::move(result)));
-
-  return ExecutionResult::Continue;
 }
 
 ExecutionResult Interpreter::visitLoadInst(llvm::LoadInst& inst) {


### PR DESCRIPTION
As in title. No new features but the implementations become a bit simpler with the new semantics associated with LLVMValue.

/stack #249