### PR TITLE
Introduce new `AssertionList` data structure

### DIFF
--- a/include/caffeine/Interpreter/AssertionList.h
+++ b/include/caffeine/Interpreter/AssertionList.h
@@ -96,9 +96,8 @@ public:
   }
 
   llvm::iterator_range<const_iterator> unproven() const {
-    return llvm::iterator_range<const_iterator>(
-        list_.iterator_at(mark_),
-        end());
+    return llvm::iterator_range<const_iterator>(list_.iterator_at(mark_),
+                                                end());
   }
 };
 

--- a/include/caffeine/Interpreter/AssertionList.h
+++ b/include/caffeine/Interpreter/AssertionList.h
@@ -1,0 +1,105 @@
+#pragma once
+
+#include "caffeine/ADT/SparseVector.h"
+#include "caffeine/IR/Assertion.h"
+#include "caffeine/IR/Operation.h"
+#include <boost/range/join.hpp>
+#include <initializer_list>
+#include <llvm/ADT/ArrayRef.h>
+#include <llvm/ADT/FunctionExtras.h>
+#include <unordered_set>
+#include <vector>
+
+namespace caffeine {
+
+// A list of assertions.
+//
+// This class is designed to allow other algorithms which have to regularly
+// operate on the list of assertions to easily be written as incremental
+// algorithms.
+//
+// Overall Design
+// ==============
+// The assertions contained within this class are split into two groups:
+// - There are the assertions that have been proven to be satisfiable by running
+//   through a solver and it returning SAT. Adding new assertions does not
+//   change the satisfiability of these assertions.
+// - Next, there are the assertions that have not yet been proven to be
+//   satisfiable. These double as new information since the last solver call and
+//   so are useful for incrementally simplifying the overall expressions.
+//
+// Assertions get moved to the first group from the second one when mark_sat()
+// is called. This should only be called once a solver evaluates the expression
+// and determines that it is satisfiable.
+class AssertionList {
+private:
+  SparseVector<Assertion> list_;
+  std::unordered_set<Assertion> lookup_;
+  size_t mark_ = 0;
+
+public:
+  using const_iterator = decltype(list_)::const_iterator;
+
+  enum Status { Proven, Unproven };
+
+  AssertionList() = default;
+
+  AssertionList(llvm::ArrayRef<Assertion> values);
+  AssertionList(std::initializer_list<Assertion> list)
+      : AssertionList(llvm::ArrayRef<Assertion>(list)) {}
+
+  size_t size() const {
+    return lookup_.size();
+  }
+  bool empty() const {
+    return size() == 0;
+  }
+
+  const Assertion& operator[](size_t idx) const {
+    return list_[idx];
+  }
+
+  void clear();
+
+  // Mark all expressions currently within this AssertionList as having been
+  // proven to be satisfiable.
+  void mark_sat();
+
+  // Insert a new assertion at the end of the list.
+  //
+  // Automatically decomposes expressions composed of multiple terms ANDed
+  // together into their component expressions. This is to help normalize the
+  // representation of assertions. (The assertions within the list are already
+  // anded together.)
+  //
+  // This will also deduplicate inserted expressions. If an expression is
+  // already present within the list then it will not be inserted.
+  void insert(const Assertion& assertion);
+  void insert(llvm::ArrayRef<Assertion> assertions);
+
+  // Efficiently check whether this list contains the given assertion.
+  bool contains(const Assertion& assertion);
+
+  void erase(const_iterator it);
+
+  void compress();
+
+  const SparseVector<Assertion>& backing() const {
+    return list_;
+  }
+
+  const_iterator begin() const {
+    return list_.begin();
+  }
+  const_iterator end() const {
+    return list_.end();
+  }
+
+  llvm::iterator_range<const_iterator> unproven() const {
+    return llvm::iterator_range<const_iterator>(
+        list_.iterator_at(mark_),
+        end());
+  }
+};
+
+} // namespace caffeine

--- a/include/caffeine/Interpreter/AssertionList.h
+++ b/include/caffeine/Interpreter/AssertionList.h
@@ -82,8 +82,6 @@ public:
 
   void erase(const_iterator it);
 
-  void compress();
-
   const SparseVector<Assertion>& backing() const {
     return list_;
   }

--- a/src/Interpreter/AssertionList.cpp
+++ b/src/Interpreter/AssertionList.cpp
@@ -16,10 +16,12 @@ AssertionList::AssertionList(llvm::ArrayRef<Assertion> values) {
 void AssertionList::clear() {
   list_.clear();
   lookup_.clear();
+  mark_ = 0;
 }
 
 void AssertionList::mark_sat() {
-  mark_ = list_.backing_size();
+  list_.compress();
+  mark_ = list_.size();
 }
 
 void AssertionList::insert(const Assertion& assertion) {
@@ -64,16 +66,6 @@ void AssertionList::insert(llvm::ArrayRef<Assertion> assertions) {
 
 bool AssertionList::contains(const Assertion& assertion) {
   return lookup_.count(assertion);
-}
-
-void AssertionList::compress() {
-  if (mark_ < list_.backing_size()) {
-    mark_ = std::distance(list_.begin(), ++list_.iterator_at(mark_));
-  } else {
-    mark_ = list_.size();
-  }
-
-  list_.compress();
 }
 
 void AssertionList::erase(const_iterator it) {

--- a/src/Interpreter/AssertionList.cpp
+++ b/src/Interpreter/AssertionList.cpp
@@ -1,0 +1,84 @@
+#include "caffeine/Interpreter/AssertionList.h"
+#include "caffeine/IR/Matching.h"
+#include "caffeine/Support/Assert.h"
+#include <algorithm>
+#include <fmt/format.h>
+
+namespace caffeine {
+
+AssertionList::AssertionList(llvm::ArrayRef<Assertion> values) {
+  lookup_.reserve(values.size());
+  list_.reserve(values.size());
+
+  insert(values);
+}
+
+void AssertionList::clear() {
+  list_.clear();
+  lookup_.clear();
+}
+
+void AssertionList::mark_sat() {
+  mark_ = list_.backing_size();
+}
+
+void AssertionList::insert(const Assertion& assertion) {
+  insert(llvm::ArrayRef<Assertion>{assertion});
+}
+void AssertionList::insert(llvm::ArrayRef<Assertion> assertions) {
+  using namespace matching;
+
+  llvm::SmallVector<OpRef, 8> decomposed;
+  for (const Assertion& a : assertions) {
+    decomposed.push_back(a.value());
+
+    while (!decomposed.empty()) {
+      OpRef op = decomposed.pop_back_val();
+      OpRef lhs, rhs;
+
+      // A & B -> A, B
+      if (matches(op, And(lhs, rhs))) {
+        decomposed.push_back(std::move(lhs));
+        decomposed.push_back(std::move(rhs));
+        continue;
+      }
+
+      // !(A | B) -> !A, !B
+      if (matches(op, Not(Or(lhs, rhs)))) {
+        decomposed.push_back(UnaryOp::CreateNot(lhs));
+        decomposed.push_back(UnaryOp::CreateNot(rhs));
+        continue;
+      }
+
+      if (a.is_constant_value(true))
+        continue;
+
+      if (lookup_.count(Assertion(op)))
+        continue;
+
+      list_.push_back(Assertion(op));
+      lookup_.insert(Assertion(op));
+    }
+  }
+}
+
+bool AssertionList::contains(const Assertion& assertion) {
+  return lookup_.count(assertion);
+}
+
+void AssertionList::compress() {
+  if (mark_ < list_.backing_size()) {
+    mark_ = std::distance(list_.begin(), ++list_.iterator_at(mark_));
+  } else {
+    mark_ = list_.size();
+  }
+
+  list_.compress();
+}
+
+void AssertionList::erase(const_iterator it) {
+  lookup_.erase(*it);
+  list_.erase(it.index());
+}
+
+} // namespace caffeine

--- a/test/unit/Interpreter/AssertionList.cpp
+++ b/test/unit/Interpreter/AssertionList.cpp
@@ -1,0 +1,50 @@
+
+#include "caffeine/Interpreter/AssertionList.h"
+#include <gtest/gtest.h>
+
+using namespace caffeine;
+
+TEST(AssertionListTests, breaks_down_top_level_and) {
+  AssertionList list;
+  list.insert(Assertion(BinaryOp::CreateAnd(
+      BinaryOp::CreateAnd(Constant::Create(Type::int_ty(1), 0),
+                          Constant::Create(Type::int_ty(1), 1)),
+      Constant::Create(Type::int_ty(1), 2))));
+
+  ASSERT_EQ(list.size(), 3);
+  auto assertions = std::vector<Assertion>(list.begin(), list.end());
+
+  std::sort(assertions.begin(), assertions.end(),
+            [](const auto& a, const auto& b) {
+              const auto* lhs = llvm::cast<Constant>(a.value().get());
+              const auto* rhs = llvm::cast<Constant>(b.value().get());
+              return lhs->number() < rhs->number();
+            });
+
+  ASSERT_EQ(llvm::cast<Constant>(*assertions[0].value()).number(), 0);
+  ASSERT_EQ(llvm::cast<Constant>(*assertions[1].value()).number(), 1);
+  ASSERT_EQ(llvm::cast<Constant>(*assertions[2].value()).number(), 2);
+}
+
+TEST(AssertionListTests, breaks_down_top_level_not_or) {
+  AssertionList list;
+  list.insert(Assertion(UnaryOp::CreateNot(BinaryOp::CreateOr(
+      UnaryOp::CreateNot(
+          BinaryOp::CreateAnd(Constant::Create(Type::int_ty(1), 0),
+                              Constant::Create(Type::int_ty(1), 1))),
+      UnaryOp::CreateNot(Constant::Create(Type::int_ty(1), 2))))));
+
+  ASSERT_EQ(list.size(), 3);
+  auto assertions = std::vector<Assertion>(list.begin(), list.end());
+
+  std::sort(assertions.begin(), assertions.end(),
+            [](const auto& a, const auto& b) {
+              const auto* lhs = llvm::cast<Constant>(a.value().get());
+              const auto* rhs = llvm::cast<Constant>(b.value().get());
+              return lhs->number() < rhs->number();
+            });
+
+  ASSERT_EQ(llvm::cast<Constant>(*assertions[0].value()).number(), 0);
+  ASSERT_EQ(llvm::cast<Constant>(*assertions[1].value()).number(), 1);
+  ASSERT_EQ(llvm::cast<Constant>(*assertions[2].value()).number(), 2);
+}


### PR DESCRIPTION
This is meant to be a dedicated data structure for handling lists of assertions. It separates assertions into known-SAT and unproven assertions. This allows for transforms and various solvers to be done incrementally. Furthermore, `AssertionList` automatically breaks down top level and-expressions (list `DecompositionSolver`). See the comment at the top of `AssertionList` for a better explanation.

In the next set of PRs I will convert the rest of the code to use `AssertionList`.

/stack #324 
