### PR TITLE
Delete WRAP_FUNC macro from Interpreter.cpp

### DIFF
--- a/src/Interpreter/Interpreter.cpp
+++ b/src/Interpreter/Interpreter.cpp
@@ -33,8 +33,6 @@ auto zip(R1& range1, R2& range2) {
          });
 }
 
-#define WRAP_FUNC(func) [](const auto&... args) { return (func)(args...); }
-
 Interpreter::Interpreter(Executor* queue, Context* ctx, FailureLogger* logger,
                          const InterpreterOptions& options)
     : ctx{ctx}, queue{queue}, logger{logger}, options(options) {}


### PR DESCRIPTION
It's not used anymore so it should be deleted.