### PR TITLE
Add `--invert-exitcode` option to `caffeine-bin` and use it for tests

### DIFF
--- a/cmake/CaffeineTestUtils.cmake
+++ b/cmake/CaffeineTestUtils.cmake
@@ -60,7 +60,7 @@ function(build_command)
 endfunction()
 
 # Utility function for declaring a test case
-function(declare_test TEST_NAME_OUT test)
+function(declare_test TEST_NAME_OUT test EXPECTED)
   file(RELATIVE_PATH test_name "${CMAKE_SOURCE_DIR}/test" "${test}")
   should_skip_test(should_skip "${test}")
 
@@ -141,6 +141,12 @@ function(declare_test TEST_NAME_OUT test)
     DEPENDS "${DIS_OUT}"
   )
 
+  if ("${EXPECTED}" STREQUAL "FAIL")
+    set(TEST_FLAGS --invert-exitcode)
+  else()
+    set(TEST_FLAGS "")
+  endif()
+
   if(should_skip)
     add_test(
       NAME "${test_name}"
@@ -149,7 +155,7 @@ function(declare_test TEST_NAME_OUT test)
   else()
     add_test(
       NAME "${test_name}"
-      COMMAND caffeine-bin "${DIS_OUT}" main
+      COMMAND caffeine-bin ${TEST_FLAGS} "${DIS_OUT}" main
     )
   endif()
 

--- a/src/bin/caffeine.cpp
+++ b/src/bin/caffeine.cpp
@@ -144,9 +144,6 @@ int main(int argc, char** argv) {
     errs() << argv[0] << ": ";
     WithColor::error() << " loading file '" << input_filename.getValue()
                        << "'\n";
-    // TODO: this is done to make cmake run-fail unit tests fail properly. We
-    //       should really be detecting based on return status.
-    std::abort();
     return 2;
   }
 
@@ -154,9 +151,6 @@ int main(int argc, char** argv) {
   if (!function) {
     errs() << argv[0] << ": ";
     WithColor::error() << " no method '" << target_method.getValue() << "'";
-    // TODO: this is done to make cmake run-fail unit tests fail properly. We
-    //       should really be detecting based on return status.
-    std::abort();
     return 2;
   }
 
@@ -177,7 +171,7 @@ int main(int argc, char** argv) {
   exec.run();
 
   int exitcode = logger.num_failures == 0 ? 0 : 1;
-  
+
   if (invert_exitcode)
     exitcode = !exitcode;
 

--- a/src/bin/caffeine.cpp
+++ b/src/bin/caffeine.cpp
@@ -44,7 +44,7 @@ cl::opt<std::string> input_filename{cl::Positional};
 cl::opt<std::string> target_method{cl::Positional};
 cl::opt<bool> invert_exitcode{
     "invert-exitcode",
-    cl::desc("invert the exit code. 1 if the program returns a failure, 0 "
+    cl::desc("invert the exit code. 0 if the program returns a failure, 1 "
              "otherwise. All other exit codes remain the same.")};
 
 static ExitOnError exit_on_err;

--- a/src/bin/caffeine.cpp
+++ b/src/bin/caffeine.cpp
@@ -42,6 +42,10 @@ public:
 
 cl::opt<std::string> input_filename{cl::Positional};
 cl::opt<std::string> target_method{cl::Positional};
+cl::opt<bool> invert_exitcode{
+    "invert-exitcode",
+    cl::desc("invert the exit code. 1 if the program returns a failure, 0 "
+             "otherwise. All other exit codes remain the same.")};
 
 static ExitOnError exit_on_err;
 
@@ -172,7 +176,10 @@ int main(int argc, char** argv) {
 
   exec.run();
 
-  if (logger.num_failures == 0)
-    return 0;
-  return 1;
+  int exitcode = logger.num_failures == 0 ? 0 : 1;
+  
+  if (invert_exitcode)
+    exitcode = !exitcode;
+
+  return exitcode;
 }

--- a/test/regression/CMakeLists.txt
+++ b/test/regression/CMakeLists.txt
@@ -12,15 +12,10 @@
 function(add_regression_test source)
   get_filename_component(basename "${source}" NAME)
 
-  declare_test(TEST_NAME "${source}")
-
+  set(EXPECTED PASS)
   if(basename MATCHES "^issue-[0-9]+\.(pass|fail)\.")
     if(CMAKE_MATCH_1 STREQUAL "fail")
-      set_tests_properties(
-        "${TEST_NAME}"
-        PROPERTIES
-        WILL_FAIL TRUE
-      )
+      set(EXPECTED FAIL)
     endif()
   else()
     message(SEND_ERROR
@@ -31,6 +26,8 @@ function(add_regression_test source)
       "    ${basename}\n"
     )
   endif()
+
+  declare_test(TEST_NAME "${source}" ${EXPECTED})
 endfunction()
 
 file(GLOB tests CONFIGURE_DEPENDS *.c *.ll *.cpp)

--- a/test/run-fail/CMakeLists.txt
+++ b/test/run-fail/CMakeLists.txt
@@ -2,13 +2,7 @@
 file(GLOB_RECURSE tests CONFIGURE_DEPENDS *.c *.cpp *.cc *.ll *.bc)
 
 foreach(test ${tests})
-  declare_test(TEST_NAME "${test}")
-
-  set_tests_properties(
-    "${TEST_NAME}"
-    PROPERTIES
-    WILL_FAIL TRUE
-  )
+  declare_test(TEST_NAME "${test}" FAIL)
 endforeach()
 
 llvm_compile_options(run-fail_mem_alloca-escaped.c PRIVATE -Wno-return-stack-address)

--- a/test/run-pass/CMakeLists.txt
+++ b/test/run-pass/CMakeLists.txt
@@ -2,5 +2,5 @@
 file(GLOB_RECURSE tests CONFIGURE_DEPENDS *.c *.cpp *.cc *.ll *.bc)
 
 foreach(test ${tests})
-  declare_test(TEST_NAME "${test}")
+  declare_test(TEST_NAME "${test}" PASS)
 endforeach()


### PR DESCRIPTION
Currently, we call `std::abort` if we fail to parse one the input files to `caffeine-bin`. This is done so that the run-fail tests fail if we fail to parse the file even though the `WILL_FAIL` property is set to true.

This PR adds a new flag `--invert-exitcode` to caffeine bin which flips the exit code for failures (e.g. 0 on failure found, 1 otherwise) but keeps the other error cases as their original exit codes. I've then gone and changed the test cases to take advantage of this.