### PR TITLE
Redesign context forking API

### DIFF
--- a/include/caffeine/Interpreter/Context.h
+++ b/include/caffeine/Interpreter/Context.h
@@ -6,6 +6,7 @@
 #include "caffeine/Memory/MemHeap.h"
 #include "caffeine/Solver/Solver.h"
 
+#include <llvm/ADT/SmallVector.h>
 #include <llvm/IR/Constant.h>
 #include <llvm/IR/Function.h>
 
@@ -40,6 +41,13 @@ public:
    * one but has the same state.
    */
   Context fork_once() const;
+
+  /**
+   * Create count identical contexts to this one.
+   *
+   * After calling this method the original context is no longer available.
+   */
+  llvm::SmallVector<Context, 2> fork(size_t count) &&;
 
   /**
    * Get the top frame of the stack.

--- a/include/caffeine/Interpreter/Context.h
+++ b/include/caffeine/Interpreter/Context.h
@@ -39,7 +39,7 @@ public:
    * Create a new context that is independent from this
    * one but has the same state.
    */
-  Context fork() const;
+  Context fork_once() const;
 
   /**
    * Get the top frame of the stack.

--- a/include/caffeine/Interpreter/Context.h
+++ b/include/caffeine/Interpreter/Context.h
@@ -47,7 +47,7 @@ public:
    *
    * After calling this method the original context is no longer available.
    */
-  llvm::SmallVector<Context, 2> fork(size_t count) &&;
+  llvm::SmallVector<Context, 2> fork(size_t count);
 
   /**
    * Get the top frame of the stack.

--- a/include/caffeine/Interpreter/Interpreter.h
+++ b/include/caffeine/Interpreter/Interpreter.h
@@ -13,7 +13,28 @@
 
 namespace caffeine {
 
-enum class ExecutionResult { Continue, Stop };
+class ExecutionResult {
+public:
+  enum Status { Continue, Dead, Stop };
+
+  ExecutionResult(Status status);
+  ExecutionResult(llvm::SmallVector<Context, 2>&& contexts);
+
+  Status status() const {
+    return status_;
+  }
+
+  llvm::SmallVectorImpl<Context>& contexts() {
+    return contexts_;
+  }
+  const llvm::SmallVectorImpl<Context>& contexts() const {
+    return contexts_;
+  }
+
+private:
+  Status status_;
+  llvm::SmallVector<Context, 2> contexts_;
+};
 
 class Interpreter : public llvm::InstVisitor<Interpreter, ExecutionResult> {
 private:

--- a/src/Interpreter/Context.cpp
+++ b/src/Interpreter/Context.cpp
@@ -62,7 +62,7 @@ Context::Context(llvm::Function* function, std::shared_ptr<Solver> solver)
   }
 }
 
-Context Context::fork() const {
+Context Context::fork_once() const {
   return Context{*this};
 }
 

--- a/src/Interpreter/Context.cpp
+++ b/src/Interpreter/Context.cpp
@@ -66,7 +66,7 @@ Context Context::fork_once() const {
   return Context{*this};
 }
 
-llvm::SmallVector<Context, 2> Context::fork(size_t count) && {
+llvm::SmallVector<Context, 2> Context::fork(size_t count) {
   if (count == 0)
     return {};
 

--- a/src/Interpreter/Context.cpp
+++ b/src/Interpreter/Context.cpp
@@ -66,6 +66,19 @@ Context Context::fork_once() const {
   return Context{*this};
 }
 
+llvm::SmallVector<Context, 2> Context::fork(size_t count) && {
+  if (count == 0)
+    return {};
+
+  llvm::SmallVector<Context, 2> forks;
+  for (size_t i = 0; i < count - 1; ++i) {
+    forks.push_back(*this);
+  }
+
+  forks.push_back(std::move(*this));
+  return forks;
+}
+
 const StackFrame& Context::stack_top() const {
   CAFFEINE_ASSERT(!stack.empty());
   return stack.back();


### PR DESCRIPTION
The fork API for context is rather inconvenient to work with. This PR changes it to return a vector of contexts so that it's not necessary distinguish between the current context and all the forks.

The old API is still available as `Context::fork_once` when that is more convenient.