### PR TITLE
Add support for recovering from an unimplemented feature

### DIFF
--- a/include/caffeine/Support/UnsupportedOperation.h
+++ b/include/caffeine/Support/UnsupportedOperation.h
@@ -1,0 +1,72 @@
+#pragma once
+
+#include "caffeine/Support/Assert.h"
+#include <atomic>
+#include <stdexcept>
+
+namespace caffeine {
+
+class Context;
+
+class UnsupportedOperationException : public std::exception {
+private:
+  std::string message;
+
+public:
+  UnsupportedOperationException(std::string&& message)
+      : message(std::move(message)) {}
+
+  const char* what() const noexcept override {
+    return message.c_str();
+  }
+};
+
+class UnsupportedOperation {
+private:
+  static thread_local const Context* CurrentContext;
+  static std::atomic<bool> RecoverFailures;
+
+public:
+  class ContextGuard;
+  friend class ContextGuard;
+
+  [[noreturn]] static void Abort(const char* condition, const char* function,
+                                 unsigned int line, const char* file,
+                                 std::string_view message);
+
+  static void SetRecoverable(bool recoverable) {
+    RecoverFailures.store(recoverable);
+  }
+  static ContextGuard SetCurrentContext(Context* current) {
+    return ContextGuard(current);
+  }
+
+  class ContextGuard {
+  public:
+    ContextGuard(Context* context) {
+      CAFFEINE_ASSERT(context != nullptr,
+                      "Cannot set a null context as current");
+      UnsupportedOperation::CurrentContext = context;
+    }
+    ~ContextGuard() {
+      CurrentContext = nullptr;
+    }
+
+    ContextGuard(ContextGuard&&) = delete;
+    ContextGuard(const ContextGuard&) = delete;
+    ContextGuard& operator=(ContextGuard&&) = delete;
+    ContextGuard& operator=(const ContextGuard&) = delete;
+  };
+};
+
+#define CAFFEINE_UNSUPPORTED(message)                                          \
+  ::caffeine::UnsupportedOperation::Abort(nullptr, CAFFEINE_FUNCTION,          \
+                                          __LINE__, __FILE__, message)
+#define CAFFEINE_UASSERT(condition, message)                                   \
+  do {                                                                         \
+    if (!(condition))                                                          \
+      ::caffeine::UnsupportedOperation::Abort(#condition, CAFFEINE_FUNCTION,   \
+                                              __LINE__, __FILE__, message);    \
+  } while (false)
+
+} // namespace caffeine

--- a/src/Interpreter/Executor.cpp
+++ b/src/Interpreter/Executor.cpp
@@ -23,10 +23,14 @@ void run_worker(Executor* exec, FailureLogger* logger,
     try {
       Interpreter interp(&ctx.value(), exec->policy, store, logger, solver);
       interp.execute();
-    } catch (UnsupportedOperation&) {
+    } catch (UnsupportedOperationException&) {
       // The assert that threw this already printed an error message
-      // TODO: We should have some way to indicate that this failed to the
+      // TODO: We should have a better way to indicate that this failed to the
       //       parent program.
+
+      logger->log_failure(
+          caffeine::EmptyModel(SolverResult::Unknown), ctx.value(),
+          Failure(Assertion(), "internal error: unsupported operation"));
     }
   }
 }

--- a/src/Interpreter/ExprEval.cpp
+++ b/src/Interpreter/ExprEval.cpp
@@ -4,6 +4,7 @@
 #include "caffeine/Interpreter/Value.h"
 #include "caffeine/Memory/MemHeap.h"
 #include "caffeine/Support/LLVMFmt.h"
+#include "caffeine/Support/UnsupportedOperation.h"
 #include <fmt/format.h>
 #include <fmt/ostream.h>
 #include <llvm/IR/Constants.h>
@@ -92,10 +93,9 @@ LLVMValue ExprEvaluator::evaluate(llvm::Value* val) {
   if (auto* cnst = llvm::dyn_cast<llvm::GlobalVariable>(val))
     return visitGlobalVariable(*cnst);
 
-  std::cout << magic_enum::enum_name((llvm::Value::ValueTy)val->getValueID())
-            << std::endl;
-
-  CAFFEINE_ABORT(fmt::format("Unsupported expression: {}", *val));
+  CAFFEINE_UNSUPPORTED(fmt::format(
+      "Unsupported expression ({}): {}",
+      magic_enum::enum_name((llvm::Value::ValueTy)val->getValueID()), *val));
 }
 LLVMValue ExprEvaluator::evaluate(llvm::Value& val) {
   return evaluate(&val);
@@ -112,7 +112,7 @@ std::optional<LLVMValue> ExprEvaluator::try_visit(llvm::Value* val) {
  *********************************************/
 
 LLVMValue ExprEvaluator::visitConstant(llvm::Constant& cnst) {
-  CAFFEINE_ABORT(
+  CAFFEINE_UNSUPPORTED(
       fmt::format("Unable to evaluate constant expression: {}", cnst));
 }
 

--- a/src/Support/UnsupportedOperation.cpp
+++ b/src/Support/UnsupportedOperation.cpp
@@ -1,0 +1,48 @@
+#include "caffeine/Support/UnsupportedOperation.h"
+#include "caffeine/Interpreter/Context.h"
+#include <boost/core/demangle.hpp>
+#include <fmt/format.h>
+#include <fmt/ostream.h>
+#include <llvm/Support/Signals.h>
+#include <llvm/Support/raw_ostream.h>
+#include <sstream>
+
+namespace caffeine {
+
+thread_local const Context* UnsupportedOperation::CurrentContext;
+std::atomic<bool> UnsupportedOperation::RecoverFailures{true};
+
+void UnsupportedOperation::Abort(const char* condition, const char* function,
+                                 unsigned int line, const char* file,
+                                 std::string_view message) {
+  auto demangled = boost::core::demangle(function);
+
+  std::stringstream output;
+  fmt::print(output,
+             "Unsupported operation: {}\n"
+             "  location: {}:{}\n"
+             "  function: {}\n",
+             message, file, line, function);
+
+  if (condition)
+    fmt::print(output, "  condition: {}\n", condition);
+
+  if (CurrentContext) {
+    fmt::print(output, "\nSymbolic Backtrace:\n");
+    CurrentContext->print_backtrace(output);
+  }
+
+  fmt::print(output, "\nCaffeine Backtrace:");
+  llvm::errs() << output.str();
+  llvm::errs().flush();
+  // PrintStackTrace may just end up printing straight to stderr in some cases
+  // (even if we pass in a different ostream) so just always print it out to
+  // stderr.
+  llvm::sys::PrintStackTrace(llvm::errs());
+
+  if (RecoverFailures.load())
+    throw UnsupportedOperationException(output.str());
+  std::exit(127);
+}
+
+} // namespace caffeine

--- a/src/Support/UnsupportedOperation.cpp
+++ b/src/Support/UnsupportedOperation.cpp
@@ -32,7 +32,7 @@ void UnsupportedOperation::Abort(const char* condition, const char* function,
     CurrentContext->print_backtrace(output);
   }
 
-  fmt::print(output, "\nCaffeine Backtrace:");
+  fmt::print(output, "\nCaffeine Backtrace:\n");
   llvm::errs() << output.str();
   llvm::errs().flush();
   // PrintStackTrace may just end up printing straight to stderr in some cases


### PR DESCRIPTION
This PR allows for caffeine to recover from running into an unsupported LLVM operation by killing the currently executing context. To do this it introduces two new assertion/abort macros:
- `CAFFEINE_UNSUPPORTED(message)`, and
- `CAFFEINE_UASSERT(cond, message)`

These behave like `CAFFEINE_ABORT` and `CAFFEINE_ASSERT`, respectively, but instead of aborting the whole process will instead (depending on configuration) throw an exception that gets caught within executor. This means that we end up killing the context but not the whole process, allowing other contexts to continue executing. Since we know that things aren't entirely broken we also have the ability to do things like print out a nice call stack of the current context.

/stack #354 