### PR TITLE
Add cmake option to disable IR tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,9 +5,10 @@ project(caffeine LANGUAGES C CXX)
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake")
 
 
-option(CAFFEINE_ENABLE_TESTS  "Enable test targets" ON)
-option(CAFFEINE_ENABLE_FORMAT "Enable formatting targets" ON)
-option(CAFFEINE_BUILD_BITCODE "If true compile tests and libraries down to bitcode, otherwise compile them to text IR" OFF)
+option(CAFFEINE_ENABLE_TESTS    "Enable test targets" ON)
+option(CAFFEINE_ENABLE_FORMAT   "Enable formatting targets" ON)
+option(CAFFEINE_BUILD_BITCODE   "If true compile tests and libraries down to bitcode, otherwise compile them to text IR" OFF)
+option(CAFFEINE_ENABLE_IR_TESTS "Enable tests which involve handwritten LLVM IR" ON)
 
 # Optimization settings
 set(CAFFEINE_ENABLE_LTO OFF CACHE STRING "Enable link-time-optimizations. Valid values: ON, OFF, FULL, THIN")

--- a/cmake/CaffeineTestUtils.cmake
+++ b/cmake/CaffeineTestUtils.cmake
@@ -67,6 +67,16 @@ function(declare_test TEST_NAME_OUT test)
   string(REGEX REPLACE "\\\\|/" "_" test_target "${test_name}")
 
   get_filename_component(test_ext "${test_name}" LAST_EXT)
+  
+  if (NOT CAFFEINE_ENABLE_IR_TESTS AND 
+      ("${test_ext}" STREQUAL ".ll" OR "${test_ext}" STREQUAL ".bc"))
+    add_test(
+      NAME "${test_name}"
+      COMMAND skip-test "IR tests are disabled"
+    )
+    set_tests_properties("${test_name}" PROPERTIES SKIP_RETURN_CODE 77)
+    return()
+  endif()
 
   if("${test_ext}" STREQUAL ".ll")
     set(test_output "${CMAKE_BINARY_DIR}/test/${test_name}")


### PR DESCRIPTION
This should be the last bit needed to get caffeine to compile (although not with all the tests) on windows.