### PR TITLE
Use a script in CI to simplify the build matrix

### DIFF
--- a/.github/scripts/setup-env.sh
+++ b/.github/scripts/setup-env.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+# This script is meant to simplify the compilation matrix in the case where we have
+# multiple dependent definitions
+
+function error {
+  echo "$1" >&2
+}
+
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    --compiler)
+      COMPILER="$2"
+      ;;
+    *)
+      error "Unknown option '$1'"
+      exit 1
+      ;;
+  esac
+done
+
+case $COMPILER in
+  clang)
+    export CC=clang
+    export CXX=clang++
+    ;;
+  gcc)
+    export CC=gcc
+    export CXX=g++
+    ;;
+esac

--- a/.github/scripts/setup-env.sh
+++ b/.github/scripts/setup-env.sh
@@ -1,9 +1,9 @@
-#!/bin/bash
+#!/bin/sh
 
 # This script is meant to simplify the compilation matrix in the case where we have
 # multiple dependent definitions
 
-function error {
+error() {
   echo "$1" >&2
 }
 

--- a/.github/workflows/build-project.yml
+++ b/.github/workflows/build-project.yml
@@ -14,11 +14,7 @@ jobs:
     container: insufficientlycaffeinated/bob
     strategy:
       matrix:
-        include:
-          - cc: clang-11
-            cxx: clang++-11
-          - cc: gcc
-            cxx: g++
+        compiler: [clang, gcc]
       # We explicitly want to run all the compilers
       fail-fast: false
     steps:
@@ -27,6 +23,7 @@ jobs:
 
       - name: Configure
         run: |
+          source ./.github/scripts/setup-env.sh --compiler ${{ matrix.compiler }}
           mkdir -p build
           cmake -B build \
             -DCAFFEINE_CI=ON \
@@ -34,9 +31,6 @@ jobs:
             -DCAFFEINE_ENABLE_UBSAN=ON \
             -DCAFFEINE_ENABLE_LIBC=ON \
             -DCAFFEINE_ENABLE_ASAN=ON
-        env:
-          CC: ${{ matrix.cc }}
-          CXX: ${{ matrix.cxx }}
 
       - name: Build
         run: cmake --build "build" -j$(nproc)

--- a/.github/workflows/build-project.yml
+++ b/.github/workflows/build-project.yml
@@ -23,7 +23,7 @@ jobs:
 
       - name: Configure
         run: |
-          source ./.github/scripts/setup-env.sh --compiler ${{ matrix.compiler }}
+          . ./.github/scripts/setup-env.sh --compiler ${{ matrix.compiler }}
           mkdir -p build
           cmake -B build \
             -DCAFFEINE_CI=ON \


### PR DESCRIPTION
As in title. This should ensure that branch protection sticks around when we want to change things.