### PR TITLE
Centralize declaration of Operation opcodes

### DIFF
--- a/include/caffeine/IR/Operation.def
+++ b/include/caffeine/IR/Operation.def
@@ -1,0 +1,171 @@
+
+/**
+ * This file is meant to be similar to LLVM's Instruction.def. Users can define
+ * HANDLE_OP or HANDLE_OPCLASS and then template out code for each of the
+ * defined opertions.
+ *
+ * A quick guide to working with this:
+ * - If you want to handle every opcode use HANDLE_OP
+ * - If you want to handle every operation name (i.e. grouping together FCmp,
+ *   Constant, and ICmp variants) then use HANDLE_OPCLASS
+ * - If you also want the properties of the opcodes (and can't extract them from
+ *   Operation::Opcode for some reason) then use HANDLE_FULL_OP
+ *
+ * Implementation notes:
+ * - Most values are defined using HANDLE_FULL_OP
+ * - If there are multiple opcodes that share a name use HANDLE_REPT_OP for all
+ *   but the first one. This ensures that HANDLE_OPCLASS works properly.
+ */
+
+#undef CAFFEINE_ICMP_BASE
+#undef CAFFEINE_FCMP_BASE
+
+#define CAFFEINE_ICMP_BASE 5
+#define CAFFEINE_FCMP_BASE 4
+
+#ifndef HANDLE_REPT_OP
+#ifdef HANDLE_OPCLASS
+#define HANDLE_REPT_OP(opcode, opname, opclass, op_base, op_nargs, op_aux)
+#else
+#define HANDLE_REPT_OP(opcode, opname, opclass, op_base, op_nargs, op_aux)     \
+  HANDLE_FULL_OP(opcode, opname, opclass, op_base, op_nargs, op_aux)
+#endif
+#endif
+
+#ifndef HANDLE_FULL_OP
+#define HANDLE_FULL_OP(opcode, opname, opclass, op_base, op_nargs, op_aux)     \
+  HANDLE_OP(opcode, opname, opclass)
+#endif
+
+#ifndef HANDLE_BINARY_OP_LAST
+#define HANDLE_BINARY_OP_LAST()
+#endif
+#ifndef HANDLE_BINARY_OP_FIRST
+#define HANDLE_BINARY_OP_FIRST(opcode)
+#endif
+
+#ifndef HANDLE_UNARY_OP_LAST
+#define HANDLE_UNARY_OP_LAST()
+#endif
+#ifndef HANDLE_UNARY_OP_FIRST
+#define HANDLE_UNARY_OP_FIRST(opcode)
+#endif
+
+#ifndef HANDLE_OP
+#define HANDLE_OP(opcode, opname, opclass) HANDLE_OPCLASS(opname, opclass)
+#endif
+
+#ifndef HANDLE_OPCLASS
+#define HANDLE_OPCLASS(opname, opclass)
+#endif
+
+// clang-format off
+
+// Constants
+HANDLE_FULL_OP(ConstantNamed,     Constant,       Constant,       1, 0, 0)
+HANDLE_REPT_OP(ConstantNumbered,  Constant,       Constant,       1, 0, 1)
+HANDLE_FULL_OP(ConstantInt,       ConstantInt,    ConstantInt,    1, 0, 5)
+HANDLE_FULL_OP(ConstantFloat,     ConstantFloat,  ConstantFloat,  1, 0, 6)
+HANDLE_FULL_OP(ConstantArray,     ConstantArray,  ConstantArray,  1, 1, 7)
+
+/**
+ * An unnamed symbolic constant that can have any value whenever it is
+ * used. Has the same semantics as LLVM's undef.
+ *
+ * It is valid for solvers to have any value for the undef constant.
+ */
+HANDLE_FULL_OP(Undef, Undef, Undef, 1, 0, 15)
+
+// Binary Opcodes
+HANDLE_FULL_OP(Add,  Add,  BinaryOp, 2, 2, 0)
+HANDLE_FULL_OP(Sub,  Sub,  BinaryOp, 2, 2, 1)
+HANDLE_FULL_OP(Mul,  Mul,  BinaryOp, 2, 2, 2)
+HANDLE_FULL_OP(UDiv, UDiv, BinaryOp, 2, 2, 3)
+HANDLE_FULL_OP(SDiv, SDiv, BinaryOp, 2, 2, 4)
+HANDLE_FULL_OP(URem, URem, BinaryOp, 2, 2, 5)
+HANDLE_FULL_OP(SRem, SRem, BinaryOp, 2, 2, 6)
+
+HANDLE_FULL_OP(And,  And,  BinaryOp, 2, 2, 7)
+HANDLE_FULL_OP(Or,   Or,   BinaryOp, 2, 2, 8)
+HANDLE_FULL_OP(Xor,  Xor,  BinaryOp, 2, 2, 9)
+HANDLE_FULL_OP(Shl,  Shl,  BinaryOp, 2, 2, 10)
+HANDLE_FULL_OP(LShr, LShr, BinaryOp, 2, 2, 11)
+HANDLE_FULL_OP(AShr, AShr, BinaryOp, 2, 2, 12)
+
+// Floating-point opcodes
+HANDLE_FULL_OP(FAdd, FAdd, BinaryOp, 3, 2, 0)
+HANDLE_FULL_OP(FSub, FSub, BinaryOp, 3, 2, 1)
+HANDLE_FULL_OP(FMul, FMul, BinaryOp, 3, 2, 2)
+HANDLE_FULL_OP(FDiv, FDiv, BinaryOp, 3, 2, 3)
+HANDLE_FULL_OP(FRem, FRem, BinaryOp, 3, 2, 4)
+
+// Integer comparison operations
+HANDLE_FULL_OP(ICmpEq,  ICmp, ICmpOp, CAFFEINE_ICMP_BASE, 2, 0x08)
+HANDLE_REPT_OP(ICmpNe,  ICmp, ICmpOp, CAFFEINE_ICMP_BASE, 2, 0x09)
+HANDLE_REPT_OP(ICmpUgt, ICmp, ICmpOp, CAFFEINE_ICMP_BASE, 2, ((0 << 2) | 0x0))
+HANDLE_REPT_OP(ICmpUge, ICmp, ICmpOp, CAFFEINE_ICMP_BASE, 2, ((0 << 2) | 0x1))
+HANDLE_REPT_OP(ICmpUlt, ICmp, ICmpOp, CAFFEINE_ICMP_BASE, 2, ((0 << 2) | 0x2))
+HANDLE_REPT_OP(ICmpUle, ICmp, ICmpOp, CAFFEINE_ICMP_BASE, 2, ((0 << 2) | 0x3))
+HANDLE_REPT_OP(ICmpSgt, ICmp, ICmpOp, CAFFEINE_ICMP_BASE, 2, ((1 << 2) | 0x0))
+HANDLE_REPT_OP(ICmpSge, ICmp, ICmpOp, CAFFEINE_ICMP_BASE, 2, ((1 << 2) | 0x1))
+HANDLE_REPT_OP(ICmpSlt, ICmp, ICmpOp, CAFFEINE_ICMP_BASE, 2, ((1 << 2) | 0x2))
+HANDLE_REPT_OP(ICmpSle, ICmp, ICmpOp, CAFFEINE_ICMP_BASE, 2, ((1 << 2) | 0x3))
+
+// Floating-point comparison operations
+HANDLE_FULL_OP(FCmpEq, FCmp, FCmpOp, CAFFEINE_FCMP_BASE, 2, 0)
+HANDLE_REPT_OP(FCmpGt, FCmp, FCmpOp, CAFFEINE_FCMP_BASE, 2, 1)
+HANDLE_REPT_OP(FCmpGe, FCmp, FCmpOp, CAFFEINE_FCMP_BASE, 2, 2)
+HANDLE_REPT_OP(FCmpLt, FCmp, FCmpOp, CAFFEINE_FCMP_BASE, 2, 3)
+HANDLE_REPT_OP(FCmpLe, FCmp, FCmpOp, CAFFEINE_FCMP_BASE, 2, 4)
+HANDLE_REPT_OP(FCmpNe, FCmp, FCmpOp, CAFFEINE_FCMP_BASE, 2, 5)
+
+HANDLE_BINARY_OP_LAST()
+HANDLE_BINARY_OP_FIRST(Add)
+
+// Unary opcodes
+HANDLE_FULL_OP(Not,     Not,    UnaryOp,  10, 1, 0)
+HANDLE_FULL_OP(FNeg,    FNeg,   UnaryOp,  10, 1, 1)
+HANDLE_FULL_OP(FIsNaN,  FIsNaN, UnaryOp,  10, 1, 2)
+
+// Conversion opcodes
+HANDLE_FULL_OP(Trunc,   Trunc,    UnaryOp,  11, 1, 0)
+HANDLE_FULL_OP(SExt,    SExt,     UnaryOp,  11, 1, 1)
+HANDLE_FULL_OP(ZExt,    ZExt,     UnaryOp,  11, 1, 2)
+HANDLE_FULL_OP(FpTrunc, FpTrunc,  UnaryOp,  11, 1, 3)
+HANDLE_FULL_OP(FpExt,   FpExt,    UnaryOp,  11, 1, 4)
+HANDLE_FULL_OP(FpToUI,  FpToUI,   UnaryOp,  11, 1, 5)
+HANDLE_FULL_OP(FpToSI,  FpToSI,   UnaryOp,  11, 1, 6)
+HANDLE_FULL_OP(UIToFp,  UIToFp,   UnaryOp,  11, 1, 7)
+HANDLE_FULL_OP(SIToFp,  SIToFp,   UnaryOp,  11, 1, 8)
+HANDLE_FULL_OP(Bitcast, Bitcast,  UnaryOp,  11, 1, 9)
+
+HANDLE_UNARY_OP_LAST()
+HANDLE_UNARY_OP_FIRST(Not)
+
+// Other instructions
+HANDLE_FULL_OP(Select,     Select,     SelectOp,   20, 3, 0)
+HANDLE_FULL_OP(FixedArray, FixedArray, FixedArray, 21, 0, 0)
+
+// Allocation instructions
+/**
+ * Create a new symbolic array that is filled with a default value.
+ *
+ * This is mean to be used for malloc and alloca. Constant arrays with
+ * prefilled data should use FixedArray instead.
+ */
+HANDLE_FULL_OP(Alloc,   Alloc,  AllocOp,  21, 2, 0)
+// Store a byte to a position within an array.
+HANDLE_FULL_OP(Store,   Store,  StoreOp,  21, 3, 1)
+// Load a byte from a position within an array
+HANDLE_FULL_OP(Load,    Load,   LoadOp,   21, 2, 2)
+
+#undef HANDLE_OP
+#undef HANDLE_FULL_OP
+#undef HANDLE_REPT_OP
+#undef HANDLE_OPCLASS
+
+#undef HANDLE_BINARY_OP_FIRST
+#undef HANDLE_BINARY_OP_LAST
+
+#undef HANDLE_UNARY_OP_FIRST
+#undef HANDLE_UNARY_OP_LAST

--- a/include/caffeine/IR/Visitor.h
+++ b/include/caffeine/IR/Visitor.h
@@ -5,6 +5,7 @@
 
 #include <llvm/IR/InstVisitor.h>
 #include <llvm/Support/Casting.h>
+#include <string_view>
 
 namespace caffeine {
 
@@ -90,60 +91,27 @@ public:
   // clang-format off
   RetTy visitArrayBase(transform_t<ArrayBase>& O) { return CAFFEINE_OP_DELEGATE(Operation); }
 
-  RetTy visitConstant     (transform_t<Constant>     & O) { return CAFFEINE_OP_DELEGATE(Operation); }
-  RetTy visitConstantInt  (transform_t<ConstantInt>  & O) { return CAFFEINE_OP_DELEGATE(Operation); }
-  RetTy visitConstantFloat(transform_t<ConstantFloat>& O) { return CAFFEINE_OP_DELEGATE(Operation); }
-  RetTy visitUndef        (transform_t<Undef>        & O) { return CAFFEINE_OP_DELEGATE(Operation); }
-  RetTy visitFixedArray   (transform_t<FixedArray>   & O) { return CAFFEINE_OP_DELEGATE(ArrayBase); }
-  RetTy visitConstantArray(transform_t<ConstantArray>& O) { return CAFFEINE_OP_DELEGATE(ArrayBase); }
-
+  // visit methods for operation classes
   RetTy visitBinaryOp(transform_t<BinaryOp>& O) { return CAFFEINE_OP_DELEGATE(Operation); }
   RetTy visitUnaryOp (transform_t<UnaryOp> & O) { return CAFFEINE_OP_DELEGATE(Operation); }
   RetTy visitSelectOp(transform_t<SelectOp>& O) { return CAFFEINE_OP_DELEGATE(Operation); }
+  RetTy visitAllocOp (transform_t<AllocOp> & O) { return CAFFEINE_OP_DELEGATE(ArrayBase); }
+  RetTy visitStoreOp (transform_t<StoreOp> & O) { return CAFFEINE_OP_DELEGATE(ArrayBase); }
+  RetTy visitLoadOp  (transform_t<LoadOp>  & O) { return CAFFEINE_OP_DELEGATE(Operation); }
 
-  RetTy visitAllocOp(transform_t<AllocOp>& O) { return CAFFEINE_OP_DELEGATE(ArrayBase); }
-  RetTy visitStoreOp(transform_t<StoreOp>& O) { return CAFFEINE_OP_DELEGATE(ArrayBase); }
-  RetTy visitLoadOp (transform_t<LoadOp>&  O) { return CAFFEINE_OP_DELEGATE(Operation); }
-
-  // Binary operations
-  RetTy visitAdd (transform_t<BinaryOp>& O) { return CAFFEINE_OP_DELEGATE(BinaryOp); }
-  RetTy visitSub (transform_t<BinaryOp>& O) { return CAFFEINE_OP_DELEGATE(BinaryOp); }
-  RetTy visitMul (transform_t<BinaryOp>& O) { return CAFFEINE_OP_DELEGATE(BinaryOp); }
-  RetTy visitUDiv(transform_t<BinaryOp>& O) { return CAFFEINE_OP_DELEGATE(BinaryOp); }
-  RetTy visitSDiv(transform_t<BinaryOp>& O) { return CAFFEINE_OP_DELEGATE(BinaryOp); }
-  RetTy visitURem(transform_t<BinaryOp>& O) { return CAFFEINE_OP_DELEGATE(BinaryOp); }
-  RetTy visitSRem(transform_t<BinaryOp>& O) { return CAFFEINE_OP_DELEGATE(BinaryOp); }
-  RetTy visitAnd (transform_t<BinaryOp>& O) { return CAFFEINE_OP_DELEGATE(BinaryOp); }
-  RetTy visitOr  (transform_t<BinaryOp>& O) { return CAFFEINE_OP_DELEGATE(BinaryOp); }
-  RetTy visitXor (transform_t<BinaryOp>& O) { return CAFFEINE_OP_DELEGATE(BinaryOp); }
-  RetTy visitShl (transform_t<BinaryOp>& O) { return CAFFEINE_OP_DELEGATE(BinaryOp); }
-  RetTy visitLShr(transform_t<BinaryOp>& O) { return CAFFEINE_OP_DELEGATE(BinaryOp); }
-  RetTy visitAShr(transform_t<BinaryOp>& O) { return CAFFEINE_OP_DELEGATE(BinaryOp); }
-  RetTy visitFAdd(transform_t<BinaryOp>& O) { return CAFFEINE_OP_DELEGATE(BinaryOp); }
-  RetTy visitFSub(transform_t<BinaryOp>& O) { return CAFFEINE_OP_DELEGATE(BinaryOp); }
-  RetTy visitFMul(transform_t<BinaryOp>& O) { return CAFFEINE_OP_DELEGATE(BinaryOp); }
-  RetTy visitFDiv(transform_t<BinaryOp>& O) { return CAFFEINE_OP_DELEGATE(BinaryOp); }
-  RetTy visitFRem(transform_t<BinaryOp>& O) { return CAFFEINE_OP_DELEGATE(BinaryOp); }
-
-  RetTy visitICmp(transform_t<ICmpOp>& O) { return CAFFEINE_OP_DELEGATE(BinaryOp); }
-  RetTy visitFCmp(transform_t<FCmpOp>& O) { return CAFFEINE_OP_DELEGATE(BinaryOp); }
-
-  // Unary operations
-  RetTy visitNot (transform_t<UnaryOp>& O) { return CAFFEINE_OP_DELEGATE(UnaryOp); }
-  RetTy visitFNeg(transform_t<UnaryOp>& O) { return CAFFEINE_OP_DELEGATE(UnaryOp); }
-  RetTy visitFIsNaN(transform_t<UnaryOp>& O) { return CAFFEINE_OP_DELEGATE(UnaryOp); }
-
-  RetTy visitTrunc  (transform_t<UnaryOp>& O) { return CAFFEINE_OP_DELEGATE(UnaryOp); }
-  RetTy visitZExt   (transform_t<UnaryOp>& O) { return CAFFEINE_OP_DELEGATE(UnaryOp); }
-  RetTy visitSExt   (transform_t<UnaryOp>& O) { return CAFFEINE_OP_DELEGATE(UnaryOp); }
-  RetTy visitFpTrunc(transform_t<UnaryOp>& O) { return CAFFEINE_OP_DELEGATE(UnaryOp); }
-  RetTy visitFpExt  (transform_t<UnaryOp>& O) { return CAFFEINE_OP_DELEGATE(UnaryOp); }
-  RetTy visitFpToUI (transform_t<UnaryOp>& O) { return CAFFEINE_OP_DELEGATE(UnaryOp); }
-  RetTy visitFpToSI (transform_t<UnaryOp>& O) { return CAFFEINE_OP_DELEGATE(UnaryOp); }
-  RetTy visitUIToFp (transform_t<UnaryOp>& O) { return CAFFEINE_OP_DELEGATE(UnaryOp); }
-  RetTy visitSIToFp (transform_t<UnaryOp>& O) { return CAFFEINE_OP_DELEGATE(UnaryOp); }
-  RetTy visitBitcast(transform_t<UnaryOp>& O) { return CAFFEINE_OP_DELEGATE(UnaryOp); }
+  RetTy visitFCmpOp  (transform_t<FCmpOp>  & O) { return CAFFEINE_OP_DELEGATE(BinaryOp); }
+  RetTy visitICmpOp  (transform_t<ICmpOp>  & O) { return CAFFEINE_OP_DELEGATE(BinaryOp); }
   // clang-format on
+
+#define HANDLE_OPCLASS(opname, opclass)                                        \
+  RetTy visit##opname(transform_t<opclass>& O) {                               \
+    if constexpr (std::is_base_of_v<FixedArray, opclass>)                      \
+      return CAFFEINE_OP_DELEGATE(ArrayBase);                                  \
+    if constexpr (std::string_view(#opname) == #opclass)                       \
+      return CAFFEINE_OP_DELEGATE(Operation);                                  \
+    return CAFFEINE_OP_DELEGATE(opclass);                                      \
+  }
+#include "caffeine/IR/Operation.def"
 
   RetTy visit(transform_t<Operation>* O);
   RetTy visit(transform_t<Operation>& O);

--- a/include/caffeine/IR/Visitor.inl
+++ b/include/caffeine/IR/Visitor.inl
@@ -75,6 +75,13 @@ RetTy OpVisitorBase<Transform, SubClass, RetTy>::visit(
     DELEGATE(Trunc, UnaryOp);
     DELEGATE(SExt, UnaryOp);
     DELEGATE(ZExt, UnaryOp);
+    DELEGATE(FpTrunc, UnaryOp);
+    DELEGATE(FpExt, UnaryOp);
+    DELEGATE(FpToUI, UnaryOp);
+    DELEGATE(FpToSI, UnaryOp);
+    DELEGATE(UIToFp, UnaryOp);
+    DELEGATE(SIToFp, UnaryOp);
+    DELEGATE(Bitcast, UnaryOp);
 
     DELEGATE(Alloc, AllocOp, AllocOp);
     DELEGATE(Store, StoreOp, StoreOp);

--- a/include/caffeine/IR/Visitor.inl
+++ b/include/caffeine/IR/Visitor.inl
@@ -21,85 +21,22 @@ template <template <typename T> class Transform, typename SubClass,
           typename RetTy>
 RetTy OpVisitorBase<Transform, SubClass, RetTy>::visit(
     transform_t<Operation>& op) {
-
-#define CAFFEINE_DELEGATE_2(opcode, type_)                                     \
-  case Operation::opcode:                                                      \
-    return static_cast<SubClass*>(this)->visit##opcode(                        \
-        *static_cast<transform_t<type_>*>(&op))
-#define CAFFEINE_DELEGATE_3(opcode, type_, name)                               \
-  case Operation::opcode:                                                      \
-    return static_cast<SubClass*>(this)->visit##name(                          \
-        *static_cast<transform_t<type_>*>(&op))
-
-#define DELEGATE(...) CAFFEINE_INVOKE_NUMBERED(CAFFEINE_DELEGATE_, __VA_ARGS__)
-
-  // Special case for icmp and fcmp since they have multiple opcodes
-  if (auto* icmp = llvm::dyn_cast<transform_t<ICmpOp>>(&op))
-    return static_cast<SubClass*>(this)->visitICmp(*icmp);
-  if (auto* fcmp = llvm::dyn_cast<transform_t<FCmpOp>>(&op))
-    return static_cast<SubClass*>(this)->visitFCmp(*fcmp);
-  if (auto* cnst = llvm::dyn_cast<transform_t<Constant>>(&op))
-    return static_cast<SubClass*>(this)->visitConstant(*cnst);
-
   switch (op.opcode()) {
-    DELEGATE(Add, BinaryOp);
-    DELEGATE(Sub, BinaryOp);
-    DELEGATE(Mul, BinaryOp);
-    DELEGATE(UDiv, BinaryOp);
-    DELEGATE(SDiv, BinaryOp);
-    DELEGATE(URem, BinaryOp);
-    DELEGATE(SRem, BinaryOp);
-    DELEGATE(And, BinaryOp);
-    DELEGATE(Or, BinaryOp);
-    DELEGATE(Xor, BinaryOp);
-    DELEGATE(Shl, BinaryOp);
-    DELEGATE(LShr, BinaryOp);
-    DELEGATE(AShr, BinaryOp);
-    DELEGATE(FAdd, BinaryOp);
-    DELEGATE(FSub, BinaryOp);
-    DELEGATE(FMul, BinaryOp);
-    DELEGATE(FDiv, BinaryOp);
-    DELEGATE(FRem, BinaryOp);
-
-    DELEGATE(Not, UnaryOp);
-    DELEGATE(FNeg, UnaryOp);
-    DELEGATE(FIsNaN, UnaryOp);
-
-    DELEGATE(Select, SelectOp, SelectOp);
-    DELEGATE(ConstantInt, ConstantInt);
-    DELEGATE(ConstantFloat, ConstantFloat);
-    DELEGATE(ConstantArray, ConstantArray);
-    DELEGATE(Undef, Undef);
-    DELEGATE(FixedArray, FixedArray);
-
-    DELEGATE(Trunc, UnaryOp);
-    DELEGATE(SExt, UnaryOp);
-    DELEGATE(ZExt, UnaryOp);
-    DELEGATE(FpTrunc, UnaryOp);
-    DELEGATE(FpExt, UnaryOp);
-    DELEGATE(FpToUI, UnaryOp);
-    DELEGATE(FpToSI, UnaryOp);
-    DELEGATE(UIToFp, UnaryOp);
-    DELEGATE(SIToFp, UnaryOp);
-    DELEGATE(Bitcast, UnaryOp);
-
-    DELEGATE(Alloc, AllocOp, AllocOp);
-    DELEGATE(Store, StoreOp, StoreOp);
-    DELEGATE(Load, LoadOp, LoadOp);
+#define HANDLE_OP(opcode, opname, opclass)                                     \
+  case Operation::opcode:                                                      \
+    return static_cast<SubClass*>(this)->visit##opname(                        \
+        *static_cast<transform_t<opclass>*>(&op));
+#include "caffeine/IR/Operation.def"
 
   case Operation::BinaryOpLast:
   case Operation::UnaryOpLast:
   case Operation::Invalid:
     CAFFEINE_ABORT("tried to visit an invalid operation");
-
-  default:
-    // this will also assert if your instruction above doesn't have a
-    // delegate call
-    CAFFEINE_ABORT(detail::visitor::unknown_opcode_msg(op));
   }
 
-#undef CAFFEINE_DELEGATE_2
-#undef CAFFEINE_DELEGATE_3
+  // this will also assert if your instruction above doesn't have a
+  // delegate call
+  CAFFEINE_ABORT(detail::visitor::unknown_opcode_msg(op));
 }
 
 template <template <typename T> class Transform, typename SubClass,


### PR DESCRIPTION
I've discovered that we're missing implementations of a number of different visitor methods. Since this will probably happen again if we're manually declaring new opcodes I've instead gone and added a definitions file (similar to LLVM's `Instruction.def`) that we can use to generate code by specifying some macros.

This PR rewrites Visitor and Operation to make use of it. I will add some more follow-on PRs to add it to everywhere that should use it and also to add some implementations for the missing opcodes identified.

This is the first step towards fixing #262 