### PR TITLE
Take advantage of `AssertionList` features

### DIFF
--- a/include/caffeine/Solver/Z3Solver.h
+++ b/include/caffeine/Solver/Z3Solver.h
@@ -23,6 +23,8 @@ public:
   Z3Solver();
   ~Z3Solver();
 
+  SolverResult check(AssertionList& assertions,
+                     const Assertion& extra) override;
   /**
    * Validate whether the set of assertions combined with the extra assertion,
    * if it isn't empty, is satisfiable and return a model.

--- a/src/Interpreter/Context.cpp
+++ b/src/Interpreter/Context.cpp
@@ -137,11 +137,17 @@ LLVMValue Context::lookup(llvm::Value* value) {
 
 SolverResult Context::check(std::shared_ptr<Solver> solver,
                             const Assertion& extra) {
-  return solver->check(assertions, extra);
+  auto result = solver->check(assertions, extra);
+  if (result == SolverResult::SAT)
+    assertions.mark_sat();
+  return result;
 }
 std::unique_ptr<Model> Context::resolve(std::shared_ptr<Solver> solver,
                                         const Assertion& extra) {
-  return solver->resolve(assertions, extra);
+  auto model = solver->resolve(assertions, extra);
+  if (model->result() == SolverResult::SAT)
+    assertions.mark_sat();
+  return model;
 }
 
 uint64_t Context::next_constant() {

--- a/src/Solver/Z3Solver.cpp
+++ b/src/Solver/Z3Solver.cpp
@@ -207,6 +207,16 @@ Z3Solver::Z3Solver() : ctx(std::make_unique<z3::context>()) {
 
 Z3Solver::~Z3Solver() {}
 
+SolverResult Z3Solver::check(AssertionList& assertions,
+                             const Assertion& extra) {
+  AssertionList list = assertions;
+  list.insert(extra);
+
+  if (list.unproven().empty())
+    return SolverResult::SAT;
+  return resolve(assertions, extra)->result();
+}
+
 std::unique_ptr<Model> Z3Solver::resolve(AssertionList& assertions,
                                          const Assertion& extra) {
   z3::solver solver = z3::tactic(*ctx, "default").mk_solver();


### PR DESCRIPTION
This takes advantage of the features of `AssertionList` to avoid performing solver queries if not necessary.

Closes #320 