### PR TITLE
Add small testcase for invalid access of `SparseArray`

### DIFF
--- a/test/unit/ADT/SparseVector.cpp
+++ b/test/unit/ADT/SparseVector.cpp
@@ -78,3 +78,18 @@ TEST(SparseVectorTests, iteratorAtEnd) {
 
   ASSERT_EQ(vector.iterator_at(2).index(), 2);
 }
+
+TEST(SparseVectorTests, eraseElementAtIteratorRef) {
+  SparseVector<uint32_t> vector{0, 1};
+
+  auto it = vector.begin();
+
+  ASSERT_EQ(vector[0], 0);
+
+  vector.erase(0);
+
+  try {
+    *it;
+    FAIL();
+  } catch (std::bad_variant_access) {}
+}

--- a/test/unit/ADT/SparseVector.cpp
+++ b/test/unit/ADT/SparseVector.cpp
@@ -87,9 +87,5 @@ TEST(SparseVectorTests, eraseElementAtIteratorRef) {
   ASSERT_EQ(vector[0], 0);
 
   vector.erase(0);
-
-  try {
-    *it;
-    FAIL();
-  } catch (std::bad_variant_access) {}
+  ASSERT_THROW(*it, std::bad_variant_access);
 }


### PR DESCRIPTION
This testcase documents the behaviour of invalid access for the `SparseArray`