### PR TITLE
Implement more robust patching script

### DIFF
--- a/cmake/CaffeinePatch.cmake
+++ b/cmake/CaffeinePatch.cmake
@@ -8,6 +8,15 @@ if (NOT EXITCODE EQUAL 0)
   message (FATAL_ERROR "Failed to reset repo")
 endif()
 
+execute_process(
+  COMMAND git clean -fxd
+  RESULT_VARIABLE EXITCODE
+)
+
+if (NOT EXITCODE EQUAL 0)
+  message (FATAL_ERROR "Failed to clean repo")
+endif()
+
 set(ARG_NUM 1)
 while (ARG_NUM LESS CMAKE_ARGC)
   set(ARG "${CMAKE_ARGV${ARG_NUM}}")


### PR DESCRIPTION
The current one fails when a new file has been added since `git reset --hard` doesn't remove those fails. This fixes that by also running `git clean` to remove untracked files.