### PR TITLE
Add transparent interning for operations

### DIFF
--- a/include/caffeine/IR/Operation.h
+++ b/include/caffeine/IR/Operation.h
@@ -294,7 +294,7 @@ public:
   Operation& operator=(Operation&& op) noexcept;
 
   // Need to force operation to have a vtable
-  virtual ~Operation() = default;
+  virtual ~Operation();
 
 protected:
   /**

--- a/src/IR/Operation.h
+++ b/src/IR/Operation.h
@@ -96,14 +96,18 @@ class OperationCache {
 private:
   std::mutex mutex;
   std::unordered_multimap<size_t, std::weak_ptr<const Operation>> map;
+  size_t counter = 0;
 
   std::pair<size_t, OpRef> find(const Operation& op);
+  void gc_impl();
 
 public:
   OperationCache() = default;
 
   OpRef intern(Operation&& op);
   OpRef intern(const Operation& op);
+
+  void gc();
 
   static OperationCache cache;
 };

--- a/src/IR/Operation.h
+++ b/src/IR/Operation.h
@@ -96,10 +96,8 @@ class OperationCache {
 private:
   std::mutex mutex;
   std::unordered_multimap<size_t, std::weak_ptr<const Operation>> map;
-  size_t counter = 0;
 
   std::pair<size_t, OpRef> find(const Operation& op);
-  void gc_impl();
 
 public:
   OperationCache() = default;
@@ -107,7 +105,7 @@ public:
   OpRef intern(Operation&& op);
   OpRef intern(const Operation& op);
 
-  void gc();
+  void erase(const Operation& op);
 
   static OperationCache cache;
 };

--- a/src/IR/Operation.h
+++ b/src/IR/Operation.h
@@ -3,8 +3,10 @@
 #include "caffeine/IR/Matching.h"
 #include "caffeine/IR/Operation.h"
 #include "caffeine/IR/Visitor.h"
-
 #include <llvm/Support/MathExtras.h>
+#include <memory>
+#include <mutex>
+#include <unordered_map>
 
 /**
  * This header has a bunch of utility methods for constant folding.
@@ -89,6 +91,22 @@ inline uint64_t ilog2(uint64_t x) {
   bool ispow2 = (x & (x - 1)) == 0;
   return sizeof(x) * CHAR_BIT - llvm::countLeadingZeros(x) - (ispow2 ? 1 : 0);
 }
+
+class OperationCache {
+private:
+  std::mutex mutex;
+  std::unordered_multimap<size_t, std::weak_ptr<const Operation>> map;
+
+  std::pair<size_t, OpRef> find(const Operation& op);
+
+public:
+  OperationCache() = default;
+
+  OpRef intern(Operation&& op);
+  OpRef intern(const Operation& op);
+
+  static OperationCache cache;
+};
 
 template <bool move_out = false>
 class ConstantFolder : public ConstOpVisitor<ConstantFolder<move_out>, OpRef> {


### PR DESCRIPTION
This PR adds code to transparently intern operation references at creation time. It does this by maintaining a global map containing `weak_ptr`s to all `Operation` instances. This allows it to transparently reuse operation instances while they are being created.

This can then be reused by downstream systems to efficiently deduplicate expressions.