### PR TITLE
Add debug printing methods to MemHeap and Assertion

### DIFF
--- a/include/caffeine/IR/Assertion.h
+++ b/include/caffeine/IR/Assertion.h
@@ -31,6 +31,8 @@ public:
   Assertion operator!() const;
 
   static Assertion constant(bool value);
+
+  void DebugPrint() const;
 };
 
 std::ostream& operator<<(std::ostream& os, const Assertion& assertion);

--- a/include/caffeine/Memory/MemHeap.h
+++ b/include/caffeine/Memory/MemHeap.h
@@ -106,6 +106,8 @@ public:
              const llvm::DataLayout& layout);
   void write(const OpRef& offset, llvm::Type* type, const LLVMValue& value,
              const MemHeap& heap, const llvm::DataLayout& layout);
+
+  void DebugPrint() const;
 };
 
 using AllocId = typename slot_map<Allocation>::key_type;
@@ -174,6 +176,8 @@ public:
    * Get an assertion to check if this pointer is a null pointer.
    */
   Assertion check_null(const MemHeap& heap) const;
+
+  void DebugPrint() const;
 };
 
 class MemHeap {
@@ -250,6 +254,8 @@ public:
    */
   llvm::SmallVector<Pointer, 1> resolve(const Pointer& value,
                                         Context& ctx) const;
+
+  void DebugPrint() const;
 };
 
 } // namespace caffeine

--- a/src/IR/Debug.cpp
+++ b/src/IR/Debug.cpp
@@ -1,4 +1,5 @@
 #include "caffeine/IR/Operation.h"
+#include "caffeine/IR/Assertion.h"
 
 #include <iostream>
 
@@ -18,4 +19,9 @@ void Operation::DebugPrint() const {
     std::cout << "NULL" << std::endl;
   }
 }
+
+void Assertion::DebugPrint() const {
+  std::cout << *this << std::endl;
+}
+
 } // namespace caffeine

--- a/src/Memory/Debug.cpp
+++ b/src/Memory/Debug.cpp
@@ -1,0 +1,38 @@
+#include "caffeine/Memory/MemHeap.h"
+
+#include <fmt/format.h>
+#include <fmt/ostream.h>
+#include <iostream>
+#include <magic_enum.hpp>
+
+namespace caffeine {
+
+void Allocation::DebugPrint() const {
+  fmt::print(std::cout,
+             FMT_STRING("Allocation {{\n"
+                        "  address: {}\n"
+                        "  size:    {}\n"
+                        "  data:    {}\n"
+                        "  kind:    {}\n"
+                        "}}\n"),
+             *address_, *size_, *data_, magic_enum::enum_name(kind_));
+}
+
+void Pointer::DebugPrint() const {
+  fmt::print(std::cout,
+             FMT_STRING("Pointer {{\n"
+                        "  alloc:  {}\n"
+                        "  offset: {}\n"
+                        "}}\n"),
+             alloc_.first, *offset_);
+}
+
+void MemHeap::DebugPrint() const {
+  std::cout << "MemHeap [\n";
+  for (const auto& alloc : allocs_) {
+    alloc.DebugPrint();
+  }
+  std::cout << "]" << std::endl;
+}
+
+} // namespace caffeine


### PR DESCRIPTION
As in title, these are provided to be useful while debugging or while adding print statements to the program.