### PR TITLE
Add AFLplusplus for symbolic mutator

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,7 +69,7 @@ if (CAFFEINE_ENABLE_BUILD)
   find_package(fmt REQUIRED)
   find_package(CapnProto REQUIRED)
 
-  include (CaffeineDependencies)
+  include(CaffeineDependencies)
 
   set(IR_USE_BITCODE ${CAFFEINE_BUILD_BITCODE})
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,9 @@
 cmake_minimum_required(VERSION 3.8)
 
+if (CMAKE_VERSION VERSION_GREATER "3.16")
+  cmake_policy(SET CMP0097 NEW)
+endif()
+
 project(caffeine LANGUAGES C CXX)
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake")

--- a/cmake/AFLplusplus.patch
+++ b/cmake/AFLplusplus.patch
@@ -1,0 +1,19 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+new file mode 100644
+index 00000000..a5991245
+--- /dev/null
++++ b/CMakeLists.txt
+@@ -0,0 +1,13 @@
++cmake_minimum_required(VERSION 3.8)
++
++project(AFLplusplus VERSION "3.12" LANGUAGES C)
++include(CMakePackageConfigHelpers)
++add_library(${PROJECT_NAME} INTERFACE)
++target_include_directories(${PROJECT_NAME}
++  INTERFACE
++  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
++  $<INSTALL_INTERFACE:include/AFLplusplus>
++)
++install(TARGETS ${PROJECT_NAME} EXPORT ${PROJECT_NAME}Config)
++install(EXPORT ${PROJECT_NAME}Config DESTINATION lib/cmake/${PROJECT_NAME})
++install(DIRECTORY include/ DESTINATION include/${PROJECT_NAME})

--- a/cmake/AFLplusplus.patch
+++ b/cmake/AFLplusplus.patch
@@ -3,7 +3,10 @@ new file mode 100644
 index 00000000..a5991245
 --- /dev/null
 +++ b/CMakeLists.txt
-@@ -0,0 +1,13 @@
+@@ -0,0 +1,16 @@
++# This doesn't actually need any build steps because we just care about
++# being able to include "afl-fuzz.h". If that changes in the future we
++# can update this approach.
 +cmake_minimum_required(VERSION 3.8)
 +
 +project(AFLplusplus VERSION "3.12" LANGUAGES C)

--- a/cmake/CaffeineDependencies.cmake
+++ b/cmake/CaffeineDependencies.cmake
@@ -35,7 +35,7 @@ function(caffeine_dependency PACKAGE VERSION)
   make_directory("${SUB_DIR}")
 
   set(QUOTED_ARGS "")
-  foreach(ARG ${ARGN})
+  foreach(ARG IN LISTS ARGN)
     set(QUOTED_ARGS "${QUOTED_ARGS} \"${ARG}\"")
   endforeach()
 
@@ -117,4 +117,5 @@ caffeine_dependency(
   PATCH_COMMAND  "${CMAKE_COMMAND}"
     "${CMAKE_CURRENT_LIST_DIR}/immer.patch"
     -P "${CMAKE_CURRENT_LIST_DIR}/CaffeinePatch.cmake"
+  GIT_SUBMODULES ""
 )

--- a/cmake/CaffeineDependencies.cmake
+++ b/cmake/CaffeineDependencies.cmake
@@ -119,3 +119,14 @@ caffeine_dependency(
     -P "${CMAKE_CURRENT_LIST_DIR}/CaffeinePatch.cmake"
   GIT_SUBMODULES ""
 )
+
+caffeine_dependency(
+  AFLplusplus                ""
+  GIT_REPOSITORY             https://github.com/AFLplusplus/AFLplusplus
+  GIT_TAG                    3.12c
+  GIT_SHALLOW                TRUE
+  GIT_SUBMODULES             ""
+  PATCH_COMMAND  "${CMAKE_COMMAND}"
+    "${CMAKE_SOURCE_DIR}/cmake/AFLplusplus.patch"
+    -P "${CMAKE_SOURCE_DIR}/cmake/CaffeinePatch.cmake"
+)

--- a/tools/guided-fuzzing/CMakeLists.txt
+++ b/tools/guided-fuzzing/CMakeLists.txt
@@ -26,21 +26,6 @@ target_include_directories(afl-guided-mutator SYSTEM
   PRIVATE "${FMT_INCLUDE_DIRS}"
 )
 
-if (CMAKE_VERSION VERSION_GREATER "3.16")
-  cmake_policy(SET CMP0097 NEW)
-endif()
-
-caffeine_dependency(
-  AFLplusplus                ""
-  GIT_REPOSITORY             https://github.com/AFLplusplus/AFLplusplus
-  GIT_TAG                    3.12c
-  GIT_SHALLOW                TRUE
-  GIT_SUBMODULES             ""
-  PATCH_COMMAND  "${CMAKE_COMMAND}"
-    "${CMAKE_SOURCE_DIR}/cmake/AFLplusplus.patch"
-    -P "${CMAKE_SOURCE_DIR}/cmake/CaffeinePatch.cmake"
-)
-
 target_link_libraries(afl-guided-mutator PRIVATE caffeine)
 set_property(TARGET caffeine PROPERTY POSITION_INDEPENDENT_CODE ON)
 target_link_libraries(afl-guided-mutator PRIVATE LLVMCore LLVMIRReader LLVMBitWriter LLVMTransformUtils)

--- a/tools/guided-fuzzing/CMakeLists.txt
+++ b/tools/guided-fuzzing/CMakeLists.txt
@@ -26,7 +26,22 @@ target_include_directories(afl-guided-mutator SYSTEM
   PRIVATE "${FMT_INCLUDE_DIRS}"
 )
 
+if (CMAKE_VERSION VERSION_GREATER "3.16")
+  cmake_policy(SET CMP0097 NEW)
+endif()
+
+caffeine_dependency(
+  AFLplusplus                ""
+  GIT_REPOSITORY             https://github.com/AFLplusplus/AFLplusplus
+  GIT_TAG                    3.12c
+  GIT_SHALLOW                TRUE
+  GIT_SUBMODULES             ""
+  PATCH_COMMAND  "${CMAKE_COMMAND}"
+    "${CMAKE_SOURCE_DIR}/cmake/AFLplusplus.patch"
+    -P "${CMAKE_SOURCE_DIR}/cmake/CaffeinePatch.cmake"
+)
+
 target_link_libraries(afl-guided-mutator PRIVATE caffeine)
 set_property(TARGET caffeine PROPERTY POSITION_INDEPENDENT_CODE ON)
 target_link_libraries(afl-guided-mutator PRIVATE LLVMCore LLVMIRReader LLVMBitWriter LLVMTransformUtils)
-target_link_libraries(afl-guided-mutator PRIVATE fmt::fmt)
+target_link_libraries(afl-guided-mutator PRIVATE fmt::fmt AFLplusplus)

--- a/tools/guided-fuzzing/src/SymbolicMutator.cpp
+++ b/tools/guided-fuzzing/src/SymbolicMutator.cpp
@@ -1,0 +1,1 @@
+#include "afl-fuzz.h"


### PR DESCRIPTION
This PR fixes a bug where empty strings cannot be passed to the `caffeine_dependency` rule and also adds AFL++ to the symbolic mutator / guided fuzzing tool.