### PR TITLE
Fix bad depfile generation when building LLVM IR libraries

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,6 +48,9 @@ string(TOUPPER "${CAFFEINE_ENABLE_LTO}" CAFFEINE_ENABLE_LTO)
 set(CAFFEINE_FMTONLY OFF CACHE BOOL "Avoid building the project itself")
 mark_as_advanced(CAFFEINE_FMTONLY)
 
+# Disable messages for targets on makefile generators
+set_property(GLOBAL PROPERTY TARGET_MESSAGES OFF)
+
 if (CAFFEINE_ENABLE_BUILD)
   # TODO: We should have an option to download and build these locally if needed.
   find_package(LLVM 10.0 REQUIRED)

--- a/cmake/CaffeineTestUtils.cmake
+++ b/cmake/CaffeineTestUtils.cmake
@@ -70,7 +70,7 @@ function(declare_test TEST_NAME_OUT test)
     OUTPUT "${GEN_OUT}"
     COMMAND gen-test-main --skip-if-present -o "${GEN_OUT}" "${TGT_OUT}" test
     MAIN_DEPENDENCY "${TGT_OUT}"
-    COMMENT Generating main method for "${test_target}"
+    COMMENT "Generating main method for ${test_target}"
   )
 
   # Remove unused methods
@@ -78,7 +78,7 @@ function(declare_test TEST_NAME_OUT test)
     OUTPUT "${OPT_OUT}"
     COMMAND "${LLVM_OPT}" -internalize -globaldce "${GEN_OUT}" -o "${OPT_OUT}"
     MAIN_DEPENDENCY "${GEN_OUT}"
-    COMMENT Optimizing "${test_target}"
+    COMMENT "Optimizing ${test_target}"
   )
 
   add_custom_command(
@@ -91,7 +91,6 @@ function(declare_test TEST_NAME_OUT test)
   add_custom_target(
     "gen-${test_target}" ALL
     DEPENDS "${DIS_OUT}"
-    COMMENT "Built target gen-${test_target}"
   )
 
   if(should_skip)


### PR DESCRIPTION
In the previous setup clang would generate a depfile with the dependencies specified using absolute paths. However, ninja expects
the depfile target path to be relative to the binary directory. To fix this we need to update both the WORKING_DIRECTORY and the output filename for the compilation commands.

As an extra bonus, this also sets a property to disable useless "Built target X" messages when building using makefiles.