### PR TITLE
Introduce ExecutionPolicy interface

### DIFF
--- a/include/caffeine/Interpreter/Interpreter.h
+++ b/include/caffeine/Interpreter/Interpreter.h
@@ -13,6 +13,8 @@
 
 namespace caffeine {
 
+class ExecutionPolicy;
+
 class ExecutionResult {
 public:
   enum Status { Continue, Dead, Stop };
@@ -34,44 +36,6 @@ public:
 private:
   Status status_;
   llvm::SmallVector<Context, 2> contexts_;
-};
-
-class ExecutionPolicy {
-public:
-  enum ExitStatus { Success, Fail, Dead };
-
-public:
-  ExecutionPolicy() = default;
-  virtual ~ExecutionPolicy() = default;
-
-  /**
-   * Called when a context forks to determine whether we should continue
-   * executing that branch.
-   *
-   * Note that this method does not control whether dead branches continue to
-   * execute. Those will be pruned irregardless of what this method returns.
-   */
-  virtual bool should_queue_path(Context* ctx) = 0;
-
-  // Called when a context is forked into multiple contexts.
-  //
-  // Note that assertion failures do not cause a path to be forked.
-  virtual void on_path_forked(Context* ctx);
-  // Called when a context is removed from the queue to be executed.
-  virtual void on_path_dequeued(Context* ctx);
-  // Called when a path completes along with the status of how that path
-  // completed.
-  //
-  // Note that when the exit status is `Fail` the context will continue to be
-  // used for the non-failure path if it is valid.
-  virtual void on_path_complete(const Context* ctx, ExitStatus status);
-
-protected:
-  ExecutionPolicy(ExecutionPolicy&&) = default;
-  ExecutionPolicy(const ExecutionPolicy&) = default;
-
-  ExecutionPolicy& operator=(ExecutionPolicy&&) = default;
-  ExecutionPolicy& operator=(const ExecutionPolicy&) = default;
 };
 
 class Interpreter : public llvm::InstVisitor<Interpreter, ExecutionResult> {

--- a/include/caffeine/Interpreter/Policy.h
+++ b/include/caffeine/Interpreter/Policy.h
@@ -1,0 +1,62 @@
+#pragma once
+
+namespace caffeine {
+
+class Context;
+
+/**
+ * Class to control the behaviour of an Interpreter instance. It also provides a
+ * number of hooks for the policy to execute code when various context-related
+ * events occur within the executor. By default, these do nothing.
+ *
+ * If you don't care about controlling queuing behaviour you may want to derive
+ * from AlwaysAllowExecutionPolicy instead of the base ExecutionPolicy class.
+ */
+class ExecutionPolicy {
+public:
+  enum ExitStatus { Success, Fail, Dead };
+
+public:
+  ExecutionPolicy() = default;
+  virtual ~ExecutionPolicy() = default;
+
+  /**
+   * Called when a context forks to determine whether we should continue
+   * executing that branch.
+   *
+   * Note that this method does not control whether dead branches continue to
+   * execute. Those will be pruned irregardless of what this method returns.
+   */
+  virtual bool should_queue_path(const Context& ctx) = 0;
+
+  // Called when a context is forked into multiple contexts.
+  //
+  // Note that assertion failures do not cause a path to be forked.
+  virtual void on_path_forked(Context& ctx);
+  // Called when a context is removed from the queue to be executed.
+  virtual void on_path_dequeued(Context& ctx);
+  // Called when a path completes along with the status of how that path
+  // completed.
+  //
+  // Note that when the exit status is `Fail` the context will continue to be
+  // used for the non-failure path if it is valid.
+  virtual void on_path_complete(const Context& ctx, ExitStatus status);
+
+protected:
+  ExecutionPolicy(ExecutionPolicy&&) = default;
+  ExecutionPolicy(const ExecutionPolicy&) = default;
+
+  ExecutionPolicy& operator=(ExecutionPolicy&&) = default;
+  ExecutionPolicy& operator=(const ExecutionPolicy&) = default;
+};
+
+/**
+ * Execution policy which always indicates that a new context should be
+ * enqueued.
+ */
+class AlwaysAllowExecutionPolicy : public ExecutionPolicy {
+public:
+  virtual bool should_queue_path(const Context& ctx) override;
+};
+
+} // namespace caffeine

--- a/src/Interpreter/Interpreter.cpp
+++ b/src/Interpreter/Interpreter.cpp
@@ -20,6 +20,10 @@ ExecutionResult::ExecutionResult(Status status) : status_(status) {}
 ExecutionResult::ExecutionResult(llvm::SmallVector<Context, 2>&& contexts)
     : status_(Dead), contexts_(std::move(contexts)) {}
 
+void ExecutionPolicy::on_path_forked(Context*) {}
+void ExecutionPolicy::on_path_dequeued(Context*) {}
+void ExecutionPolicy::on_path_complete(const Context*, ExitStatus) {}
+
 Interpreter::Interpreter(Executor* queue, Context* ctx, FailureLogger* logger,
                          const InterpreterOptions& options)
     : ctx{ctx}, queue{queue}, logger{logger}, options(options) {}

--- a/src/Interpreter/Interpreter.cpp
+++ b/src/Interpreter/Interpreter.cpp
@@ -1,5 +1,6 @@
 #include "caffeine/Interpreter/Interpreter.h"
 #include "caffeine/Interpreter/ExprEval.h"
+#include "caffeine/Interpreter/Policy.h"
 #include "caffeine/Interpreter/StackFrame.h"
 #include "caffeine/Interpreter/Value.h"
 #include "caffeine/Support/Assert.h"
@@ -19,10 +20,6 @@ namespace caffeine {
 ExecutionResult::ExecutionResult(Status status) : status_(status) {}
 ExecutionResult::ExecutionResult(llvm::SmallVector<Context, 2>&& contexts)
     : status_(Dead), contexts_(std::move(contexts)) {}
-
-void ExecutionPolicy::on_path_forked(Context*) {}
-void ExecutionPolicy::on_path_dequeued(Context*) {}
-void ExecutionPolicy::on_path_complete(const Context*, ExitStatus) {}
 
 Interpreter::Interpreter(Executor* queue, Context* ctx, FailureLogger* logger,
                          const InterpreterOptions& options)

--- a/src/Interpreter/Policy.cpp
+++ b/src/Interpreter/Policy.cpp
@@ -1,0 +1,14 @@
+#include "caffeine/Interpreter/Policy.h"
+#include "caffeine/Interpreter/Context.h"
+
+namespace caffeine {
+
+void ExecutionPolicy::on_path_forked(Context&) {}
+void ExecutionPolicy::on_path_dequeued(Context&) {}
+void ExecutionPolicy::on_path_complete(const Context&, ExitStatus) {}
+
+bool AlwaysAllowExecutionPolicy::should_queue_path(const Context&) {
+  return true;
+}
+
+} // namespace caffeine


### PR DESCRIPTION
This is meant to be an interface that controls the behaviour of an Interpreter instance as well as providing a number of callback hooks. Currently not used anywhere, will be used in follow-up PRs.