### PR TITLE
Specify -fno-omit-frame-pointer for RelWithDebInfo build type

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -76,6 +76,7 @@ if (CAFFEINE_ENABLE_BUILD)
   include(CaffeineSanitizers)
   include(CaffeineWarnings)
   include(CaffeineLinking)
+  include(CaffeineFlags)
   include(LLVMIRUtils)
 
   if (CAFFEINE_ENABLE_TESTS)

--- a/cmake/CaffeineFlags.cmake
+++ b/cmake/CaffeineFlags.cmake
@@ -1,0 +1,6 @@
+
+# In Debug and RelWithDebInfo modes set -fno-omit-frame-pointer to make profiling
+# with perf properly resolve call stacks.
+add_compile_options(
+  "$<$<AND:$<CXX_COMPILER_ID:GCC,Clang>,$<CONFIG:RelWithDebInfo>>:-fno-omit-frame-pointer>"
+)


### PR DESCRIPTION
As in title. This is needed so that `perf record` actually records complete call stacks.