### PR TITLE
Skip run-fail/fp/approx-sqrt test

### DIFF
--- a/test/run-fail/fp/approx-sqrt.c
+++ b/test/run-fail/fp/approx-sqrt.c
@@ -1,3 +1,4 @@
+// SKIP TEST
 
 #include "caffeine.h"
 #include <stdlib.h>


### PR DESCRIPTION
This currently takes an extremely long time to run. Until we figure out why we're better off disabling it.