### PR TITLE
Extract repetitive parts of CaffeineTestUtils to utility function

### DIFF
--- a/tools/gen-test-main/CMakeLists.txt
+++ b/tools/gen-test-main/CMakeLists.txt
@@ -5,8 +5,8 @@ add_executable(gen-test-main
 
 # The SYSTEM should silence warnings within these headers
 target_include_directories(gen-test-main SYSTEM
-  PUBLIC "${LLVM_INCLUDE_DIRS}"
-  PUBLIC "${FMT_INCLUDE_DIRS}"
+  PRIVATE "${LLVM_INCLUDE_DIRS}"
+  PRIVATE "${FMT_INCLUDE_DIRS}"
 )
 
 target_link_libraries(gen-test-main PRIVATE LLVMCore LLVMIRReader LLVMBitWriter LLVMTransformUtils)


### PR DESCRIPTION
I'm planning on making some changes to this code here so this PR just reorganizes the cmake code here to be a little more sane. It also puts generated artifacts in more consistent directories which is helpful if you need to look at the build output.