### PR TITLE
Simplify gen-test-main using llvm::IRBuilder

### DIFF
--- a/cmake/CaffeineTestUtils.cmake
+++ b/cmake/CaffeineTestUtils.cmake
@@ -68,9 +68,10 @@ function(declare_test TEST_NAME_OUT test)
 
   add_custom_command(
     OUTPUT "${GEN_OUT}"
-    COMMAND gen-test-main --skip-if-present -o "${GEN_OUT}" "${TGT_OUT}" test
+    COMMAND gen-test-main ARGS --skip-if-present -o "${GEN_OUT}" "${TGT_OUT}" test
     MAIN_DEPENDENCY "${TGT_OUT}"
     COMMENT "Generating main method for ${test_target}"
+    DEPENDS "$<TARGET_FILE:gen-test-main>"
   )
 
   # Remove unused methods


### PR DESCRIPTION
I found this class while looking around at some LLVM tutorials. Since it's likely I'm going to be using it in the future I decided to learn how to use it by cleaning up the `gen-target-main` executable.

I've also bundled a dependency fix so changing `gen-target-main` rebuilds all the dependent files that use it in a build step.