### PR TITLE
Move ScopeGuard from SlotMap.h into its own header

### DIFF
--- a/include/caffeine/ADT/Guard.h
+++ b/include/caffeine/ADT/Guard.h
@@ -1,0 +1,41 @@
+#pragma once
+
+#include <type_traits>
+
+namespace caffeine {
+namespace detail {
+  /**
+   * RAII class that calls a user-provided function during its destructor.
+   *
+   * This is useful for ensuring that code is executed even if an exception is
+   * thrown (i.e. it can be used to emulate a try/finally statenent).
+   *
+   * The design is based off of folly's ScopeGuard class.
+   */
+  template <typename F>
+  class ScopeGuard : F {
+  private:
+    bool dismissed = false;
+
+  public:
+    constexpr ScopeGuard(F&& func) : F(std::move(func)) {}
+    constexpr ScopeGuard(const F& func) : F(func) {}
+
+    ~ScopeGuard() {
+      if (!dismissed) {
+        (*this)();
+      }
+    }
+
+    constexpr void dismiss() noexcept {
+      dismissed = true;
+    }
+  };
+} // namespace detail
+
+template <typename F>
+constexpr detail::ScopeGuard<std::decay_t<F>> make_guard(F&& func) {
+  return detail::ScopeGuard<std::decay_t<F>>(std::forward<F>(func));
+}
+
+} // namespace caffeine

--- a/include/caffeine/ADT/SlotMap.h
+++ b/include/caffeine/ADT/SlotMap.h
@@ -9,35 +9,11 @@
 #include <type_traits>
 #include <utility>
 
+#include "caffeine/ADT/Guard.h"
+
 namespace caffeine {
 
 namespace detail {
-  /**
-   * RAII class that calls a user-provided function during it's destructor.
-   *
-   * This is useful for ensuring that code is executed even if an exception is
-   * thrown (i.e. it can be used to emulate a try/finally statenent).
-   */
-  template <typename F>
-  class drop_guard : F {
-  public:
-    constexpr drop_guard(F&& func) : F(std::move(func)) {}
-    constexpr drop_guard(const F& func) : F(func) {}
-
-    ~drop_guard() {
-      (*this)();
-    }
-  };
-
-  template <typename F>
-  constexpr drop_guard<F> make_guard(F&& func) {
-    return drop_guard<F>(std::move(func));
-  }
-  template <typename F>
-  constexpr drop_guard<F> make_guard(const F& func) {
-    return drop_guard<F>(func);
-  }
-
   /**
    * Replace a value in the location and return the previous value.
    */
@@ -142,7 +118,7 @@ private:
     void remove(size_t next) {
       assert(has_value);
 
-      auto guard = detail::make_guard([&] {
+      auto guard = make_guard([&] {
         has_value = false;
         this->next = next;
         gen += 1;


### PR DESCRIPTION
This takes the `drop_guard` type from `SlotMap.h`, renames it to `ScopeGuard` and moves it to its own header so that it can be more broadly used.

I've also added a `dismiss` method since that's present in folly's version and I found it to be quite useful on occasion.