### PR TITLE
Avoid running CI on stackbot branches

### DIFF
--- a/.github/workflows/build-project.yml
+++ b/.github/workflows/build-project.yml
@@ -1,6 +1,12 @@
 
 name: build-and-test
-on: [push, pull_request]
+
+on:
+  # Don't build CI for stackbot internal branches, they are already built for PRs
+  push:
+    branches-ignore:
+      - stackbot/**
+  pull_request:
 
 jobs:
   build:


### PR DESCRIPTION
Stackbot branches are always identical to the head of a PR branch. There's no point in building them in CI since that's already being covered by the PR build.