### PR TITLE
Update CI to build things with debug info

### DIFF
--- a/.github/workflows/build-project.yml
+++ b/.github/workflows/build-project.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Configure
         run: |
           mkdir -p build
-          cmake -B build -DCAFFEINE_CI=ON
+          cmake -B build -DCAFFEINE_CI=ON -DCMAKE_BUILD_TYPE=RelWithDebInfo
 
       - name: Build
         run: cmake --build "build" -j$(nproc)

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,7 @@ RUN apt-get update \
         llvm-10-dev \
         clang-10 \
         clang++-10 \
+        clang-format \
         libz-dev \
         build-essential \
         gcc-9 \


### PR DESCRIPTION
Currently backtraces given in CI are useless - this changes CI to build everything in the `RelWithDebInfo` cmake profile. It also adds clang-format to the CI docker image.