### PR TITLE
Fix `select` operation for pointer types

### DIFF
--- a/include/caffeine/Interpreter/ExprEval.h
+++ b/include/caffeine/Interpreter/ExprEval.h
@@ -138,6 +138,7 @@ public:
 
 private:
   OpRef scalarize(const LLVMScalar& scalar) const;
+  static LLVMScalar pointerize(const OpRef& op, bool turn_to_pointer) const;
 
 private:
   Context* ctx;

--- a/include/caffeine/Interpreter/ExprEval.h
+++ b/include/caffeine/Interpreter/ExprEval.h
@@ -138,7 +138,7 @@ public:
 
 private:
   OpRef scalarize(const LLVMScalar& scalar) const;
-  static LLVMScalar pointerize(const OpRef& op, bool turn_to_pointer) const;
+  static LLVMScalar pointerize(const OpRef& op, bool turn_to_pointer);
 
 private:
   Context* ctx;

--- a/src/Interpreter/ExprEval.cpp
+++ b/src/Interpreter/ExprEval.cpp
@@ -44,6 +44,12 @@ OpRef ExprEvaluator::scalarize(const LLVMScalar& scalar) const {
     return scalar.expr();
   return scalar.pointer().value(ctx->heap);
 }
+LLVMScalar ExprEvaluator::pointerize(const OpRef& op,
+                                     bool turn_to_pointer) const {
+  if (turn_to_pointer)
+    return LLVMScalar(Pointer(op));
+  return LLVMScalar(op);
+}
 
 LLVMValue ExprEvaluator::visit(llvm::Value* val) {
   const auto& frame = ctx->stack_top();

--- a/src/Interpreter/ExprEval.cpp
+++ b/src/Interpreter/ExprEval.cpp
@@ -44,8 +44,7 @@ OpRef ExprEvaluator::scalarize(const LLVMScalar& scalar) const {
     return scalar.expr();
   return scalar.pointer().value(ctx->heap);
 }
-LLVMScalar ExprEvaluator::pointerize(const OpRef& op,
-                                     bool turn_to_pointer) const {
+LLVMScalar ExprEvaluator::pointerize(const OpRef& op, bool turn_to_pointer) {
   if (turn_to_pointer)
     return LLVMScalar(Pointer(op));
   return LLVMScalar(op);
@@ -679,8 +678,10 @@ LLVMValue ExprEvaluator::visitSelectInst(llvm::SelectInst& op) {
   return transform_elements(
       [&](const auto& cond, const auto& t_val,
           const auto& f_val) -> LLVMScalar {
-        return SelectOp::Create(cond.expr(), scalarize(t_val),
-                                scalarize(f_val));
+        auto is_ptr = t_val.is_pointer() || f_val.is_pointer();
+        return pointerize(
+            SelectOp::Create(cond.expr(), scalarize(t_val), scalarize(f_val)),
+            is_ptr);
       },
       cond, t_val, f_val);
 }

--- a/test/regression/issue-359.pass.pointer-select.c
+++ b/test/regression/issue-359.pass.pointer-select.c
@@ -1,0 +1,11 @@
+#include "caffeine.h"
+#include <stdint.h>
+
+uint32_t a = 0;
+uint32_t b = 0;
+
+void test(uint8_t x) {
+  uint32_t* ptr = x ? &a : &b;
+
+  *ptr = 1;
+}


### PR DESCRIPTION
Within caffeine pointers are stored within the `Pointer` type. However, when executing a `select` instruction `ExprEvaluator::visitSelectInst` would return a non-pointer expression. This broke assumptions of later instructions and resulted in assertion failures.

This PR fixes this problem by changing `visitSelectInst` to return a pointer if either of the operands are pointers. I've checked the other methods in `ExprEvaluator` and I didn't see anywhere else where this could happen. (The only other case I could think of was the vector instructions but apparently vectors of pointers aren't allowed).