### PR TITLE
Introduce ExecutionContextStore interface

### DIFF
--- a/include/caffeine/Interpreter/Interpreter.h
+++ b/include/caffeine/Interpreter/Interpreter.h
@@ -38,6 +38,35 @@ private:
   llvm::SmallVector<Context, 2> contexts_;
 };
 
+/**
+ * A store of Contexts that are not currently being executed.
+ *
+ * Note that when executing in a multithreaded fashion this may be accessed
+ * concurrently from multiple threads.
+ */
+class ExecutionContextStore {
+public:
+  ExecutionContextStore() = default;
+  virtual ~ExecutionContextStore() = default;
+
+  // Add a context to the store so that it can be retrieved later.
+  virtual void add_context(Context&& ctx) = 0;
+  // Get the next available context in the store
+  virtual Context next_context() = 0;
+
+  // Add multiple contexts to the store at once.
+  //
+  // By default this will just call add_context in a loop.
+  virtual void add_context_multi(Context* ctxs, size_t count);
+
+protected:
+  ExecutionContextStore(ExecutionContextStore&&) = default;
+  ExecutionContextStore(const ExecutionContextStore&) = default;
+
+  ExecutionContextStore& operator=(ExecutionContextStore&&) = default;
+  ExecutionContextStore& operator=(const ExecutionContextStore&) = default;
+};
+
 class Interpreter : public llvm::InstVisitor<Interpreter, ExecutionResult> {
 private:
   Context* ctx;

--- a/include/caffeine/Interpreter/Store.h
+++ b/include/caffeine/Interpreter/Store.h
@@ -1,0 +1,38 @@
+#pragma once
+
+#include "caffeine/ADT/Span.h"
+
+namespace caffeine {
+
+class Context;
+  
+/**
+ * A store of Contexts that are not currently being executed.
+ *
+ * Note that when executing in a multithreaded fashion this may be accessed
+ * concurrently from multiple threads.
+ */
+class ExecutionContextStore {
+public:
+  ExecutionContextStore() = default;
+  virtual ~ExecutionContextStore() = default;
+
+  // Add a context to the store so that it can be retrieved later.
+  virtual void add_context(Context&& ctx) = 0;
+  // Get the next available context in the store
+  virtual Context next_context() = 0;
+
+  // Add multiple contexts to the store at once.
+  //
+  // By default this will just call add_context in a loop.
+  virtual void add_context_multi(Span<Context> contexts);
+
+protected:
+  ExecutionContextStore(ExecutionContextStore&&) = default;
+  ExecutionContextStore(const ExecutionContextStore&) = default;
+
+  ExecutionContextStore& operator=(ExecutionContextStore&&) = default;
+  ExecutionContextStore& operator=(const ExecutionContextStore&) = default;
+};
+
+}

--- a/include/caffeine/Interpreter/Store.h
+++ b/include/caffeine/Interpreter/Store.h
@@ -1,11 +1,15 @@
 #pragma once
 
 #include "caffeine/ADT/Span.h"
+#include <condition_variable>
+#include <mutex>
+#include <optional>
+#include <queue>
 
 namespace caffeine {
 
 class Context;
-  
+
 /**
  * A store of Contexts that are not currently being executed.
  *
@@ -17,12 +21,15 @@ public:
   ExecutionContextStore() = default;
   virtual ~ExecutionContextStore() = default;
 
+  // Get the next available context in the store. If no context is available
+  // then returns std::nullopt.
+  virtual std::optional<Context> next_context() = 0;
+
   // Add a context to the store so that it can be retrieved later.
   virtual void add_context(Context&& ctx) = 0;
-  // Get the next available context in the store
-  virtual Context next_context() = 0;
 
-  // Add multiple contexts to the store at once.
+  // Add multiple contexts to the store at once. This method may move out of the
+  // contexts provided within the span.
   //
   // By default this will just call add_context in a loop.
   virtual void add_context_multi(Span<Context> contexts);
@@ -35,4 +42,37 @@ protected:
   ExecutionContextStore& operator=(const ExecutionContextStore&) = default;
 };
 
-}
+/**
+ * Global context store which stores all tasks in a global queue. Reading the
+ * next context will block if one is not present in the queue.
+ *
+ * This queue has one special behaviour in that it will exit once all the
+ * readers have blocked on the queue. For that reason, the number of consuming
+ * threads must be known in advance.
+ */
+class QueueingContextStore : public ExecutionContextStore {
+public:
+  explicit QueueingContextStore(size_t num_readers);
+
+  std::optional<Context> next_context() override;
+
+  void add_context(Context&& ctx) override;
+  void add_context_multi(Span<Context> contexts) override;
+
+  void shutdown();
+
+private:
+  Context dequeue();
+
+private:
+  std::mutex mutex;
+  std::condition_variable condvar;
+
+  size_t blocked = 0;
+  size_t num_readers;
+
+  bool done = false;
+  std::queue<Context> queue;
+};
+
+} // namespace caffeine

--- a/src/Interpreter/Interpreter.cpp
+++ b/src/Interpreter/Interpreter.cpp
@@ -21,6 +21,12 @@ ExecutionResult::ExecutionResult(Status status) : status_(status) {}
 ExecutionResult::ExecutionResult(llvm::SmallVector<Context, 2>&& contexts)
     : status_(Dead), contexts_(std::move(contexts)) {}
 
+void ExecutionContextStore::add_context_multi(Context* ctxs, size_t count) {
+  for (size_t i = 0; i < count; ++i) {
+    add_context(std::move(ctxs[i]));
+  }
+}
+
 Interpreter::Interpreter(Executor* queue, Context* ctx, FailureLogger* logger,
                          const InterpreterOptions& options)
     : ctx{ctx}, queue{queue}, logger{logger}, options(options) {}

--- a/src/Interpreter/Interpreter.cpp
+++ b/src/Interpreter/Interpreter.cpp
@@ -2,6 +2,7 @@
 #include "caffeine/Interpreter/ExprEval.h"
 #include "caffeine/Interpreter/Policy.h"
 #include "caffeine/Interpreter/StackFrame.h"
+#include "caffeine/Interpreter/Store.h"
 #include "caffeine/Interpreter/Value.h"
 #include "caffeine/Support/Assert.h"
 
@@ -20,12 +21,6 @@ namespace caffeine {
 ExecutionResult::ExecutionResult(Status status) : status_(status) {}
 ExecutionResult::ExecutionResult(llvm::SmallVector<Context, 2>&& contexts)
     : status_(Dead), contexts_(std::move(contexts)) {}
-
-void ExecutionContextStore::add_context_multi(Context* ctxs, size_t count) {
-  for (size_t i = 0; i < count; ++i) {
-    add_context(std::move(ctxs[i]));
-  }
-}
 
 Interpreter::Interpreter(Executor* queue, Context* ctx, FailureLogger* logger,
                          const InterpreterOptions& options)

--- a/src/Interpreter/Store.cpp
+++ b/src/Interpreter/Store.cpp
@@ -1,0 +1,13 @@
+
+#include "caffeine/Interpreter/Store.h"
+#include "caffeine/Interpreter/Context.h"
+
+namespace caffeine {
+
+void ExecutionContextStore::add_context_multi(Span<Context> contexts) {
+  for (Context& ctx : contexts) {
+    add_context(std::move(ctx));
+  }
+}
+
+} // namespace caffeine

--- a/src/Interpreter/Store.cpp
+++ b/src/Interpreter/Store.cpp
@@ -1,6 +1,8 @@
 
 #include "caffeine/Interpreter/Store.h"
+#include "caffeine/ADT/Guard.h"
 #include "caffeine/Interpreter/Context.h"
+#include "caffeine/Support/Assert.h"
 
 namespace caffeine {
 
@@ -8,6 +10,66 @@ void ExecutionContextStore::add_context_multi(Span<Context> contexts) {
   for (Context& ctx : contexts) {
     add_context(std::move(ctx));
   }
+}
+
+QueueingContextStore::QueueingContextStore(size_t num_readers)
+    : num_readers(num_readers) {}
+
+std::optional<Context> QueueingContextStore::next_context() {
+  auto lock = std::unique_lock(mutex);
+
+  if (done)
+    return std::nullopt;
+  if (!queue.empty())
+    return dequeue();
+
+  blocked += 1;
+  auto guard = make_guard([&] { blocked -= 1; });
+
+  if (blocked == num_readers) {
+    done = true;
+    condvar.notify_all();
+  }
+
+  while (queue.empty() && !done)
+    condvar.wait(lock);
+
+  if (done)
+    return std::nullopt;
+  return dequeue();
+}
+
+void QueueingContextStore::add_context(Context&& ctx) {
+  auto lock = std::unique_lock(mutex);
+  queue.push(std::move(ctx));
+  lock.unlock();
+  condvar.notify_one();
+}
+void QueueingContextStore::add_context_multi(Span<Context> ctxs) {
+  auto lock = std::unique_lock(mutex);
+  for (Context& ctx : ctxs)
+    queue.push(std::move(ctx));
+  lock.unlock();
+
+  if (ctxs.size() == 1)
+    condvar.notify_one();
+  else
+    condvar.notify_all();
+}
+
+void QueueingContextStore::shutdown() {
+  auto lock = std::unique_lock(mutex);
+  done = true;
+  lock.unlock();
+  condvar.notify_all();
+}
+
+Context QueueingContextStore::dequeue() {
+  CAFFEINE_ASSERT(!queue.empty());
+
+  Context ctx = std::move(queue.front());
+  queue.pop();
+  return ctx;
 }
 
 } // namespace caffeine


### PR DESCRIPTION
This is meant to be a generalized interface to store/retrieve `Context` instances as needed for running interpreters.

The `ExecutionContextStore` is meant to manage:
- Prioritizing which contexts to run first and which to run later or never
- Blocking executor threads until a context is ready

I've also included an implementation of a threadsafe queue store that will serve up contexts to executors until all executors are blocked at which point it will return `std::nullopt`.

This isn't used yet but will be used in following PRs.

/stack #284 