### PR TITLE
Add support for debug info

### DIFF
--- a/cmake/LLVMIRUtils.cmake
+++ b/cmake/LLVMIRUtils.cmake
@@ -190,7 +190,7 @@ function(llvm_library TARGET_NAME)
     add_custom_command(
       OUTPUT "${object}"
       COMMAND "${COMPILER}" ARGS
-        -emit-llvm -MMD -c
+        -emit-llvm -MMD -g -c
         "${sys_includes}"
         "${tgt_includes}"
         "${src_includes}"

--- a/cmake/LLVMIRUtils.cmake
+++ b/cmake/LLVMIRUtils.cmake
@@ -28,7 +28,7 @@ set_if_unset(LLVM_LINK "${LLVM_TOOLS_BINARY_DIR}/llvm-link")
 set_if_unset(LLVM_OPT  "${LLVM_TOOLS_BINARY_DIR}/opt")
 set_if_unset(LLVM_DIS  "${LLVM_TOOLS_BINARY_DIR}/llvm-dis")
 
-set_if_unset(IR_USE_BITCODE OFF)
+set_if_unset(IR_USE_BITCODE ON)
 
 if (IR_USE_BITCODE)
   set(IR_EXTRA_FLAGS "")
@@ -108,7 +108,7 @@ function(llvm_library TARGET_NAME)
   set(objects "")
   set(counter 0)
   set(library "${ARG_OUTPUT}")
-  set(linked  "${intermediate_dir}/linked.${target_ext}")
+  set(linked  "${intermediate_dir}/linked${target_ext}")
 
   add_custom_target(
     "${TARGET_NAME}" ALL

--- a/include/caffeine/Interpreter/Interpreter.h
+++ b/include/caffeine/Interpreter/Interpreter.h
@@ -93,6 +93,8 @@ public:
   ExecutionResult visitMemMoveInst(llvm::MemMoveInst& memmove);
   ExecutionResult visitMemSetInst(llvm::MemSetInst& memset);
 
+  ExecutionResult visitDbgInfoIntrinsic(llvm::DbgInfoIntrinsic&);
+
 private:
   void logFailure(Context& ctx, const Assertion& assertion,
                   std::string_view message = "");

--- a/src/Interpreter/Interpreter.cpp
+++ b/src/Interpreter/Interpreter.cpp
@@ -455,6 +455,11 @@ ExecutionResult Interpreter::visitMemSetInst(llvm::MemSetInst&) {
                  "first to generate definitions that caffeine can execute.");
 }
 
+ExecutionResult Interpreter::visitDbgInfoIntrinsic(llvm::DbgInfoIntrinsic&) {
+  // Ignore debug info since it doesn't affect semantics.
+  return ExecutionResult::Continue;
+}
+
 /***************************************************
  * External function                               *
  ***************************************************/


### PR DESCRIPTION
There's nothing special that caffeine needs to do to support debug info, we just have to ignore it. This PR does just that. I've also enabled debug info in all tests so that when #354 gets merged it'll also show the source lines (where applicable).