### PR TITLE
Update clang

### DIFF
--- a/.github/workflows/build-project.yml
+++ b/.github/workflows/build-project.yml
@@ -15,8 +15,8 @@ jobs:
     strategy:
       matrix:
         include:
-          - cc: clang-10
-            cxx: clang++-10
+          - cc: clang-11
+            cxx: clang++-11
           - cc: gcc
             cxx: g++
       # We explicitly want to run all the compilers
@@ -40,7 +40,7 @@ jobs:
 
       - name: Build
         run: cmake --build "build" -j$(nproc)
-      
+
       - name: Test
         run: |
           cd build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,7 +62,7 @@ set_property(GLOBAL PROPERTY TARGET_MESSAGES OFF)
 
 if (CAFFEINE_ENABLE_BUILD)
   # TODO: We should have an option to download and build these locally if needed.
-  find_package(LLVM 10.0 REQUIRED)
+  find_package(LLVM 11.0 REQUIRED)
   find_package(GTest REQUIRED)
   find_package(Z3 4.8.7 REQUIRED)
   find_package(Boost REQUIRED)

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,9 +9,9 @@ ARG DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update \
     && apt-get -y install \
-        llvm-10-dev \
-        clang-10 \
-        clang++-10 \
+        llvm-11-dev \
+        clang-11 \
+        clang++-11 \
         clang-format \
         libz-dev \
         build-essential \
@@ -28,3 +28,4 @@ RUN apt-get update \
         capnproto \
         pkg-config \
     && rm -rf /var/lib/apt/lists/*
+RUN sudo update-alternatives --install /usr/local/bin/llvm-config llvm-config /usr/bin/llvm-config-11 20

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Once that's done you shouldn't have to worry about it anymore.
 Running with TSAN can help detect a bunch of bugs in your code. To configure
 your build to run with TSAN do:
 ```
-CC=clang-10 CXX=clang++-10 cmake -DCAFFEINE_ENABLE_TSAN=ON ..
+CC=clang-11 CXX=clang++-11 cmake -DCAFFEINE_ENABLE_TSAN=ON ..
 ```
 
 It's also possible to specify UBSAN, ASAN, and others with the following flags:
@@ -29,9 +29,9 @@ It's also possible to specify UBSAN, ASAN, and others with the following flags:
 ```
 apt-get update \
     && apt-get -y install \
-        llvm-10-dev \
-        clang-10 \
-        clang++-10 \
+        llvm-11-dev \
+        clang-11 \
+        clang++-11 \
         libz-dev \
         build-essential \
         gcc-9 \

--- a/cmake/CaffeineDependencies.cmake
+++ b/cmake/CaffeineDependencies.cmake
@@ -109,7 +109,7 @@ caffeine_dependency(
 
 caffeine_dependency(
   # Note: for some reason the generated ImmerConfig.cmake doesn't have a version.
-  #       To make things work here we explicitly set the version to nothing. 
+  #       To make things work here we explicitly set the version to nothing.
   Immer          ""
   GIT_REPOSITORY https://github.com/arximboldi/immer
   GIT_TAG        v0.6.2

--- a/src/Memory/MemHeap.cpp
+++ b/src/Memory/MemHeap.cpp
@@ -139,13 +139,13 @@ LLVMValue Allocation::read(const OpRef& offset, llvm::Type* type,
   }
 
   if (type->isVectorTy()) {
-    CAFFEINE_ASSERT(!type->getVectorIsScalable(),
-                    "scalable vectors are not supported yet");
+    auto fixedVectorTy = llvm::dyn_cast<llvm::FixedVectorType>(type);
+    CAFFEINE_ASSERT(fixedVectorTy, "Scalable vectors are not supported yet");
     LLVMValue::OpVector members;
-    members.reserve(type->getVectorNumElements());
-    llvm::Type* elem_ty = type->getVectorElementType();
+    members.reserve(fixedVectorTy->getNumElements());
+    llvm::Type* elem_ty = fixedVectorTy->getElementType();
 
-    for (size_t i = 0; i < type->getVectorNumElements(); ++i) {
+    for (size_t i = 0; i < fixedVectorTy->getNumElements(); ++i) {
       OpRef newoffset =
           BinaryOp::CreateAdd(offset, i * layout.getTypeAllocSize(elem_ty));
 
@@ -206,8 +206,10 @@ void Allocation::write(const OpRef& offset, llvm::Type* type,
                        const llvm::DataLayout& layout) {
   if (value.is_vector()) {
     if (type->isVectorTy()) {
-      CAFFEINE_ASSERT(value.num_elements() == type->getVectorNumElements());
-      type = type->getVectorElementType();
+      auto fixedVectorTy = llvm::dyn_cast<llvm::FixedVectorType>(type);
+      CAFFEINE_ASSERT(fixedVectorTy, "Scalable vectors are not supported");
+      CAFFEINE_ASSERT(value.num_elements() == fixedVectorTy->getNumElements());
+      type = fixedVectorTy->getElementType();
     }
 
     for (size_t i = 0; i < value.num_elements(); ++i) {

--- a/src/Solver/Z3Solver.cpp
+++ b/src/Solver/Z3Solver.cpp
@@ -8,6 +8,8 @@
 #include <fmt/format.h>
 #include <fmt/ostream.h>
 
+#include <llvm/ADT/SmallString.h>
+
 namespace caffeine {
 
 llvm::APInt z3_to_apint(const z3::expr& expr) {

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,6 +1,6 @@
 
-find_program(CLANG   NAMES clang   clang-10)
-find_program(CLANGXX NAMES clang++ clang++-10)
+find_program(CLANG   NAMES clang   clang-11)
+find_program(CLANGXX NAMES clang++ clang++-11)
 
 if ("${CLANG}" STREQUAL "CLANG-NOTFOUND")
   message(${CAFFEINE_WARNING}

--- a/tools/gen-builtins/memcpy.cpp
+++ b/tools/gen-builtins/memcpy.cpp
@@ -126,10 +126,10 @@ llvm::Function* generateMemcpy(llvm::Module* m, llvm::Function* decl) {
   // Entry block
   auto resolve_dst = generateResolve(m, arg_dst->getType(), arg_len->getType());
   auto resolve_src = generateResolve(m, arg_src->getType(), arg_len->getType());
-  auto res_src = entry.CreateCall(resolve_dst.getCallee(),
-                                  ArrayRef<Value*>{arg_src, arg_len});
-  auto res_dst = entry.CreateCall(resolve_src.getCallee(),
-                                  ArrayRef<Value*>{arg_dst, arg_len});
+  auto res_src =
+      entry.CreateCall(resolve_dst, ArrayRef<Value*>{arg_src, arg_len});
+  auto res_dst =
+      entry.CreateCall(resolve_src, ArrayRef<Value*>{arg_dst, arg_len});
 
   // We only need to generate this comparison if the pointers are in the same
   // address space. Otherwise they're guaranteed not to overlap.
@@ -149,7 +149,7 @@ llvm::Function* generateMemcpy(llvm::Module* m, llvm::Function* decl) {
     auto cmp2 = entry.CreateICmpULE(src_int_hi, dst_int_lo);
     auto cond = entry.CreateOr(cmp1, cmp2);
     auto caffeine_assert = generateAssert(m);
-    entry.CreateCall(caffeine_assert.getCallee(), ArrayRef<Value*>{cond});
+    entry.CreateCall(caffeine_assert, ArrayRef<Value*>{cond});
   }
 
   entry.CreateBr(head_);

--- a/tools/gen-builtins/memset.cpp
+++ b/tools/gen-builtins/memset.cpp
@@ -96,8 +96,8 @@ llvm::Function* generateMemset(llvm::Module* m, llvm::Function* decl) {
 
   // First build entry block
   auto resolve = generateResolve(m, arg_dst->getType(), arg_len->getType());
-  auto resolved = entry.CreateCall(resolve.getCallee(),
-                                   ArrayRef<llvm::Value*>{arg_dst, arg_len});
+  auto resolved =
+      entry.CreateCall(resolve, ArrayRef<llvm::Value*>{arg_dst, arg_len});
   entry.CreateBr(head_);
 
   // Now build the loop header. We'll fix up the PHIs at the end

--- a/tools/gen-test-main/main.cpp
+++ b/tools/gen-test-main/main.cpp
@@ -55,7 +55,7 @@ void generate(llvm::Module* m, llvm::Function* function,
 
   size_t i = 0;
   for (const Argument& arg : function->args()) {
-    std::string name = arg.getName();
+    std::string name = arg.getName().str();
     if (name.empty()) {
       name = fmt::format("arg{}", i);
     }


### PR DESCRIPTION
This PR updates clang (depends on the PR to update the docker container #346)
* Updated to use new `FixedVectorType` / `ScalableVectorType`
* Fixes `ShuffleVector` implementation (mask must be constant)
* Fixes misc changes

_"major version bump, how bad can it be?"_ -me, 4 hours ago