### PR TITLE
Fix a few small issues

### DIFF
--- a/src/Interpreter/ExprEval.cpp
+++ b/src/Interpreter/ExprEval.cpp
@@ -574,6 +574,9 @@ LLVMValue ExprEvaluator::visitIntToPtr(llvm::IntToPtrInst& inst) {
 }
 
 LLVMValue ExprEvaluator::visitBitCast(llvm::BitCastInst& inst) {
+  CAFFEINE_ASSERT(inst.getType()->isPointerTy(),
+                  "Non-pointer bitcasts are not implemented");
+
   return visit(inst.getOperand(0));
 }
 

--- a/src/Interpreter/Interpreter.cpp
+++ b/src/Interpreter/Interpreter.cpp
@@ -516,6 +516,8 @@ ExecutionResult Interpreter::visitSymbolicAlloca(llvm::CallInst& call) {
 
   auto resolved = ctx->heap.resolve(name, *ctx);
 
+  CAFFEINE_ASSERT(!resolved.empty(),
+                  "caffeine_make_symbolic called with invalid name pointer");
   CAFFEINE_ASSERT(resolved.size() == 1,
                   "caffeine_make_symbolic called with symbolic name");
 

--- a/src/Memory/MemHeap.cpp
+++ b/src/Memory/MemHeap.cpp
@@ -282,8 +282,10 @@ AllocId MemHeap::allocate(const OpRef& size, const OpRef& alignment,
       Constant::Create(size->type(), ctx.next_constant()), size, data, kind);
 
   // Ensure that the allocation is properly aligned
-  ctx.add(ICmpOp::CreateICmp(
-      ICmpOpcode::EQ, BinaryOp::CreateURem(newalloc.address(), alignment), 0));
+  auto is_aligned = ICmpOp::CreateICmp(
+      ICmpOpcode::EQ, BinaryOp::CreateURem(newalloc.address(), alignment), 0);
+  auto align_is_zero = ICmpOp::CreateICmp(ICmpOpcode::EQ, alignment, 0);
+  ctx.add(BinaryOp::CreateOr(is_aligned, align_is_zero));
   // The allocation can never wrap around the address space
   ctx.add(ICmpOp::CreateICmp(ICmpOpcode::ULE, newalloc.address(),
                              BinaryOp::CreateAdd(newalloc.address(), size)));


### PR DESCRIPTION
It didn't feel worthwhile to create multiple PRs for this. Summary:
- Add a better assert message if the pointer to the name in `caffeine_make_symbolic` resolves to nothing
- Add an assertion if someone tries to bitcast something that isn't a pointer. This is supported by LLVM just not by us right now.
- Add support for zero-alignment allocations. 