### PR TITLE
Add GuidedExecutionPolicy

### DIFF
--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -1,3 +1,4 @@
 
 add_subdirectory(gen-test-main)
 add_subdirectory(gen-builtins)
+add_subdirectory(guided-fuzzing)

--- a/tools/guided-fuzzing/CMakeLists.txt
+++ b/tools/guided-fuzzing/CMakeLists.txt
@@ -1,0 +1,32 @@
+
+file(
+  GLOB sources
+  CONFIGURE_DEPENDS
+  RELATIVE "${CMAKE_CURRENT_SOURCE_DIR}"
+  "${CMAKE_CURRENT_SOURCE_DIR}/src/*.cpp"
+)
+
+file(
+  GLOB_RECURSE headers
+  CONFIGURE_DEPENDS
+  RELATIVE "${CMAKE_CURRENT_SOURCE_DIR}"
+  "${CMAKE_CURRENT_SOURCE_DIR}/include/*.hpp"
+  "${CMAKE_CURRENT_SOURCE_DIR}/include/*.h"
+  "${CMAKE_CURRENT_SOURCE_DIR}/include/*.inl"
+)
+
+add_library(afl-guided-mutator SHARED
+  ${sources}
+  ${headers}
+)
+
+# The SYSTEM should silence warnings within these headers
+target_include_directories(afl-guided-mutator SYSTEM
+  PRIVATE "${LLVM_INCLUDE_DIRS}"
+  PRIVATE "${FMT_INCLUDE_DIRS}"
+)
+
+target_link_libraries(afl-guided-mutator PRIVATE caffeine)
+set_property(TARGET caffeine PROPERTY POSITION_INDEPENDENT_CODE ON)
+target_link_libraries(afl-guided-mutator PRIVATE LLVMCore LLVMIRReader LLVMBitWriter LLVMTransformUtils)
+target_link_libraries(afl-guided-mutator PRIVATE fmt::fmt)

--- a/tools/guided-fuzzing/include/GuidedExecutionPolicy.h
+++ b/tools/guided-fuzzing/include/GuidedExecutionPolicy.h
@@ -1,0 +1,42 @@
+#pragma once
+
+#include "caffeine/Interpreter/Context.h"
+#include "caffeine/Interpreter/Policy.h"
+#include "caffeine/Solver/Solver.h"
+
+namespace caffeine {
+
+/**
+ * Class to control the behaviour of an Interpreter instance. It also provides a
+ * number of hooks for the policy to execute code when various context-related
+ * events occur within the executor. By default, these do nothing.
+ *
+ * If you don't care about controlling queuing behaviour you may want to derive
+ * from AlwaysAllowExecutionPolicy instead of the base ExecutionPolicy class.
+ */
+class GuidedExecutionPolicy : ExecutionPolicy {
+  AssertionList requiredAssertions_;
+  std::shared_ptr<Solver> solver_;
+
+public:
+  GuidedExecutionPolicy(AssertionList& list, std::shared_ptr<Solver> solver);
+  ~GuidedExecutionPolicy() = default;
+
+  /**
+   * Called when a context forks to determine whether we should continue
+   * executing that branch.
+   *
+   * Note that this method does not control whether dead branches continue to
+   * execute. Those will be pruned irregardless of what this method returns.
+   */
+  virtual bool should_queue_path(const Context& ctx);
+
+protected:
+  GuidedExecutionPolicy(GuidedExecutionPolicy&&) = default;
+  GuidedExecutionPolicy(const GuidedExecutionPolicy&) = default;
+
+  GuidedExecutionPolicy& operator=(GuidedExecutionPolicy&&) = default;
+  GuidedExecutionPolicy& operator=(const GuidedExecutionPolicy&) = default;
+};
+
+} // namespace caffeine

--- a/tools/guided-fuzzing/include/GuidedExecutionPolicy.h
+++ b/tools/guided-fuzzing/include/GuidedExecutionPolicy.h
@@ -7,14 +7,10 @@
 namespace caffeine {
 
 /**
- * Class to control the behaviour of an Interpreter instance. It also provides a
- * number of hooks for the policy to execute code when various context-related
- * events occur within the executor. By default, these do nothing.
- *
- * If you don't care about controlling queuing behaviour you may want to derive
- * from AlwaysAllowExecutionPolicy instead of the base ExecutionPolicy class.
+ * This class accepts an AssertionList and makes sure that every Context's
+ * assertions combined with the given AssertionList is satisfiable.
  */
-class GuidedExecutionPolicy : ExecutionPolicy {
+class GuidedExecutionPolicy : public ExecutionPolicy {
   AssertionList requiredAssertions_;
   std::shared_ptr<Solver> solver_;
 
@@ -22,13 +18,6 @@ public:
   GuidedExecutionPolicy(AssertionList& list, std::shared_ptr<Solver> solver);
   ~GuidedExecutionPolicy() = default;
 
-  /**
-   * Called when a context forks to determine whether we should continue
-   * executing that branch.
-   *
-   * Note that this method does not control whether dead branches continue to
-   * execute. Those will be pruned irregardless of what this method returns.
-   */
   virtual bool should_queue_path(const Context& ctx);
 
 protected:

--- a/tools/guided-fuzzing/src/GuidedExecutionPolicy.cpp
+++ b/tools/guided-fuzzing/src/GuidedExecutionPolicy.cpp
@@ -11,10 +11,7 @@ GuidedExecutionPolicy::GuidedExecutionPolicy(AssertionList& list,
 }
 
 bool GuidedExecutionPolicy::should_queue_path(const Context& ctx) {
-  AssertionList combined;
-  for (const auto& i : ctx.assertions) {
-    combined.insert(i);
-  }
+  AssertionList combined = ctx.assertions;
 
   for (const auto& i : requiredAssertions_) {
     combined.insert(i);

--- a/tools/guided-fuzzing/src/GuidedExecutionPolicy.cpp
+++ b/tools/guided-fuzzing/src/GuidedExecutionPolicy.cpp
@@ -1,0 +1,26 @@
+#include "include/GuidedExecutionPolicy.h"
+
+namespace caffeine {
+
+GuidedExecutionPolicy::GuidedExecutionPolicy(AssertionList& list,
+                                             std::shared_ptr<Solver> solver)
+    : requiredAssertions_{list}, solver_{solver} {
+  if (solver_->check(list) == UNSAT) {
+    CAFFEINE_ABORT("GuidedExecutionPolicy requires satisfiable premise");
+  }
+}
+
+bool GuidedExecutionPolicy::should_queue_path(const Context& ctx) {
+  AssertionList combined;
+  for (const auto& i : ctx.assertions) {
+    combined.insert(i);
+  }
+
+  for (const auto& i : requiredAssertions_) {
+    combined.insert(i);
+  }
+
+  return solver_->check(combined) != UNSAT;
+}
+
+} // namespace caffeine


### PR DESCRIPTION
This PR adds a `GuidedExecutionPolicy` class. The purpose of this class will be to load it with assertions in order to only allow execution of paths that fit a given concrete input to a function.