### PR TITLE
Fix zext bug within `Z3Solver`

### DIFF
--- a/src/Solver/Z3Solver.cpp
+++ b/src/Solver/Z3Solver.cpp
@@ -591,13 +591,13 @@ z3::expr Z3OpVisitor::visitZExt(const UnaryOp& op) {
   auto operand = visit(*op.operand());
   auto src = normalize_to_bv(operand);
 
-  return z3::zext(src, op.type().bitwidth() - operand.get_sort().bv_size());
+  return z3::zext(src, op.type().bitwidth() - src.get_sort().bv_size());
 }
 z3::expr Z3OpVisitor::visitSExt(const UnaryOp& op) {
   auto operand = visit(*op.operand());
   auto src = normalize_to_bv(operand);
 
-  return z3::sext(src, op.type().bitwidth() - operand.get_sort().bv_size());
+  return z3::sext(src, op.type().bitwidth() - src.get_sort().bv_size());
 }
 
 z3::expr Z3OpVisitor::visitLoadOp(const LoadOp& op) {

--- a/test/regression/issue-361.pass.zext-bool.ll
+++ b/test/regression/issue-361.pass.zext-bool.ll
@@ -1,0 +1,26 @@
+source_filename   = "llvm-link"
+target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128"
+target triple     = "x86_64-pc-linux-gnu"
+
+; The bug that this test case is trying to test occurs when we try to zext an i1
+; for which Z3Solver has built a z3::expr that is a boolean.
+;
+; To hit this case, we call zext on the result of a comparison. The rest is just
+; to make sure that the expression is placed within an assertion that we care
+; about.
+define dso_local void @test(i8 zeroext %x) local_unnamed_addr #0 {
+  %1 = icmp ne i8 %x, 0
+  %2 = zext i1 %1 to i8
+  %3 = icmp eq i8 %2, 0
+  %4 = icmp eq i8 %2, 1
+  %5 = or i1 %3, %4
+  call void @caffeine_assert(i1 zeroext %5)
+  ret void
+}
+
+declare void @caffeine_assert(i1 zeroext) local_unnamed_addr #1
+
+
+attributes #0 = { optnone noinline nounwind }
+attributes #1 = { nounwind }
+


### PR DESCRIPTION
This PR fixes a bug where caffeine will crash when `Z3Solver` attempts to build a `zext` operation for an inner type which is actually represented using a boolean. See the commit messages for a more detailed description of the bug. I've included a test case to ensure that the issue doesn't crop up again.

Closes #361 