### PR TITLE
Make PrintingFailureLogger print failure reason if one is present

### DIFF
--- a/src/Interpreter/PrintingFailureLogger.cpp
+++ b/src/Interpreter/PrintingFailureLogger.cpp
@@ -102,6 +102,9 @@ void PrintingFailureLogger::log_failure(const Model& model, const Context& ctx,
   *os << "Backtrace:\n";
   print_context_backtrace(*os, ctx);
 
+  if (!failure.message.empty())
+    *os << "Reason:\n  " << failure.message << '\n';
+
   *os << std::flush;
 }
 


### PR DESCRIPTION
This makes interpreting why something failed a lot easier (assuming that the log_failure call was annotated with a failure message).