### PR TITLE
Introduce tool to generate implementations of LLVM builtins

### DIFF
--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -1,2 +1,3 @@
 
 add_subdirectory(gen-test-main)
+add_subdirectory(gen-builtins)

--- a/tools/gen-builtins/CMakeLists.txt
+++ b/tools/gen-builtins/CMakeLists.txt
@@ -1,0 +1,16 @@
+
+add_executable(gen-builtins
+  main.cpp
+  memset.cpp
+  resolve.cpp
+)
+
+target_include_directories(gen-builtins
+  PRIVATE "${LLVM_INCLUDE_DIRS}"
+  PRIVATE "${FMT_INCLUDE_DIRS}"
+)
+
+target_link_libraries(gen-builtins PRIVATE LLVMCore LLVMIRReader LLVMBitWriter)
+target_link_libraries(gen-builtins PRIVATE fmt::fmt)
+target_link_libraries(gen-builtins PRIVATE caffeine)
+

--- a/tools/gen-builtins/builtins.h
+++ b/tools/gen-builtins/builtins.h
@@ -1,0 +1,29 @@
+#pragma once
+
+#include <llvm/IR/Function.h>
+#include <llvm/IR/Module.h>
+#include <llvm/IR/Type.h>
+
+namespace caffeine {
+
+/**
+ * Generate an implementation for an instance of the llvm.memset.* builtin and
+ * replace the provided function with it within the parent module.
+ *
+ * This function takes a function pointer to a memset defintion within the
+ * current module and generates the corresponding implementation.
+ */
+llvm::Function* generateMemset(llvm::Module* mod, llvm::Function* memsetDecl);
+
+/**
+ * Get the existing declaration of a variant of the caffeine.resolve builtin. If
+ * the requested variant is not available then generate it within the provided
+ * module.
+ *
+ * The resolve builtin has the interpreter "prefault" an address range. This
+ * makes so that subsequent accesses to that pointer can be quicker.
+ */
+llvm::FunctionCallee generateResolve(llvm::Module* module, llvm::Type* ptr_ty,
+                                     llvm::Type* size_ty);
+
+} // namespace caffeine

--- a/tools/gen-builtins/main.cpp
+++ b/tools/gen-builtins/main.cpp
@@ -52,7 +52,6 @@ int main(int argc, char** argv) {
   // parse for LLVM 10.0.0. To work around that I'm printing using textual IR.
   if (OutputFilename == "-") {
     module->print(llvm::outs(), nullptr);
-    // WriteBitcodeToFile(*m, llvm::outs());
   } else {
     std::error_code EC;
     llvm::raw_fd_ostream os(OutputFilename, EC);
@@ -65,6 +64,5 @@ int main(int argc, char** argv) {
     }
 
     module->print(os, nullptr);
-    // WriteBitcodeToFile(*m, os);
   }
 }

--- a/tools/gen-builtins/main.cpp
+++ b/tools/gen-builtins/main.cpp
@@ -1,0 +1,70 @@
+
+#include "builtins.h"
+#include "caffeine/Support/Assert.h"
+#include <fmt/format.h>
+#include <llvm/IR/LLVMContext.h>
+#include <llvm/IRReader/IRReader.h>
+#include <llvm/Support/CommandLine.h>
+#include <llvm/Support/InitLLVM.h>
+#include <llvm/Support/SourceMgr.h>
+#include <llvm/Support/WithColor.h>
+
+using namespace llvm;
+
+cl::opt<std::string> InputFilename(cl::Positional, cl::Required,
+                                   cl::desc("<input file>"));
+cl::opt<std::string> OutputFilename("o", cl::desc("output filename"),
+                                    cl::value_desc("filename"), cl::init("-"));
+
+int main(int argc, char** argv) {
+  llvm::InitLLVM X{argc, argv};
+  CAFFEINE_ASSERT(argc != 0,
+                  "gen-builtins called with 0 command line arguments");
+
+  llvm::cl::ParseCommandLineOptions(argc, argv,
+                                    "\n  Replace all calls to certain LLVM "
+                                    "builtins with implementations that"
+                                    "\n  caffeine can execute.");
+
+  llvm::LLVMContext context;
+  llvm::SMDiagnostic error;
+
+  std::unique_ptr<llvm::Module> module =
+      llvm::parseIRFile(InputFilename, error, context);
+  if (!module) {
+    errs() << argv[0] << ": ";
+    WithColor::error() << " loading file '" << InputFilename << "'\n";
+    return EXIT_FAILURE;
+  }
+
+  for (llvm::Function& function : module->functions()) {
+    if (!function.isDeclaration())
+      continue;
+
+    auto name = function.getName();
+    if (name.startswith("llvm.memset.")) {
+      caffeine::generateMemset(module.get(), &function);
+      continue;
+    }
+  }
+
+  // NOTE: WriteBitcodeToFile seems to produce something that llvm-dis can't
+  // parse for LLVM 10.0.0. To work around that I'm printing using textual IR.
+  if (OutputFilename == "-") {
+    module->print(llvm::outs(), nullptr);
+    // WriteBitcodeToFile(*m, llvm::outs());
+  } else {
+    std::error_code EC;
+    llvm::raw_fd_ostream os(OutputFilename, EC);
+
+    if (EC) {
+      errs() << argv[0] << ": ";
+      WithColor::error() << " unable to write to output file '"
+                         << OutputFilename << "': " << EC.message() << "\n";
+      return 1;
+    }
+
+    module->print(os, nullptr);
+    // WriteBitcodeToFile(*m, os);
+  }
+}

--- a/tools/gen-builtins/memset.cpp
+++ b/tools/gen-builtins/memset.cpp
@@ -1,0 +1,155 @@
+
+#include "builtins.h"
+#include "caffeine/Support/Assert.h"
+#include <fmt/format.h>
+#include <llvm/IR/Constants.h>
+#include <llvm/IR/IRBuilder.h>
+
+namespace caffeine {
+
+/**
+ * In C-ish pseudocode, the most basic equivalent to LLVM's memset looks
+ * somewhat like this (including the isvolatile parameter but leaving it
+ * unused):
+ *
+ * void llvm.memset.p0i8.i32(i8* dst, i8 val, i32 len, i1 isvolatile) {
+ *   while (len > 0) {
+ *     *dst = val;
+ *     dst += 1;
+ *     len -= 1;
+ *   }
+ * }
+ *
+ * However, this version requires that the solver perform an expensive check on
+ * every single store as the index is increasing. To avoid this, I'll take
+ * advantage of a caffeine builtin function. Here's version 2:
+ *
+ * void llvm.memset.p0i8.i32(i8* dst_, i8 val, i32 len, i1 _) {
+ *   i8* dst = caffeine.resolve.p0i8.i32(dst_, len);
+ *
+ *   while (len > 0) {
+ *     *dst = val;
+ *     dst += 1;
+ *     len -= 1;
+ *   }
+ * }
+ *
+ * The main new thing here is the caffeine.resolve.* calls. These effectively
+ * tell the interpreter "we're going to access this range of memory" so that we
+ * can get any bad accesses out of the way right away instead of having to do a
+ * more expensive check on every iteration. With decent constant evaluation, it
+ * should be possible to make all the following accesses without ever hitting
+ * the underlying solver.
+ *
+ * Now, we can't use this C code directly. For one, it needs to be templated out
+ * for a variety of different types. Secondly, the compiler has a tendency to
+ * optimize this down to a llvm.memset call. This obviously doesn't help us
+ * here. For that reason, we need to turn it into LLVM IR ourselves. So here we
+ * go (roughly):
+ *
+ * define void @caffeine.memset.p0i8.i32(
+ *     i8* %arg_dst, i8 %val, i32 %arg_len, i1* %isvolatile) {
+ * entry:
+ *   %resolved = call void @caffeine.resolve.p0i8.i32(i8* %arg_dst, i32 %arg_len)
+ *   br label %head
+ *
+ * head:
+ *   %dst = phi i8* [ %entry, %resolved ], [ %body, %next_dst ]
+ *   %len = phi i32 [ %entry, %arg_len  ], [ %body, %next_len ]
+ *   %cond = icmp ne i32 %len, 0
+ *   br i1 %cond, label %exit, label %body
+ *
+ * body:
+ *   store i8 %val, i8* %dst, align 1
+ *   %next_dst = getelementptr i8, i8* %dst, i32 1
+ *   %next_len = sub i32 %len, 1
+ *   br label %head
+ *
+ * exit:
+ *  ret void
+ * }
+ */
+
+llvm::Function* generateMemset(llvm::Module* m, llvm::Function* decl) {
+  using llvm::ArrayRef;
+  using llvm::Attribute;
+  using llvm::ConstantInt;
+
+  CAFFEINE_ASSERT(decl->arg_size() == 4);
+  CAFFEINE_ASSERT(decl->getBasicBlockList().empty());
+  CAFFEINE_ASSERT(decl->getArg(0)->getType()->getPointerElementType() ==
+                  decl->getArg(1)->getType());
+
+  auto arg_dst = decl->getArg(0);
+  auto arg_val = decl->getArg(1);
+  auto arg_len = decl->getArg(2);
+
+  auto entry_ = llvm::BasicBlock::Create(m->getContext(), "entry", decl);
+  auto head_ = llvm::BasicBlock::Create(m->getContext(), "head", decl);
+  auto body_ = llvm::BasicBlock::Create(m->getContext(), "body", decl);
+  auto exit_ = llvm::BasicBlock::Create(m->getContext(), "exit", decl);
+
+  auto entry = llvm::IRBuilder{entry_};
+  auto head = llvm::IRBuilder{head_};
+  auto body = llvm::IRBuilder{body_};
+  auto exit = llvm::IRBuilder{exit_};
+
+  // First build entry block
+  auto resolve = generateResolve(m, arg_dst->getType(), arg_len->getType());
+  auto resolved = entry.CreateCall(resolve.getCallee(),
+                                   ArrayRef<llvm::Value*>{arg_dst, arg_len});
+  entry.CreateBr(head_);
+
+  // Now build the loop header. We'll fix up the PHIs at the end
+  auto dst = head.CreatePHI(arg_dst->getType(), 2);
+  auto len = head.CreatePHI(arg_len->getType(), 2);
+  auto cond = head.CreateICmpNE(len, ConstantInt::get(arg_len->getType(), 0));
+  head.CreateCondBr(cond, body_, exit_);
+
+  // And now the loop body
+  body.CreateStore(arg_val, dst);
+  auto next_dst = body.CreateInBoundsGEP(
+      dst, ArrayRef<llvm::Value*>{
+               ConstantInt::get(llvm::Type::getInt32Ty(m->getContext()), 1)});
+  auto next_len = body.CreateSub(len, ConstantInt::get(len->getType(), 1));
+  body.CreateBr(head_);
+
+  // And finally the exit block
+  exit.CreateRetVoid();
+
+  // Lastly, we fix up the PHI nodes within the loop header
+  dst->addIncoming(resolved, entry_);
+  dst->addIncoming(next_dst, body_);
+  len->addIncoming(arg_len, entry_);
+  len->addIncoming(next_len, body_);
+
+  llvm::AttrBuilder builder;
+  // Prevent any future optimizations from touching the internals of this
+  // function. Otherwise it's likely to get optimized to a memset call
+  builder.addAttribute(Attribute::OptimizeNone);
+  builder.addAttribute(Attribute::NoInline);
+
+  // Other attributes that seem to apply.
+  builder.addAttribute(Attribute::NoRecurse);
+  builder.addAttribute(Attribute::NoBuiltin);
+  builder.addAttribute(Attribute::NoRecurse);
+  builder.addAttribute(Attribute::NoUnwind);
+  builder.addAttribute(Attribute::ArgMemOnly);
+  builder.addAttribute(Attribute::NoFree);
+
+  decl->setAttributes(llvm::AttributeList::get(
+      m->getContext(), llvm::AttributeList::FunctionIndex, builder));
+  decl->setName(fmt::format("caffeine.memset.p{}i{}.i{}",
+                            arg_dst->getType()->getPointerAddressSpace(),
+                            arg_val->getType()->getIntegerBitWidth(),
+                            arg_len->getType()->getIntegerBitWidth()));
+
+  // These are what clang sets on the dst argument to memset. Copying them
+  // here since they're probably useful.
+  decl->addAttribute(1, Attribute::WriteOnly);
+  decl->addAttribute(1, Attribute::NoCapture);
+
+  return decl;
+}
+
+} // namespace caffeine

--- a/tools/gen-builtins/resolve.cpp
+++ b/tools/gen-builtins/resolve.cpp
@@ -1,0 +1,34 @@
+#include "builtins.h"
+#include "caffeine/Support/Assert.h"
+#include <fmt/format.h>
+
+namespace caffeine {
+
+llvm::FunctionCallee generateResolve(llvm::Module* module, llvm::Type* ptr_ty,
+                                     llvm::Type* size_ty) {
+  using llvm::Attribute;
+
+  CAFFEINE_ASSERT(ptr_ty->isPointerTy());
+  CAFFEINE_ASSERT(ptr_ty->getPointerElementType()->isIntegerTy());
+  CAFFEINE_ASSERT(size_ty->isIntegerTy());
+
+  std::string funcname = fmt::format(
+      "caffeine.resolve.p{}i{}.i{}", ptr_ty->getPointerAddressSpace(),
+      ptr_ty->getPointerElementType()->getIntegerBitWidth(),
+      size_ty->getIntegerBitWidth());
+
+  llvm::AttrBuilder builder;
+  builder.addAttribute(Attribute::ReadNone);
+  builder.addAttribute(Attribute::ReadNone);
+  builder.addAttribute(Attribute::NoUnwind);
+  builder.addAttribute(Attribute::WillReturn);
+  builder.addAttribute(Attribute::NoFree);
+  builder.addAttribute(Attribute::ArgMemOnly);
+
+  llvm::AttributeList attrs = llvm::AttributeList::get(
+      module->getContext(), llvm::AttributeList::FunctionIndex, builder);
+
+  return module->getOrInsertFunction(funcname, attrs, ptr_ty, ptr_ty, size_ty);
+}
+
+} // namespace caffeine


### PR DESCRIPTION
The current state of the repo is that we have builtin implementations for the most common calls to the `llvm.memset.*` intrinsic. Namely, we really only support the 
```
void llvm.memset.p0i8.i64(i8* %dst, i8 %val, i64 %len, i1 %isvolatile)
```
variant. This is done by hand-implementing a function
```
void caffeine_builtin_memset(...)
```
with the same signature in _LLVM IR_ and then having the interpreter patch calls to the intrinsic to instead point to the function we implemented by hand.

This has some big limitations:
1. We don't support anything other than the most basic memset calls. Anything that gets generated to use a different type will fail to compile. As an example, this will fail on platforms where pointers are 32-bits in size.
2. We don't support any platform that is not data-layout-compatible with x86_64-linux-gnu. This is the more relevant issue because it means that we cannot compile our test cases for windows.

Both limitations are decently large problems. The solution I've undertaken here is to instead generate the required builtin
implementations at build time. This means that we never end up needing an unsupported function variant since we support _all_ the variants.

As a bonus, we can now also use IR names that can't be defined from C.

This PR is part of my work to address #293