### PR TITLE
Propagate pointer resolutions back into other equivalent pointers in the stack frame

### DIFF
--- a/include/caffeine/Interpreter/Context.h
+++ b/include/caffeine/Interpreter/Context.h
@@ -125,6 +125,16 @@ public:
   resolve(std::shared_ptr<Solver> solver,
           const Assertion& extra = Assertion::constant(true));
 
+  /**
+   * Replaces instances of the unresolved pointer within the top stack frame
+   * with the resolved one.
+   *
+   * This is meant to reduce the amount of pointer resolutions have to do. At
+   * the same time it balances between the amount of effort in propagating that
+   * resolution.
+   */
+  void backprop(const Pointer& unresolved, const Pointer& resolved);
+
 private:
   // TODO: Temporary until context redesign is completed
   friend class ExprEvaluator;

--- a/include/caffeine/Memory/MemHeap.h
+++ b/include/caffeine/Memory/MemHeap.h
@@ -178,6 +178,9 @@ public:
    */
   Assertion check_null(const MemHeap& heap) const;
 
+  bool operator==(const Pointer& p) const;
+  bool operator!=(const Pointer& p) const;
+
   void DebugPrint() const;
 };
 

--- a/src/Interpreter/Context.cpp
+++ b/src/Interpreter/Context.cpp
@@ -153,4 +153,21 @@ uint64_t Context::next_constant() {
   return constant_num_++;
 }
 
+void Context::backprop(const Pointer& unresolved, const Pointer& resolved) {
+  StackFrame& frame = stack_top();
+
+  for (auto& [key, value] : frame.variables) {
+    if (!value.is_scalar())
+      continue;
+
+    auto& scalar = value.scalar();
+    if (!scalar.is_pointer())
+      continue;
+
+    auto& pointer = scalar.pointer();
+    if (pointer == unresolved)
+      value = LLVMValue(resolved);
+  }
+}
+
 } // namespace caffeine

--- a/src/Memory/MemHeap.cpp
+++ b/src/Memory/MemHeap.cpp
@@ -259,6 +259,13 @@ Assertion Pointer::check_null(const MemHeap& heap) const {
   return ICmpOp::CreateICmp(ICmpOpcode::EQ, value(heap), 0);
 }
 
+bool Pointer::operator==(const Pointer& p) const {
+  return offset_ == p.offset_ && alloc_ == p.alloc_;
+}
+bool Pointer::operator!=(const Pointer& p) const {
+  return !(*this == p);
+}
+
 /***************************************************
  * MemHeap                                         *
  ***************************************************/

--- a/src/Solver/Z3Solver.cpp
+++ b/src/Solver/Z3Solver.cpp
@@ -212,6 +212,9 @@ std::unique_ptr<Model> Z3Solver::resolve(AssertionList& assertions,
   z3::solver solver = z3::tactic(*ctx, "default").mk_solver();
   Z3Model::ConstMap constMap;
 
+  if (extra.is_constant_value(false))
+    return std::make_unique<EmptyModel>(SolverResult::UNSAT);
+
   Z3OpVisitor visitor{&solver, constMap};
   for (Assertion assertion : assertions) {
     if (assertion.is_empty()) {


### PR DESCRIPTION
As in title. This prevents us from having to resolve the same pointer over and over again for repeated memory accesses.

As a bonus, I've also added an early-exit if `extra` is false within the Z3 solver.