### PR TITLE
Limit solvers to 1-per-thread

### DIFF
--- a/include/caffeine/Interpreter/Interpreter.h
+++ b/include/caffeine/Interpreter/Interpreter.h
@@ -56,6 +56,7 @@ public:
    */
   Interpreter(Context* ctx, ExecutionPolicy* policy,
               ExecutionContextStore* store, FailureLogger* logger,
+              const std::shared_ptr<Solver>& solver,
               const InterpreterOptions& options = InterpreterOptions());
 
   void execute();

--- a/src/Interpreter/Executor.cpp
+++ b/src/Interpreter/Executor.cpp
@@ -2,14 +2,23 @@
 #include "caffeine/Interpreter/Interpreter.h"
 #include "caffeine/Interpreter/Store.h"
 
+#include "caffeine/Solver/CanonicalizingSolver.h"
+#include "caffeine/Solver/SequenceSolver.h"
+#include "caffeine/Solver/SimplifyingSolver.h"
+#include "caffeine/Solver/Z3Solver.h"
+
 #include <thread>
+#include <z3++.h>
 
 namespace caffeine {
 
 void run_worker(Executor* exec, FailureLogger* logger,
                 ExecutionContextStore* store) {
+  auto solver = caffeine::make_sequence_solver(caffeine::SimplifyingSolver(),
+                                               caffeine::CanonicalizingSolver(),
+                                               caffeine::Z3Solver());
   while (auto ctx = store->next_context()) {
-    Interpreter interp(&ctx.value(), exec->policy, store, logger);
+    Interpreter interp(&ctx.value(), exec->policy, store, logger, solver);
     interp.execute();
   }
 }

--- a/src/Interpreter/Interpreter.cpp
+++ b/src/Interpreter/Interpreter.cpp
@@ -29,12 +29,10 @@ ExecutionResult::ExecutionResult(llvm::SmallVector<Context, 2>&& contexts)
 
 Interpreter::Interpreter(Context* ctx, ExecutionPolicy* policy,
                          ExecutionContextStore* store, FailureLogger* logger,
+                         const std::shared_ptr<Solver>& solver,
                          const InterpreterOptions& options)
-    : policy(policy), store(store), ctx(ctx), logger(logger), options(options) {
-  solver = caffeine::make_sequence_solver(caffeine::SimplifyingSolver(),
-                                          caffeine::CanonicalizingSolver(),
-                                          caffeine::Z3Solver());
-}
+    : policy(policy), store(store), ctx(ctx), logger(logger), options(options),
+      solver(solver) {}
 
 void Interpreter::logFailure(Context& ctx, const Assertion& assertion,
                              std::string_view message) {

--- a/src/Interpreter/Interpreter.cpp
+++ b/src/Interpreter/Interpreter.cpp
@@ -4,10 +4,6 @@
 #include "caffeine/Interpreter/StackFrame.h"
 #include "caffeine/Interpreter/Store.h"
 #include "caffeine/Interpreter/Value.h"
-#include "caffeine/Solver/CanonicalizingSolver.h"
-#include "caffeine/Solver/SequenceSolver.h"
-#include "caffeine/Solver/SimplifyingSolver.h"
-#include "caffeine/Solver/Z3Solver.h"
 #include "caffeine/Support/Assert.h"
 
 #include <boost/range/adaptor/transformed.hpp>
@@ -16,7 +12,6 @@
 #include <fmt/format.h>
 #include <llvm/IR/GetElementPtrTypeIterator.h>
 #include <llvm/Support/raw_ostream.h>
-#include <z3++.h>
 
 #include <iostream>
 #include <optional>


### PR DESCRIPTION
Creating a Z3 context is very expensive. It can also be reused with multiple Z3 solvers without any issues.

This commit gives a 100x performance boost by reusing the solver stack for every context in a thread.

This is part of #335 