### PR TITLE
Add automatic simplification of `Not(Not(x))` expressions

### DIFF
--- a/src/IR/Operation.h
+++ b/src/IR/Operation.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "caffeine/IR/Matching.h"
 #include "caffeine/IR/Operation.h"
 #include "caffeine/IR/Visitor.h"
 
@@ -308,6 +309,10 @@ public:
   OpRef visitNot(const UnaryOp& op) {
     if (const auto* val = llvm::dyn_cast<ConstantInt>(op.operand().get()))
       return ConstantInt::Create(~val->value());
+
+    OpRef value;
+    if (matches(op.operand(), matching::Not(value)))
+      return value;
 
     return this->visitUnaryOp(op);
   }

--- a/test/unit/IR/Matching.cpp
+++ b/test/unit/IR/Matching.cpp
@@ -54,10 +54,12 @@ TEST_F(MatchingTests, replace_double_not) {
 }
 
 TEST_F(MatchingTests, fixedarray) {
-  auto expr = FixedArray::Create(Type::int_ty(32),
-                                 UnaryOp::CreateNot(UnaryOp::CreateNot(
-                                     Constant::Create(Type::int_ty(1), 0))),
-                                 64);
+  auto expr = FixedArray::Create(
+      Type::int_ty(32),
+      BinaryOp::CreateAnd(
+          UnaryOp::CreateNot(Constant::Create(Type::int_ty(1), 0)),
+          Constant::Create(Type::int_ty(1), 1)),
+      64);
 
-  ASSERT_TRUE(matches_anywhere(expr, Not(Not(Any()))));
+  ASSERT_TRUE(matches_anywhere(expr, And(Not(Any()), Any())));
 }


### PR DESCRIPTION
Previously this was done as part of the simplify transform. However, it doesn't require any special context so this moves it be done as part of operation creation.

/stack #322 