### PR TITLE
Enable ASAN in CI

### DIFF
--- a/.github/workflows/build-project.yml
+++ b/.github/workflows/build-project.yml
@@ -31,7 +31,8 @@ jobs:
           cmake -B build \
             -DCAFFEINE_CI=ON \
             -DCMAKE_BUILD_TYPE=RelWithDebInfo \
-            -DCAFFEINE_ENABLE_UBSAN=ON
+            -DCAFFEINE_ENABLE_UBSAN=ON \
+            -DCAFFEINE_ENABLE_ASAN=ON
         env:
           CC: ${{ matrix.cc }}
           CXX: ${{ matrix.cxx }}


### PR DESCRIPTION
We no longer have any memory leaks. This means that we can enable ASAN in CI. This PR does so.