### PR TITLE
Make `gen-builtins` only depend on `caffeine-assert` target

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,5 +1,6 @@
 
 add_subdirectory(bin)
+add_subdirectory(Support)
 
 file(
   GLOB subdirs

--- a/src/Support/CMakeLists.txt
+++ b/src/Support/CMakeLists.txt
@@ -1,0 +1,8 @@
+
+add_library(caffeine-assert
+  Assert.cpp
+  "${CMAKE_SOURCE_DIR}/include/caffeine/Support/Assert.h"
+)
+
+target_include_directories(caffeine-assert PUBLIC "${CMAKE_SOURCE_DIR}/include")
+target_include_directories(caffeine-assert SYSTEM PRIVATE "${Boost_INCLUDE_DIRS}")

--- a/tools/gen-builtins/CMakeLists.txt
+++ b/tools/gen-builtins/CMakeLists.txt
@@ -7,12 +7,12 @@ add_executable(gen-builtins
   resolve.cpp
 )
 
-target_include_directories(gen-builtins
+target_include_directories(gen-builtins SYSTEM
   PRIVATE "${LLVM_INCLUDE_DIRS}"
   PRIVATE "${FMT_INCLUDE_DIRS}"
 )
 
 target_link_libraries(gen-builtins PRIVATE LLVMCore LLVMIRReader LLVMBitWriter)
 target_link_libraries(gen-builtins PRIVATE fmt::fmt)
-target_link_libraries(gen-builtins PRIVATE caffeine)
+target_link_libraries(gen-builtins PRIVATE caffeine-assert)
 


### PR DESCRIPTION
Currently `gen-builtins` gets rebuilt whenever we touch anything within caffeine. This is annoying since it causes all the IR files to get rebuilt. This PR changes it to only depend on the assert code so that it doesn't get rebuilt every time.