### PR TITLE
Fix broken clang build

### DIFF
--- a/include/caffeine/ADT/PersistentArray.h
+++ b/include/caffeine/ADT/PersistentArray.h
@@ -108,11 +108,11 @@ public:
   PersistentArray(It begin, It end)
       : PersistentArray(std::vector<T>(begin, end)) {}
 
-  constexpr size_t size() const noexcept {
+  size_t size() const noexcept {
     std::shared_lock lock(*mutex_);
     return size_unsafe_();
   }
-  constexpr bool empty() const noexcept {
+  bool empty() const noexcept {
     return size() == 0;
   }
 

--- a/src/IR/Debug.cpp
+++ b/src/IR/Debug.cpp
@@ -1,5 +1,5 @@
-#include "caffeine/IR/Operation.h"
 #include "caffeine/IR/Assertion.h"
+#include "caffeine/IR/Operation.h"
 
 #include <iostream>
 


### PR DESCRIPTION
#267 broke the build on clang. This PR fixes it.

I'm going to add a follow-up PR to use clang in CI.