### PR TITLE
Fix script to generate yarpgen tests

### DIFF
--- a/cmake/CaffeineLinking.cmake
+++ b/cmake/CaffeineLinking.cmake
@@ -16,6 +16,7 @@ elseif(CAFFEINE_ENABLE_LTO STREQUAL "THIN")
     set(lto_tmp $<$<NOT:$<CONFIG:Debug>>:-flto=thin>)
 
     add_compile_options("${lto_tmp}")
+    add_link_options("${lto_tmp}")
     list(APPEND LINK_FLAGS "${lto_tmp}")
 
     unset(lto_tmp)
@@ -26,7 +27,7 @@ endif()
 
 if (NOT CAFFEINE_USE_LINKER STREQUAL "")
   if (NOT MSVC)
-    list(APPEND LINK_FLAGS "-fuse-ld=${CAFFEINE_USE_LINKER}")
+    add_link_options("-fuse-ld=${CAFFEINE_USE_LINKER}")
   else()
     message(${CAFFEINE_WARNING} "CAFFEINE_USE_LINKER is not supported for MSVC")
   endif()

--- a/cmake/LLVMIRUtils.cmake
+++ b/cmake/LLVMIRUtils.cmake
@@ -108,6 +108,7 @@ function(llvm_library TARGET_NAME)
   set(objects "")
   set(counter 0)
   set(library "${ARG_OUTPUT}")
+  set(linked  "${intermediate_dir}/linked.bc")
 
   add_custom_target(
     "${TARGET_NAME}" ALL
@@ -138,7 +139,7 @@ function(llvm_library TARGET_NAME)
     set(object  "${intermediate_dir}/${source_base}.${counter}.bc")
     set(depfile "${intermediate_dir}/${source_base}.${counter}.d")
 
-    if (NOT source_language STREQUAL "C")
+    if (NOT source_language STREQUAL "C" AND NOT source_language STREQUAL "CXX")
       continue()
     endif()
 
@@ -185,6 +186,7 @@ function(llvm_library TARGET_NAME)
       set(DEPFILE_ARG "")
     endif()
 
+
     add_custom_command(
       OUTPUT "${object}"
       COMMAND "${COMPILER}" ARGS
@@ -215,16 +217,23 @@ function(llvm_library TARGET_NAME)
   file(RELATIVE_PATH library_rel "${CMAKE_BINARY_DIR}" "${library}")
 
   add_custom_command(
-    OUTPUT "${library}"
+    OUTPUT "${linked}"
     COMMAND "${LLVM_LINK}" ARGS
       "$<GENEX_EVAL:$<TARGET_PROPERTY:${TARGET_NAME},LLVM_LINK_OPTIONS>>"
       "$<GENEX_EVAL:$<TARGET_PROPERTY:${TARGET_NAME},LLVM_LINK_LIBRARIES>>"
       "${objects}"
       ${extra_flags}
-      -o "${library}"
+      -o "${linked}"
     DEPENDS "${objects}" "$<TARGET_PROPERTY:${TARGET_NAME},LLVM_LINK_DEPENDS>"
     COMMENT "Linking BITCODE library ${library_rel}"
     COMMAND_EXPAND_LISTS
+  )
+
+  add_custom_command(
+    OUTPUT "${library}"
+    COMMAND gen-builtins ARGS -o "${library}" "${linked}"
+    MAIN_DEPENDENCY "${linked}"
+    COMMENT "Generating builtin methods for ${library}"
   )
 endfunction()
 

--- a/cmake/LLVMIRUtils.cmake
+++ b/cmake/LLVMIRUtils.cmake
@@ -108,7 +108,7 @@ function(llvm_library TARGET_NAME)
   set(objects "")
   set(counter 0)
   set(library "${ARG_OUTPUT}")
-  set(linked  "${intermediate_dir}/linked.bc")
+  set(linked  "${intermediate_dir}/linked.${target_ext}")
 
   add_custom_target(
     "${TARGET_NAME}" ALL

--- a/scripts/gen-yarpgen-tests.sh
+++ b/scripts/gen-yarpgen-tests.sh
@@ -39,7 +39,7 @@ llvm_compile_options    ("yarpgen-${testname}" PRIVATE -O3 -w)
 
 add_test(
   NAME "yarpgen/${testname}"
-  COMMAND caffeine-bin "${CMAKE_CURRENT_BINARY_DIR}/yarpgen.bc" main
+  COMMAND caffeine-bin "${CMAKE_CURRENT_BINARY_DIR}/$<TARGET_PROPERTY:yarpgen-${testname},OUTPUT>" main
 )
 EOM
 

--- a/tools/gen-builtins/memset.cpp
+++ b/tools/gen-builtins/memset.cpp
@@ -84,6 +84,16 @@ llvm::Function* generateMemset(llvm::Module* m, llvm::Function* decl) {
   auto arg_val = decl->getArg(1);
   auto arg_len = decl->getArg(2);
 
+  std::string func_name =
+      fmt::format("caffeine.memset.p{}i{}.i{}",
+                  arg_dst->getType()->getPointerAddressSpace(),
+                  arg_val->getType()->getIntegerBitWidth(),
+                  arg_len->getType()->getIntegerBitWidth());
+  if (llvm::Function* func = m->getFunction(func_name)) {
+    decl->replaceAllUsesWith(func);
+    return func;
+  }
+
   auto entry_ = llvm::BasicBlock::Create(m->getContext(), "entry", decl);
   auto head_ = llvm::BasicBlock::Create(m->getContext(), "head", decl);
   auto body_ = llvm::BasicBlock::Create(m->getContext(), "body", decl);
@@ -139,15 +149,16 @@ llvm::Function* generateMemset(llvm::Module* m, llvm::Function* decl) {
 
   decl->setAttributes(llvm::AttributeList::get(
       m->getContext(), llvm::AttributeList::FunctionIndex, builder));
-  decl->setName(fmt::format("caffeine.memset.p{}i{}.i{}",
-                            arg_dst->getType()->getPointerAddressSpace(),
-                            arg_val->getType()->getIntegerBitWidth(),
-                            arg_len->getType()->getIntegerBitWidth()));
+  decl->setName(func_name);
 
   // These are what clang sets on the dst argument to memset. Copying them
   // here since they're probably useful.
   decl->addAttribute(1, Attribute::WriteOnly);
   decl->addAttribute(1, Attribute::NoCapture);
+
+  // Ensure that if we try to link multiple modules with a builtin definition
+  // then the linker just picks one of them.
+  decl->setLinkage(llvm::Function::LinkOnceAnyLinkage);
 
   return decl;
 }


### PR DESCRIPTION
There are two main changes here:
- `llvm_library` now automatically runs `gen-builtins` over the generated library. This is fine since `gen-builtins` is idempotent
- Fix the `gen-yarpgen-tests.sh` script to work with the new `llvm_library` cmake code. (also make it executable)
- Edit: turns out that the generated builtin functions had problems if contained in multiple modules. I've changed the linkage to be `linkonce` so that everything works (multiple definitions will be merged together).