### PR TITLE
Build packaged dependencies as external projects

### DIFF
--- a/cmake/CaffeineDependencies.cmake
+++ b/cmake/CaffeineDependencies.cmake
@@ -1,19 +1,108 @@
 
-if (NOT magic_enum_NO_PACKAGE_FOUND)
-  find_package(magic_enum 0.7.2 QUIET)
-endif()
+include(FetchContent)
 
-if (NOT magic_enum_FOUND)
-  include(FetchContent)
+set(CAFFEINE_DEP_INSTALL_DIR "${CMAKE_BINARY_DIR}/_deps/install")
+set(CAFFEINE_DEP_CONFIG_IN "${CMAKE_CURRENT_LIST_DIR}/CaffeineTemplateCMakeLists.txt.in")
+list(APPEND CMAKE_PREFIX_PATH "${CAFFEINE_DEP_INSTALL_DIR}")
 
-  FetchContent_Declare(
-    magic_enum
-    GIT_REPOSITORY https://github.com/Neargye/magic_enum.git
-    GIT_TAG        v0.7.2
-    GIT_SHALLOW TRUE
+# Add a new dependency, or build it if it cannot be found on the local system.
+#
+# The first two arguments are the package name and the version that we need to
+# find. These will be used for find_package. Any remaining arguments are passed
+# through to ExternalProject_Add.
+#
+# How it Works
+# ============
+# The main idea is that, at configuration time, we use ExternalProject_Add in a
+# separate cmake project to build and install the dependency to a local directory.
+# From there, we can use find_package with the custom install directory added to
+# the search path to find the dependencies.
+#
+# Now that that's happened the first time around, the next time find_package will
+# immediately find the installed files and we can skip having to build anything.
+function(caffeine_dependency PACKAGE VERSION)
+  if (NOT $CACHE{${PACKAGE}_BUILT_LOCALLY})
+    find_package(${PACKAGE} ${VERSION} QUIET)
+    if (${PACKAGE}_FOUND)
+      return()
+    endif()
+  endif()
+
+  set(${PACKAGE}_BUILT_LOCALLY TRUE CACHE INTERNAL "")
+  set(SUB_DIR "${CMAKE_BINARY_DIR}/_deps/${PACKAGE}/populate")
+  set(PREFIX  "${CMAKE_BINARY_DIR}/_deps/${PACKAGE}")
+
+  make_directory("${SUB_DIR}")
+
+  set(QUOTED_ARGS "")
+  foreach(ARG ${ARGN})
+    set(QUOTED_ARGS "${QUOTED_ARGS} \"${ARG}\"")
+  endforeach()
+
+  set(PACKAGE_INSTALL_PREFIX "${CAFFEINE_DEP_INSTALL_DIR}")
+
+  if (NOT "${CMAKE_BUILD_TYPE}" STREQUAL "")
+    set(PACKAGE_CONFIGURATION_TYPES "${CMAKE_BUILD_TYPE}")
+  else()
+    set(PACKAGE_CONFIGURATION_TYPES "${CMAKE_CONFIGURATION_TYPES}")
+  endif()
+
+  configure_file("${CAFFEINE_DEP_CONFIG_IN}" "${SUB_DIR}/CMakeLists.copy.txt" @ONLY)
+
+  set(NEEDS_UPDATE FALSE)
+  if (NOT EXISTS "${SUB_DIR}/CMakeLists.txt")
+    set(NEEDS_UPDATE TRUE)
+  else()
+    file(SHA512 "${SUB_DIR}/CMakeLists.txt"      OLD_HASH)
+    file(SHA512 "${SUB_DIR}/CMakeLists.copy.txt" NEW_HASH)
+
+    if (NOT "${OLD_HASH}" STREQUAL "${NEW_HASH}")
+      set(NEEDS_UPDATE TRUE)
+    endif()
+  endif()
+
+  # If the build script got updated then we need to build irregardless of
+  # whether the dependency has been installed in the local dir before.
+  if (NEEDS_UPDATE)
+    file(RENAME "${SUB_DIR}/CMakeLists.copy.txt" "${SUB_DIR}/CMakeLists.txt")
+  else()
+    find_package(${PACKAGE} ${VERSION} QUIET)
+    if (${PACKAGE}_FOUND)
+      return()
+    endif()
+  endif()
+
+  message(STATUS "Building dependency ${PACKAGE}")
+  execute_process(
+    COMMAND "${CMAKE_COMMAND}"
+      -B "${SUB_DIR}"
+      -S "${SUB_DIR}"
+      -G "${CMAKE_GENERATOR}"
+    RESULT_VARIABLE EXITCODE
   )
 
-  FetchContent_MakeAvailable(magic_enum)
+  if (NOT EXITCODE EQUAL 0)
+    message(FATAL_ERROR "Could not configure ${PACKAGE} super-project")
+  endif()
 
-  set(magic_enum_NO_PACKAGE_FOUND TRUE CACHE INTERNAL "")
-endif()
+  execute_process(
+    COMMAND "${CMAKE_COMMAND}" --build "${SUB_DIR}"
+    RESULT_VARIABLE EXITCODE
+  )
+
+  if (NOT EXITCODE EQUAL 0)
+    message(FATAL_ERROR "Failed to build ${PACKAGE}")
+  endif()
+
+  find_package(${PACKAGE} ${VERSION} REQUIRED)
+endfunction()
+
+caffeine_dependency(
+  magic_enum     0.7.2
+  GIT_REPOSITORY https://github.com/Neargye/magic_enum.git
+  GIT_TAG        v0.7.2
+  GIT_SHALLOW    TRUE
+  CMAKE_CACHE_ARGS
+    -DMAGIC_ENUM_OPT_BUILD_EXAMPLES:BOOL=FALSE
+    -DMAGIC_ENUM_OPT_BUILD_TESTS:BOOL=FALSE
+)

--- a/cmake/CaffeineTemplateCMakeLists.txt.in
+++ b/cmake/CaffeineTemplateCMakeLists.txt.in
@@ -1,0 +1,58 @@
+# Template file used by caffeine_dependency
+#
+# This file is loosely inspired by the dependency management file from the
+# Hunter package manager:
+# https://github.com/cpp-pm/hunter/blob/master/cmake/schemes/url_sha1_cmake.cmake.in
+
+cmake_minimum_required(VERSION @CMAKE_VERSION@)
+
+project(@PACKAGE@-populate NONE)
+
+include(ExternalProject)
+
+set(configuration_types "@PACKAGE_CONFIGURATION_TYPES@")
+set(build_type "@CMAKE_BUILD_TYPE@")
+
+if (NOT "${build_type}" STREQUAL "")
+  set(STEP_TARGET_CONFIG "")
+  set(INSTALL_CONFIG "")
+else()
+  set(step_targets "")
+
+  foreach(config ${configuration_types})
+    list(APPEND step_targets install-${config})
+  endforeach()
+
+  set(INSTALL_CONFIG     INSTALL_COMMAND "")
+  set(STEP_TARGET_CONFIG STEP_TARGET     ${step_targets})
+endif()
+
+ExternalProject_Add(@PACKAGE@
+  @QUOTED_ARGS@
+  PREFIX            @PREFIX@
+  BUILD_COMMAND     ""
+  ${INSTALL_CONFIG}
+  CMAKE_ARGS
+    "-G@CMAKE_GENERATOR@"
+    -Wno-dev
+  CMAKE_CACHE_ARGS
+    "-DCMAKE_INSTALL_PREFIX:STRING=@PACKAGE_INSTALL_PREFIX@"
+    "-DCMAKE_TOOLCHAIN_FILE:STRING=@CMAKE_TOOLCHAIN_FILE@"
+  ${STEP_TARGET_CONFIG}
+  USES_TERMINAL_DOWNLOAD YES
+  USES_TERMINAL_UPDATE   YES
+)
+
+if ("${build_type}" STREQUAL "")
+  foreach(config ${configuration_types})
+    ExternalProject_Add_Step(
+      @PACKAGE@ install-${config}
+      COMMAND @CMAKE_COMMAND@
+        --build "<BINARY_DIR>"
+        --target install
+        --config ${config}
+      DEPENDEES configure
+      ALWAYS
+    )
+  endforeach()
+endif()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -67,4 +67,10 @@ target_include_directories(caffeine SYSTEM
 )
 
 target_link_options(caffeine PUBLIC ${LINK_FLAGS})
-target_link_libraries(caffeine PUBLIC LLVMCore "${Z3_LIBRARIES}" fmt::fmt magic_enum CapnProto::capnp-rpc)
+target_link_libraries(caffeine PUBLIC
+  LLVMCore
+  "${Z3_LIBRARIES}"
+  fmt::fmt
+  magic_enum::magic_enum
+  CapnProto::capnp-rpc
+)


### PR DESCRIPTION
This PR rewrites `CaffeineDependencies.cmake` to build dependencies outside the project. Here's some stuff quoted from the commit message to explain what's going on (check out the commit message for the full explanation):

> At the moment, FetchContent will always add the fetched depenency as a subdirectory. This works ok if the dependency's CMakeLists is written to work properly when added as a subdirectory. Unfortunately, the CMake configurations for most projects are... not. This limits the number of dependencies that we can bundle using FetchContent to only a few.
> 
> However, cmake does already have support for doing all the difficult bits of bundling dependencies by using ExternalProject_Add. Unfortunately this doesn't help us directly as ExternalProject_Add is targetted towards building a super-project that assembles multiple subprojects into one big build.
> 
> This can be worked around by generating a simple cmake project that does nothing but call ExternalProject_Add. This is also effectively what the FetchContent module does except that it disables all the steps except the download one and expects you to use add_subdirectory.

The goal of this PR is to allow us to add bigger dependencies as downloaded ones so that setting up the project is easier. (Dependencies that just work when installing the project are easier to deal with)
