### PR TITLE
Extract interpreter control behaviour into separate interfaces

### DIFF
--- a/include/caffeine/Interpreter/Executor.h
+++ b/include/caffeine/Interpreter/Executor.h
@@ -8,30 +8,25 @@
 
 namespace caffeine {
 
+class ExecutionPolicy;
+class ExecutionContextStore;
+
+struct ExecutorOptions {
+  uint32_t num_threads = 2;
+
+  constexpr ExecutorOptions() = default;
+};
+
 class Executor {
 private:
+  ExecutionPolicy* policy;
+  ExecutionContextStore* store;
   FailureLogger* logger;
-  std::vector<Context> contexts;
-  uint32_t num_threads;
-
-  /**
-   * Are there any contexts left?
-   */
-  bool has_next() const;
-
-  /**
-   * Get the next context to be executed.
-   */
-  Context next_context();
+  ExecutorOptions options;
 
 public:
-  Executor(FailureLogger* logger, uint32_t num_threads = 2);
-
-  /**
-   * The current context has forked and the fork needs to be added
-   * to the queue.
-   */
-  void add_context(Context&& ctx);
+  Executor(ExecutionPolicy* policy, ExecutionContextStore* store,
+           FailureLogger* logger, const ExecutorOptions& options = {});
 
   /**
    * Runs the contexts in its possesion until there are none left

--- a/include/caffeine/Interpreter/Interpreter.h
+++ b/include/caffeine/Interpreter/Interpreter.h
@@ -94,6 +94,7 @@ public:
 private:
   void logFailure(Context& ctx, const Assertion& assertion,
                   std::string_view message = "");
+  void queueContext(Context&& ctx);
 
 private:
   ExecutionResult visitExternFunc(llvm::CallInst& inst);

--- a/include/caffeine/Interpreter/Interpreter.h
+++ b/include/caffeine/Interpreter/Interpreter.h
@@ -41,6 +41,9 @@ private:
 
 class Interpreter : public llvm::InstVisitor<Interpreter, ExecutionResult> {
 private:
+  ExecutionPolicy* policy;
+  ExecutionContextStore* store;
+
   Context* ctx;
   Executor* queue;
   FailureLogger* logger;

--- a/include/caffeine/Interpreter/Interpreter.h
+++ b/include/caffeine/Interpreter/Interpreter.h
@@ -92,7 +92,7 @@ public:
   ExecutionResult visitMemSetInst(llvm::MemSetInst& memset);
 
 private:
-  void logFailure(const Context& ctx, const Assertion& assertion,
+  void logFailure(Context& ctx, const Assertion& assertion,
                   std::string_view message = "");
 
 private:

--- a/include/caffeine/Interpreter/Interpreter.h
+++ b/include/caffeine/Interpreter/Interpreter.h
@@ -45,7 +45,6 @@ private:
   ExecutionContextStore* store;
 
   Context* ctx;
-  Executor* queue;
   FailureLogger* logger;
   InterpreterOptions options;
 
@@ -54,7 +53,8 @@ public:
    * The interpreter constructor needs an executor and context as well as a way
    * to log assertion failures.
    */
-  Interpreter(Executor* queue, Context* ctx, FailureLogger* logger,
+  Interpreter(Context* ctx, ExecutionPolicy* policy,
+              ExecutionContextStore* store, FailureLogger* logger,
               const InterpreterOptions& options = InterpreterOptions());
 
   void execute();

--- a/include/caffeine/Interpreter/Policy.h
+++ b/include/caffeine/Interpreter/Policy.h
@@ -14,7 +14,19 @@ class Context;
  */
 class ExecutionPolicy {
 public:
-  enum ExitStatus { Success, Fail, Dead };
+  enum ExitStatus {
+    // The context returned from the top-level function.
+    Success,
+    // The context failed an assertion. Note that the context may continue to be
+    // run with !fail_condition added to the path spec.
+    Fail,
+    // The context has an unsatisfiable path condition so there is no point in
+    // running it any further.
+    Dead,
+    // The context was removed because the policy indicated that it should not
+    // be queued.
+    Removed
+  };
 
 public:
   ExecutionPolicy() = default;

--- a/src/Interpreter/Executor.cpp
+++ b/src/Interpreter/Executor.cpp
@@ -1,36 +1,17 @@
 #include "caffeine/Interpreter/Executor.h"
 #include "caffeine/Interpreter/Interpreter.h"
+#include "caffeine/Interpreter/Store.h"
 
 namespace caffeine {
 
-Executor::Executor(FailureLogger* logger, uint32_t num_threads)
-    : logger{logger}, num_threads{num_threads} {
-  // Silence warning WRT num_threads being unused.
-  (void)this->num_threads;
-}
-
-void Executor::add_context(Context&& ctx) {
-  contexts.push_back(std::move(ctx));
-}
-
-Context Executor::next_context() {
-  CAFFEINE_ASSERT(!contexts.empty());
-
-  auto ctx = std::move(contexts.back());
-  contexts.pop_back();
-  return ctx;
-}
-
-bool Executor::has_next() const {
-  return !contexts.empty();
-}
+Executor::Executor(ExecutionPolicy* policy, ExecutionContextStore* store,
+                   FailureLogger* logger, const ExecutorOptions& options)
+    : policy(policy), store(store), logger(logger), options(options) {}
 
 void Executor::run() {
-  while (has_next()) {
-    auto ctx = next_context();
-    Interpreter interp(this, &ctx, logger);
-
-    interp.execute();
+  while (auto ctx = store->next_context()) {
+    Interpreter interpreter(&ctx.value(), policy, store, logger);
+    interpreter.execute();
   }
 }
 

--- a/src/Interpreter/Interpreter.cpp
+++ b/src/Interpreter/Interpreter.cpp
@@ -74,7 +74,7 @@ void Interpreter::execute() {
           });
       ctxs.erase(it, ctxs.end());
 
-      store->add_context_multi(ctxs.data(), ctxs.size());
+      store->add_context_multi(ctxs);
       return;
     }
 

--- a/src/Interpreter/Interpreter.cpp
+++ b/src/Interpreter/Interpreter.cpp
@@ -22,9 +22,11 @@ ExecutionResult::ExecutionResult(Status status) : status_(status) {}
 ExecutionResult::ExecutionResult(llvm::SmallVector<Context, 2>&& contexts)
     : status_(Dead), contexts_(std::move(contexts)) {}
 
-Interpreter::Interpreter(Executor* queue, Context* ctx, FailureLogger* logger,
+Interpreter::Interpreter(Context* ctx, ExecutionPolicy* policy,
+                         ExecutionContextStore* store, FailureLogger* logger,
                          const InterpreterOptions& options)
-    : ctx{ctx}, queue{queue}, logger{logger}, options(options) {}
+    : policy(policy), store(store), ctx(ctx), logger(logger), options(options) {
+}
 
 void Interpreter::logFailure(Context& ctx, const Assertion& assertion,
                              std::string_view message) {


### PR DESCRIPTION
This adds two different interfaces that control queuing behaviour of the interpreter/executor:
- `ExecutionContextStore`: A store of `Context` instances that are not currently being executed. `add_context` adds a context to the store and `next_context` retrieves new ones back from the store.
- `ExecutionPolicy`: Indicates whether a given `Context` instance should be put in the queue or whether it should just be ignored. Also has several context lifecycle events that can be used for tracking info.

This PR is still a bit of a mess but the rest is too much effort to be pulled apart so leaving it as is.

/stack #285 