### PR TITLE
Implement support for debug intrinsics

### DIFF
--- a/cmake/LLVMIRUtils.cmake
+++ b/cmake/LLVMIRUtils.cmake
@@ -190,7 +190,7 @@ function(llvm_library TARGET_NAME)
     add_custom_command(
       OUTPUT "${object}"
       COMMAND "${COMPILER}" ARGS
-        -emit-llvm -MMD -c
+        -emit-llvm -MMD -g -c
         "${sys_includes}"
         "${tgt_includes}"
         "${src_includes}"

--- a/include/caffeine/Interpreter/Interpreter.h
+++ b/include/caffeine/Interpreter/Interpreter.h
@@ -93,6 +93,8 @@ public:
   ExecutionResult visitMemMoveInst(llvm::MemMoveInst& memmove);
   ExecutionResult visitMemSetInst(llvm::MemSetInst& memset);
 
+  ExecutionResult visitDbgInfoIntrinsic(llvm::DbgInfoIntrinsic&);
+
 private:
   void logFailure(Context& ctx, const Assertion& assertion,
                   std::string_view message = "");

--- a/src/Interpreter/Interpreter.cpp
+++ b/src/Interpreter/Interpreter.cpp
@@ -455,6 +455,11 @@ ExecutionResult Interpreter::visitMemSetInst(llvm::MemSetInst&) {
                  "first to generate definitions that caffeine can execute.");
 }
 
+ExecutionResult Interpreter::visitDbgInfoIntrinsic(llvm::DbgInfoIntrinsic&) {
+  // Ignore debug info since it doesn't affect semantics.
+  return ExecutionResult::Continue;
+}
+
 /***************************************************
  * External function                               *
  ***************************************************/


### PR DESCRIPTION
There isn't anything special we need to do to support this, it's just a matter of not crashing when we encounter any of them. That is all this PR does.

To help with the better stack traces that are being introduced, and to test that this works, this PR compiles all of the IR with debug info.