### PR TITLE
Various debug output cleanups

### DIFF
--- a/include/caffeine/IR/Operation.h
+++ b/include/caffeine/IR/Operation.h
@@ -304,7 +304,7 @@ protected:
    */
   uint16_t aux_data() const;
 
-private:
+public:
   // Utility during debugging - should never actually be called by the program.
   void DebugPrint() const;
 };

--- a/include/caffeine/Interpreter/AssertionList.h
+++ b/include/caffeine/Interpreter/AssertionList.h
@@ -97,6 +97,8 @@ public:
     return llvm::iterator_range<const_iterator>(list_.iterator_at(mark_),
                                                 end());
   }
+
+  void DebugPrint() const;
 };
 
 } // namespace caffeine

--- a/include/caffeine/Solver/Solver.h
+++ b/include/caffeine/Solver/Solver.h
@@ -1,9 +1,9 @@
 #ifndef CAFFEINE_SOLVER_SOLVER_H
 #define CAFFEINE_SOLVER_SOLVER_H
 
+#include <iosfwd>
 #include <memory>
 #include <vector>
-#include <iosfwd>
 
 #include "caffeine/ADT/Ref.h"
 #include "caffeine/IR/Value.h"

--- a/include/caffeine/Solver/Solver.h
+++ b/include/caffeine/Solver/Solver.h
@@ -3,6 +3,7 @@
 
 #include <memory>
 #include <vector>
+#include <iosfwd>
 
 #include "caffeine/ADT/Ref.h"
 #include "caffeine/IR/Value.h"
@@ -157,6 +158,8 @@ public:
 
   Value lookup(const Symbol& symbol, std::optional<size_t> size) const override;
 };
+
+std::ostream& operator<<(std::ostream& os, SolverResult res);
 
 } // namespace caffeine
 

--- a/src/Interpreter/Debug.cpp
+++ b/src/Interpreter/Debug.cpp
@@ -13,4 +13,4 @@ void AssertionList::DebugPrint() const {
   std::cout << "\n]" << std::endl;
 }
 
-}
+} // namespace caffeine

--- a/src/Interpreter/Debug.cpp
+++ b/src/Interpreter/Debug.cpp
@@ -1,0 +1,16 @@
+#include "caffeine/Interpreter/AssertionList.h"
+#include <fmt/format.h>
+#include <fmt/ostream.h>
+#include <iostream>
+
+namespace caffeine {
+
+void AssertionList::DebugPrint() const {
+  std::cout << "AssertionList [";
+  for (const Assertion& a : *this) {
+    std::cout << "\n  " << a;
+  }
+  std::cout << "\n]" << std::endl;
+}
+
+}

--- a/src/Solver/Solver.cpp
+++ b/src/Solver/Solver.cpp
@@ -4,6 +4,7 @@
 #include "caffeine/IR/Visitor.h"
 #include "caffeine/Interpreter/Context.h"
 
+#include <magic_enum.hpp>
 #include <fmt/format.h>
 
 namespace caffeine {
@@ -184,6 +185,10 @@ EmptyModel::EmptyModel(SolverResult result) : Model(result) {
 
 Value EmptyModel::lookup(const Symbol&, std::optional<size_t>) const {
   CAFFEINE_ABORT("Model was empty");
+}
+
+std::ostream& operator<<(std::ostream& os, SolverResult res) {
+  return os << magic_enum::enum_name(res);
 }
 
 } // namespace caffeine

--- a/src/Solver/Solver.cpp
+++ b/src/Solver/Solver.cpp
@@ -4,8 +4,8 @@
 #include "caffeine/IR/Visitor.h"
 #include "caffeine/Interpreter/Context.h"
 
-#include <magic_enum.hpp>
 #include <fmt/format.h>
+#include <magic_enum.hpp>
 
 namespace caffeine {
 


### PR DESCRIPTION
This PR adds three things:
- A `DebugPrint` method on AssertionList
- A `operator<<` method on `SolverResult`
- `Operation::DebugPrint` is now public

These were both useful while debugging.