### PR TITLE
 Move select instruction implementation to ExprEvaluator 

### DIFF
--- a/include/caffeine/Interpreter/ExprEval.h
+++ b/include/caffeine/Interpreter/ExprEval.h
@@ -9,6 +9,7 @@ namespace caffeine {
 
 class Context;
 class LLVMValue;
+class LLVMScalar;
 
 /**
  * LLVM IR expression evaluator.
@@ -127,6 +128,11 @@ public:
   LLVMValue visitBitCast(llvm::BitCastInst& op);
 
   LLVMValue visitGetElementPtr(llvm::GetElementPtrInst& op);
+
+  LLVMValue visitSelectInst(llvm::SelectInst& op);
+
+private:
+  OpRef scalarize(const LLVMScalar& scalar) const;
 
 private:
   Context* ctx;

--- a/src/Interpreter/ExprEval.cpp
+++ b/src/Interpreter/ExprEval.cpp
@@ -17,14 +17,6 @@
 
 namespace caffeine {
 
-namespace {
-  OpRef scalarize(const LLVMScalar& scalar, const MemHeap& heap) {
-    if (scalar.is_expr())
-      return scalar.expr();
-    return scalar.pointer().value(heap);
-  }
-} // namespace
-
 ExprEvaluator::Unevaluatable::Unevaluatable(llvm::Value* expr,
                                             const char* context)
     : expr_(expr), context_(context) {
@@ -46,6 +38,12 @@ llvm::Value* ExprEvaluator::Unevaluatable::expr() const {
 
 ExprEvaluator::ExprEvaluator(Context* ctx, Options options)
     : ctx(ctx), options(options) {}
+
+OpRef ExprEvaluator::scalarize(const LLVMScalar& scalar) const {
+  if (scalar.is_expr())
+    return scalar.expr();
+  return scalar.pointer().value(ctx->heap);
+}
 
 LLVMValue ExprEvaluator::visit(llvm::Value* val) {
   const auto& frame = ctx->stack_top();
@@ -385,9 +383,7 @@ LLVMValue ExprEvaluator::visitInstruction(llvm::Instruction& inst) {
                                                                                \
     return transform_elements(                                                 \
         [&](const LLVMScalar& lhs, const LLVMScalar& rhs) -> LLVMScalar {      \
-          const auto& heap = ctx->heap;                                        \
-          return BinaryOp::Create##opcode(scalarize(lhs, heap),                \
-                                          scalarize(rhs, heap));               \
+          return BinaryOp::Create##opcode(scalarize(lhs), scalarize(rhs));     \
         },                                                                     \
         lhs, rhs);                                                             \
   }                                                                            \
@@ -587,6 +583,24 @@ LLVMValue ExprEvaluator::visitGetElementPtr(llvm::GetElementPtrInst& inst) {
         }
       },
       base, offsets);
+}
+
+LLVMValue ExprEvaluator::visitSelectInst(llvm::SelectInst& op) {
+  auto cond = visit(op.getCondition());
+  auto t_val = visit(op.getTrueValue());
+  auto f_val = visit(op.getFalseValue());
+
+  if (cond.is_scalar()) {
+    cond = cond.scalar().broadcast(t_val.num_elements());
+  }
+
+  return transform_elements(
+      [&](const auto& cond, const auto& t_val,
+          const auto& f_val) -> LLVMScalar {
+        return SelectOp::Create(cond.expr(), scalarize(t_val),
+                                scalarize(f_val));
+      },
+      cond, t_val, f_val);
 }
 
 } // namespace caffeine

--- a/src/Interpreter/Interpreter.cpp
+++ b/src/Interpreter/Interpreter.cpp
@@ -72,6 +72,7 @@ DEF_SIMPLE_OP(UnaryOperator, UnaryOperator);
 DEF_SIMPLE_OP(CastInst, CastInst);
 DEF_SIMPLE_OP(CmpInst, CmpInst);
 
+DEF_SIMPLE_OP(SelectInst, SelectInst);
 DEF_SIMPLE_OP(GetElementPtrInst, GetElementPtrInst);
 
 ExecutionResult Interpreter::visitUDiv(llvm::BinaryOperator& op) {
@@ -348,15 +349,6 @@ ExecutionResult Interpreter::visitCallInst(llvm::CallInst& call) {
   }
 
   ctx->push(std::move(callee));
-
-  return ExecutionResult::Continue;
-}
-ExecutionResult Interpreter::visitSelectInst(llvm::SelectInst& inst) {
-  auto& frame = ctx->stack_top();
-  auto cond = ctx->lookup(inst.getCondition());
-  auto trueVal = ctx->lookup(inst.getTrueValue());
-  auto falseVal = ctx->lookup(inst.getFalseValue());
-  frame.insert(&inst, transform(SelectOp::Create, cond, trueVal, falseVal));
 
   return ExecutionResult::Continue;
 }

--- a/test/run-pass/inst/select/vector-select.ll
+++ b/test/run-pass/inst/select/vector-select.ll
@@ -1,0 +1,42 @@
+target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128"
+target triple = "x86_64-pc-linux-gnu"
+
+; Here we perform a vector fcmp true operation
+define dso_local void @test() local_unnamed_addr #0 {
+  %a = select i1 false, i8 1, i8 2
+  %b = select i1 true, <2 x i8> <i8 1, i8 1>, <2 x i8> <i8 2, i8 2>
+  %c = select <2 x i1> <i1 true, i1 false>, <2 x i8> <i8 1, i8 1>, <2 x i8> <i8 2, i8 2>
+
+  %a_eq_2 = icmp eq i8 %a, 2
+  call void @caffeine_assert(i1 zeroext %a_eq_2)
+
+  %b0 = extractelement <2 x i8> %b, i32 0
+  %b1 = extractelement <2 x i8> %b, i32 1
+  %b0_eq_1 = icmp eq i8 %b0, 1
+  %b1_eq_1 = icmp eq i8 %b1, 1
+  call void @caffeine_assert(i1 zeroext %b0_eq_1)
+  call void @caffeine_assert(i1 zeroext %b1_eq_1)
+
+  %c0 = extractelement <2 x i8> %c, i32 0
+  %c1 = extractelement <2 x i8> %c, i32 1
+  %c0_eq_1 = icmp eq i8 %c0, 1
+  %c1_eq_2 = icmp eq i8 %c1, 2
+  call void @caffeine_assert(i1 zeroext %c0_eq_1)
+  call void @caffeine_assert(i1 zeroext %c1_eq_2)
+
+  ret void
+}
+
+declare dso_local void @caffeine_assume(i1 zeroext) local_unnamed_addr #1
+
+declare dso_local void @caffeine_assert(i1 zeroext) local_unnamed_addr #1
+
+attributes #0 = { nounwind uwtable "correctly-rounded-divide-sqrt-fp-math"="false" "disable-tail-calls"="false" "frame-pointer"="none" "less-precise-fpmad"="false" "min-legal-vector-width"="0" "no-infs-fp-math"="false" "no-jump-tables"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="false" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
+attributes #1 = { "correctly-rounded-divide-sqrt-fp-math"="false" "disable-tail-calls"="false" "frame-pointer"="none" "less-precise-fpmad"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="false" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
+attributes #2 = { nounwind }
+
+!llvm.module.flags = !{!0}
+!llvm.ident = !{!1}
+
+!0 = !{i32 1, !"wchar_size", i32 4}
+!1 = !{!"clang version 10.0.0-4ubuntu1 "}


### PR DESCRIPTION
This also makes select work according to the LLVM docs when the arguments are vector values. I've added a test case to cover that.

Accidentally closed this since I deleted the base branch - am reopening.

/stack #246