### PR TITLE
Fix the `check-format` target

### DIFF
--- a/cmake/CaffeineFormatting.cmake
+++ b/cmake/CaffeineFormatting.cmake
@@ -31,7 +31,7 @@ foreach(source ${fmt_sources})
     OUTPUT "${stamp_dir}/${source}"
     COMMAND ${CMAKE_COMMAND} -E make_directory "${stamp_dir}/${source_dir}"
     COMMAND ${CLANG_FORMAT} "${CMAKE_SOURCE_DIR}/${source}" > "${stamp_dir}/${source}"
-    COMMAND diff --color=always -u "${stamp_dir}/${source}" "${stamp_dir}/${source}"
+    COMMAND diff --color=always -u "${source}" "${stamp_dir}/${source}"
     DEPENDS "${CMAKE_SOURCE_DIR}/${source}"
     COMMENT "Checking formatting for ${source}"
     WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}"

--- a/include/caffeine/IR/Operation.h
+++ b/include/caffeine/IR/Operation.h
@@ -274,7 +274,6 @@ public:
    */
   OpRef into_ref() const;
 
-
   typedef detail::operand_iterator operand_iterator;
   typedef detail::operand_iterator const_operand_iterator;
 

--- a/include/caffeine/IR/Operation.inl
+++ b/include/caffeine/IR/Operation.inl
@@ -126,7 +126,7 @@ namespace detail {
   };
 
   inline operand_iterator operator+(operand_iterator::difference_type n,
-                              operand_iterator a) {
+                                    operand_iterator a) {
     return a + n;
   }
 } // namespace detail

--- a/tools/gen-builtins/memcpy.cpp
+++ b/tools/gen-builtins/memcpy.cpp
@@ -134,7 +134,8 @@ llvm::Function* generateMemcpy(llvm::Module* m, llvm::Function* decl) {
   // We only need to generate this comparison if the pointers are in the same
   // address space. Otherwise they're guaranteed not to overlap.
   if (arg_dst->getType()->getPointerAddressSpace() ==
-      arg_src->getType()->getPointerAddressSpace() && false) {
+          arg_src->getType()->getPointerAddressSpace() &&
+      false) {
     auto iptr = layout.getIntPtrType(arg_dst->getType());
     auto off_dst = entry.CreateGEP(res_dst, ArrayRef<Value*>{arg_len});
     auto off_src = entry.CreateGEP(res_src, ArrayRef<Value*>{arg_len});

--- a/tools/gen-builtins/memset.cpp
+++ b/tools/gen-builtins/memset.cpp
@@ -50,8 +50,8 @@ namespace caffeine {
  * define void @caffeine.memset.p0i8.i32(
  *     i8* %arg_dst, i8 %val, i32 %arg_len, i1* %isvolatile) {
  * entry:
- *   %resolved = call void @caffeine.resolve.p0i8.i32(i8* %arg_dst, i32 %arg_len)
- *   br label %head
+ *   %resolved = call void @caffeine.resolve.p0i8.i32(i8* %arg_dst, i32
+ * %arg_len) br label %head
  *
  * head:
  *   %dst = phi i8* [ %entry, %resolved ], [ %body, %next_dst ]


### PR DESCRIPTION
This hasn't been working for a little while. Turns out we were diffing against the wrong files. I've also formatted everything here.

This should hopefully mean that CI starts properly checking formatting again.