### PR TITLE
Break `Solver` out of `Context`

### DIFF
--- a/include/caffeine/Interpreter/Context.h
+++ b/include/caffeine/Interpreter/Context.h
@@ -24,7 +24,6 @@ class Context {
 public:
   std::vector<StackFrame> stack;
   std::unordered_map<llvm::GlobalVariable*, LLVMValue> globals;
-  std::shared_ptr<Solver> solver;
   MemHeap heap;
   std::vector<Assertion> assertions;
 
@@ -34,7 +33,7 @@ private:
   uint64_t constant_num_ = 0;
 
 public:
-  Context(llvm::Function* func, std::shared_ptr<Solver> solver);
+  Context(llvm::Function* func);
 
   /**
    * Create a new context that is independent from this
@@ -112,7 +111,8 @@ public:
    *
    * See the docs on Solver::check for more details.
    */
-  SolverResult check(const Assertion& extra = Assertion::constant(true));
+  SolverResult check(std::shared_ptr<Solver> solver,
+                     const Assertion& extra = Assertion::constant(true));
 
   /**
    * Validate whether the set of assertions combined with the extra assertion is
@@ -121,7 +121,8 @@ public:
    * See the docs on Solver::resolve for more details.
    */
   std::unique_ptr<Model>
-  resolve(const Assertion& extra = Assertion::constant(true));
+  resolve(std::shared_ptr<Solver> solver,
+          const Assertion& extra = Assertion::constant(true));
 
 private:
   // TODO: Temporary until context redesign is completed

--- a/include/caffeine/Interpreter/Interpreter.h
+++ b/include/caffeine/Interpreter/Interpreter.h
@@ -47,6 +47,7 @@ private:
   Context* ctx;
   FailureLogger* logger;
   InterpreterOptions options;
+  std::shared_ptr<Solver> solver;
 
 public:
   /**

--- a/include/caffeine/Memory/MemHeap.h
+++ b/include/caffeine/Memory/MemHeap.h
@@ -16,6 +16,7 @@ class Assertion;
 class MemHeap;
 class LLVMScalar;
 class LLVMValue;
+class Solver;
 
 /**
  * An allocation category.
@@ -252,7 +253,8 @@ public:
    * method when an already known allocation can be preserved across multiple
    * uses.
    */
-  llvm::SmallVector<Pointer, 1> resolve(const Pointer& value,
+  llvm::SmallVector<Pointer, 1> resolve(std::shared_ptr<Solver> solver,
+                                        const Pointer& value,
                                         Context& ctx) const;
 
   void DebugPrint() const;

--- a/include/caffeine/Solver/Solver.h
+++ b/include/caffeine/Solver/Solver.h
@@ -13,6 +13,9 @@ namespace caffeine {
 class Assertion;
 class Operation;
 class Constant;
+class Context;
+class LLVMScalar;
+class LLVMValue;
 class Symbol;
 
 enum SolverResult { UNSAT, SAT, Unknown };

--- a/src/Interpreter/Context.cpp
+++ b/src/Interpreter/Context.cpp
@@ -25,8 +25,8 @@ static void assert_valid_arg(llvm::Type* type) {
   CAFFEINE_ABORT(message);
 }
 
-Context::Context(llvm::Function* function, std::shared_ptr<Solver> solver)
-    : solver(std::move(solver)), mod(function->front().getModule()) {
+Context::Context(llvm::Function* function)
+    : mod(function->front().getModule()) {
   stack.emplace_back(function);
   StackFrame& frame = stack_top();
 
@@ -135,10 +135,12 @@ LLVMValue Context::lookup(llvm::Value* value) {
   return (LLVMValue)ExprEvaluator{this}.visit(value);
 }
 
-SolverResult Context::check(const Assertion& extra) {
+SolverResult Context::check(std::shared_ptr<Solver> solver,
+                            const Assertion& extra) {
   return solver->check(assertions, extra);
 }
-std::unique_ptr<Model> Context::resolve(const Assertion& extra) {
+std::unique_ptr<Model> Context::resolve(std::shared_ptr<Solver> solver,
+                                        const Assertion& extra) {
   return solver->resolve(assertions, extra);
 }
 

--- a/src/Memory/MemHeap.cpp
+++ b/src/Memory/MemHeap.cpp
@@ -393,7 +393,8 @@ Assertion MemHeap::check_starts_allocation(const Pointer& ptr) {
                              result);
 }
 
-llvm::SmallVector<Pointer, 1> MemHeap::resolve(const Pointer& ptr,
+llvm::SmallVector<Pointer, 1> MemHeap::resolve(std::shared_ptr<Solver> solver,
+                                               const Pointer& ptr,
                                                Context& ctx) const {
   llvm::SmallVector<Pointer, 1> results;
 
@@ -402,7 +403,8 @@ llvm::SmallVector<Pointer, 1> MemHeap::resolve(const Pointer& ptr,
       return results;
 
     const Allocation& alloc = (*this)[ptr.alloc()];
-    if (ctx.check(alloc.check_inbounds(ptr.offset(), 0)) == SolverResult::UNSAT)
+    if (ctx.check(solver, alloc.check_inbounds(ptr.offset(), 0)) ==
+        SolverResult::UNSAT)
       return results;
 
     results.push_back(ptr);
@@ -420,7 +422,7 @@ llvm::SmallVector<Pointer, 1> MemHeap::resolve(const Pointer& ptr,
     auto cmp2 = ICmpOp::CreateICmp(ICmpOpcode::ULT, value, end);
     auto assertion = BinaryOp::CreateAnd(cmp1, cmp2);
 
-    if (ctx.check(Assertion(assertion)) != SolverResult::UNSAT) {
+    if (ctx.check(solver, Assertion(assertion)) != SolverResult::UNSAT) {
       results.push_back(
           Pointer(it.key(), BinaryOp::CreateSub(value, alloc.address())));
     }

--- a/src/bin/caffeine.cpp
+++ b/src/bin/caffeine.cpp
@@ -2,10 +2,6 @@
 #include "caffeine/Interpreter/Interpreter.h"
 #include "caffeine/Interpreter/Policy.h"
 #include "caffeine/Interpreter/Store.h"
-#include "caffeine/Solver/CanonicalizingSolver.h"
-#include "caffeine/Solver/SequenceSolver.h"
-#include "caffeine/Solver/SimplifyingSolver.h"
-#include "caffeine/Solver/Z3Solver.h"
 
 #include <boost/core/demangle.hpp>
 #include <llvm/IR/DiagnosticInfo.h>
@@ -162,9 +158,6 @@ int main(int argc, char** argv) {
   // Print out exception messages in std::terminate
   llvm_handler = std::set_terminate(custom_terminate_handler);
 
-  std::shared_ptr<caffeine::Solver> solver = caffeine::make_sequence_solver(
-      caffeine::SimplifyingSolver(), caffeine::CanonicalizingSolver(),
-      caffeine::Z3Solver());
   auto logger = CountingFailureLogger{std::cout, function};
 
   auto options = caffeine::ExecutorOptions{
@@ -175,7 +168,7 @@ int main(int argc, char** argv) {
   auto store = caffeine::QueueingContextStore(options.num_threads);
   auto exec = caffeine::Executor(&policy, &store, &logger, options);
 
-  store.add_context(Context{function, solver});
+  store.add_context(Context{function});
 
   exec.run();
 

--- a/test/unit/Memory/MemHeap.cpp
+++ b/test/unit/Memory/MemHeap.cpp
@@ -42,7 +42,7 @@ protected:
 
 TEST_F(MemHeapTests, resolve_pointer_single) {
   MemHeap heap;
-  Context context{function.get(), solver};
+  Context context{function.get()};
 
   unsigned index_size = layout.getIndexSizeInBits(0);
   auto align = MakeInt(16);
@@ -57,11 +57,13 @@ TEST_F(MemHeapTests, resolve_pointer_single) {
 
   auto ptr = Pointer(BinaryOp::CreateAdd(heap[alloc].address(), offset));
 
-  ASSERT_EQ(context.check(!heap.check_valid(ptr, 0)), SolverResult::UNSAT);
+  ASSERT_EQ(context.check(solver, !heap.check_valid(ptr, 0)),
+            SolverResult::UNSAT);
 
-  auto res = heap.resolve(ptr, context);
+  auto res = heap.resolve(solver, ptr, context);
 
   ASSERT_EQ(res.size(), 1);
   ASSERT_EQ(res[0].alloc(), alloc);
-  ASSERT_EQ(context.check(res[0].check_null(heap)), SolverResult::UNSAT);
+  ASSERT_EQ(context.check(solver, res[0].check_null(heap)),
+            SolverResult::UNSAT);
 }


### PR DESCRIPTION
This PR breaks out the `Solver` from the `Context`. This is helpful in order to allow multiple `Solver`s to coexist in a multithreaded environment. As part of this change, the `Interpreter` now creates the `Solver` stack, as opposed to the caffeine binary harness. This is to allow each `Interpreter` to own it's `Solver` so that we can have a `Solver` per thread. Previously, it was only possible to have one `Solver` per runtime.

I was considering adding a method to `Context` along the lines of `setSolver` but decided against it because of the ownership issue.