### PR TITLE
Add cmake options to build with sanitizers

### DIFF
--- a/.github/workflows/build-project.yml
+++ b/.github/workflows/build-project.yml
@@ -22,7 +22,10 @@ jobs:
       - name: Configure
         run: |
           mkdir -p build
-          cmake -B build -DCAFFEINE_CI=ON -DCMAKE_BUILD_TYPE=RelWithDebInfo
+          cmake -B build \
+            -DCAFFEINE_CI=ON \
+            -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+            -DCAFFEINE_ENABLE_UBSAN=ON
         env:
           CC: ${{ matrix.cc }}
           CXX: ${{ matrix.cxx }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,13 @@ option(CAFFEINE_BUILD_BITCODE "If true compile tests and libraries down to bitco
 set(CAFFEINE_ENABLE_LTO OFF CACHE STRING "Enable link-time-optimizations. Valid values: ON, OFF, FULL, THIN")
 set(CAFFEINE_USE_LINKER ""  CACHE STRING "Add -fuse-ld={name} to the link invocation.")
 
+# Sanitizers
+option(CAFFEINE_ENABLE_TSAN  "Build with ThreadSanitizer"  OFF)
+option(CAFFEINE_ENABLE_ASAN  "Build with AddressSanitizer" OFF)
+option(CAFFEINE_ENABLE_UBSAN "Build with UndefinedBehaviourSanitizer" OFF)
+option(CAFFEINE_ENABLE_MSAN  "Build with MemorySanitizer"  OFF)
+option(CAFFEINE_ENABLE_LSAN  "Build with LeakSanitizer"    OFF)
+
 # Options used within CI but not really useful anywhere else
 option(CAFFEINE_CI            "Enable options that are inconvenient for normal development but are used in CI" OFF)
 option(CAFFEINE_ENABLE_BUILD  "Enable normal build targets" ON)
@@ -64,6 +71,7 @@ if (CAFFEINE_ENABLE_BUILD)
 
   set(IR_USE_BITCODE ${CAFFEINE_BUILD_BITCODE})
 
+  include(CaffeineSanitizers)
   include(CaffeineWarnings)
   include(CaffeineLinking)
   include(LLVMIRUtils)

--- a/cmake/CaffeineSanitizers.cmake
+++ b/cmake/CaffeineSanitizers.cmake
@@ -1,0 +1,45 @@
+
+function(caffeine_enable_sanitizers)
+
+if (CAFFEINE_ENABLE_TSAN
+    OR CAFFEINE_ENABLE_ASAN
+    OR CAFFEINE_ENABLE_UBSAN
+    OR CAFFEINE_ENABLE_MSAN
+    OR CAFFEINE_ENABLE_LSAN)
+  add_compile_options(-fno-omit-frame-pointer)
+endif()
+
+if (CAFFEINE_ENABLE_TSAN)
+  add_compile_options(-fsanitize=thread)
+  add_link_options   (-fsanitize=thread)
+endif()
+
+if (CAFFEINE_ENABLE_ASAN)
+  add_compile_options(-fsanitize=address)
+  add_link_options   (-fsanitize=address)
+endif()
+
+if (CAFFEINE_ENABLE_UBSAN)
+  set(UBSAN_OPTS 
+    "$<$<CXX_COMPILER_ID:Clang>:-fno-sanitize-recover=undefined,nullability>"
+      "$<$<CXX_COMPILER_ID:GCC>:-fno-sanitize-recover=undefined>"
+    "$<$<NOT:$<CXX_COMPILER_ID:Clang,GCC>>:-fsanitize=undefined>"
+  )
+
+  add_compile_options(${UBSAN_OPTS})
+  add_link_options   (${UBSAN_OPTS})
+endif()
+
+if (CAFFEINE_ENABLE_MSAN)
+  add_compile_options(-fsanitize=memory)
+  add_link_options   (-fsanitize=memory)
+endif()
+
+if (CAFFEINE_ENABLE_LSAN)
+  add_compile_options(-fsanitize=leak)
+  add_link_options   (-fsanitize=leak)
+endif()
+
+endfunction()
+
+caffeine_enable_sanitizers()


### PR DESCRIPTION
This adds some easy options to build caffeine + tests with sanitizers enabled.

I've enabled UBSAN in CI here. Will do a follow-up PR to enable ASAN once we can actually run without ASAN issues.