### PR TITLE
Generate implementations of `llvm.memset.*` intrinsic as part of the build process

### DIFF
--- a/cmake/CaffeineTestUtils.cmake
+++ b/cmake/CaffeineTestUtils.cmake
@@ -85,8 +85,6 @@ function(declare_test TEST_NAME_OUT test)
   set(DIS_OUT "${output_dir}/${basename}${extra_ext}")
 
   make_directory("${output_dir}")
-  make_directory("${CMAKE_CURRENT_BINARY_DIR}/CMakeFiles/gen")
-  make_directory("${CMAKE_CURRENT_BINARY_DIR}/CMakeFiles/opt")
 
   llvm_library(
     "${test_target}" "${test}"
@@ -100,7 +98,7 @@ function(declare_test TEST_NAME_OUT test)
 
 
   build_command(
-    OUTPUT "${OUT_DIR}/with-main.bc"
+    OUTPUT "${OUT_DIR}/with-main.ll"
     MAIN_DEPENDENCY "${OUT_DIR}/lib.bc"
     COMMAND gen-test-main ARGS --skip-if-present -o <OUTPUT> <MAIN_DEPENDENCY> test
     COMMENT "Generating main method for ${test_target}"
@@ -108,8 +106,15 @@ function(declare_test TEST_NAME_OUT test)
   )
 
   build_command(
+    OUTPUT "${OUT_DIR}/with-intrinsics.ll"
+    MAIN_DEPENDENCY "${OUT_DIR}/with-main.ll"
+    COMMAND gen-builtins ARGS -o <OUTPUT> <MAIN_DEPENDENCY>
+    COMMENT "Generating builtin methods for ${test_target}"
+  )
+
+  build_command(
     OUTPUT "${OUT_DIR}/optimized.bc"
-    MAIN_DEPENDENCY "${OUT_DIR}/with-main.bc"
+    MAIN_DEPENDENCY "${OUT_DIR}/with-intrinsics.ll"
     COMMAND "${LLVM_OPT}" ARGS -internalize -globaldce <MAIN_DEPENDENCY> -o <OUTPUT>
     COMMENT "Optimizing ${test_target}"
   )

--- a/test/run-pass/mem/memset.c
+++ b/test/run-pass/mem/memset.c
@@ -1,0 +1,22 @@
+
+#include "caffeine.h"
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+
+__attribute__((noinline)) uint32_t* alloc_bytes() {
+  uint32_t* bytes = malloc(128 * sizeof(uint32_t));
+  bytes[127] = 5;
+  memset(bytes, 0x10, sizeof(uint32_t) * 128);
+
+  return bytes;
+}
+
+void test() {
+  uint32_t* bytes = alloc_bytes();
+
+  caffeine_assert(bytes[127] == 0x10101010);
+  caffeine_assert(bytes[0] == 0x10101010);
+
+  free(bytes);
+}


### PR DESCRIPTION
Now that #294 has added a tool to generate implementations of the `memset` intrinsic this PR runs `gen-builtins` over test case IR files at build time so that they can take advantage of the new implementations.

This is part of the work towards resolving #293.

/stack #294 