### PR TITLE
Move vector insert, extract, and shuffle to ExprEvaluator 

### DIFF
--- a/include/caffeine/Interpreter/ExprEval.h
+++ b/include/caffeine/Interpreter/ExprEval.h
@@ -132,6 +132,10 @@ public:
 
   LLVMValue visitSelectInst(llvm::SelectInst& op);
 
+  LLVMValue visitInsertElement(llvm::InsertElementInst& inst);
+  LLVMValue visitExtractElement(llvm::ExtractElementInst& inst);
+  LLVMValue visitShuffleVector(llvm::ShuffleVectorInst& inst);
+
 private:
   OpRef scalarize(const LLVMScalar& scalar) const;
 

--- a/src/Interpreter/ExprEval.cpp
+++ b/src/Interpreter/ExprEval.cpp
@@ -107,6 +107,12 @@ std::optional<LLVMValue> ExprEvaluator::try_visit(llvm::Value* val) {
   } catch (Unevaluatable&) { return std::nullopt; }
 }
 
+OpRef ExprEvaluator::scalarize(const LLVMScalar& scalar) const {
+  if (scalar.is_expr())
+    return scalar.expr();
+  return scalar.pointer().value(ctx->heap);
+}
+
 /*********************************************
  * Constant visitor methods                  *
  *********************************************/

--- a/src/Interpreter/ExprEval.cpp
+++ b/src/Interpreter/ExprEval.cpp
@@ -107,12 +107,6 @@ std::optional<LLVMValue> ExprEvaluator::try_visit(llvm::Value* val) {
   } catch (Unevaluatable&) { return std::nullopt; }
 }
 
-OpRef ExprEvaluator::scalarize(const LLVMScalar& scalar) const {
-  if (scalar.is_expr())
-    return scalar.expr();
-  return scalar.pointer().value(ctx->heap);
-}
-
 /*********************************************
  * Constant visitor methods                  *
  *********************************************/


### PR DESCRIPTION
As in title. No new features but the implementations become a bit simpler with the new semantics associated with LLVMValue.

Accidentally deleted this due to deleting the base branch - am reopening.

 /stack #246