### PR TITLE
Implement support for multiple heaps

### DIFF
--- a/include/caffeine/Interpreter/Context.h
+++ b/include/caffeine/Interpreter/Context.h
@@ -26,10 +26,14 @@ class Context {
 public:
   std::vector<StackFrame> stack;
   std::unordered_map<llvm::GlobalVariable*, LLVMValue> globals;
-  MemHeap heap{0};
+  MemHeapMgr heaps;
   AssertionList assertions;
 
   llvm::Module* mod;
+
+  MemHeap& heap() {
+    return heaps[0];
+  }
 
 private:
   uint64_t constant_num_ = 0;

--- a/include/caffeine/Interpreter/Context.h
+++ b/include/caffeine/Interpreter/Context.h
@@ -26,7 +26,7 @@ class Context {
 public:
   std::vector<StackFrame> stack;
   std::unordered_map<llvm::GlobalVariable*, LLVMValue> globals;
-  MemHeap heap;
+  MemHeap heap{0};
   AssertionList assertions;
 
   llvm::Module* mod;

--- a/include/caffeine/Interpreter/Context.h
+++ b/include/caffeine/Interpreter/Context.h
@@ -31,7 +31,7 @@ public:
 
   llvm::Module* mod;
 
-  MemHeap& heap() {
+  [[deprecated]] MemHeap& heap() {
     return heaps[0];
   }
 

--- a/include/caffeine/Interpreter/Context.h
+++ b/include/caffeine/Interpreter/Context.h
@@ -31,10 +31,6 @@ public:
 
   llvm::Module* mod;
 
-  [[deprecated]] MemHeap& heap() {
-    return heaps[0];
-  }
-
 private:
   uint64_t constant_num_ = 0;
 

--- a/include/caffeine/Interpreter/ExprEval.h
+++ b/include/caffeine/Interpreter/ExprEval.h
@@ -138,7 +138,6 @@ public:
 
 private:
   OpRef scalarize(const LLVMScalar& scalar) const;
-  static LLVMScalar pointerize(const OpRef& op, bool turn_to_pointer);
 
 private:
   Context* ctx;

--- a/include/caffeine/Interpreter/StackFrame.h
+++ b/include/caffeine/Interpreter/StackFrame.h
@@ -15,6 +15,15 @@ namespace caffeine {
 
 class Context;
 
+class StackAllocation {
+public:
+  AllocId alloc;
+  unsigned heap;
+
+  StackAllocation(const AllocId& allocid, unsigned heap)
+      : alloc(allocid), heap(heap) {}
+};
+
 class StackFrame {
 public:
   std::unordered_map<llvm::Value*, LLVMValue> variables;
@@ -27,7 +36,7 @@ public:
   llvm::BasicBlock::iterator current;
 
   // Allocations within the current frame.
-  std::vector<AllocId> allocations;
+  std::vector<StackAllocation> allocations;
 
   StackFrame(llvm::Function* function);
 

--- a/include/caffeine/Memory/MemHeap.h
+++ b/include/caffeine/Memory/MemHeap.h
@@ -123,10 +123,10 @@ public:
    */
   void write(const OpRef& offset, const OpRef& value,
              const llvm::DataLayout& layout);
-  void write(const OpRef& offset, const LLVMScalar& value, const MemHeap& heap,
-             const llvm::DataLayout& layout);
+  void write(const OpRef& offset, const LLVMScalar& value,
+             const MemHeapMgr& heapmgr, const llvm::DataLayout& layout);
   void write(const OpRef& offset, llvm::Type* type, const LLVMValue& value,
-             const MemHeap& heap, const llvm::DataLayout& layout);
+             const MemHeapMgr& heapmgr, const llvm::DataLayout& layout);
 
   void DebugPrint() const;
 };

--- a/include/caffeine/Memory/MemHeap.h
+++ b/include/caffeine/Memory/MemHeap.h
@@ -216,9 +216,7 @@ private:
 public:
   MemHeap(unsigned index);
 
-  unsigned index() const {
-    return index_;
-  }
+  unsigned index() const;
 
   Allocation& operator[](const AllocId& alloc);
   const Allocation& operator[](const AllocId& alloc) const;

--- a/include/caffeine/Memory/MemHeap.h
+++ b/include/caffeine/Memory/MemHeap.h
@@ -168,13 +168,15 @@ class Pointer {
 private:
   AllocId alloc_;
   OpRef offset_;
+  unsigned heap_;
 
 public:
-  explicit Pointer(const OpRef& value);
-  Pointer(const AllocId& alloc, const OpRef& offset);
+  explicit Pointer(const OpRef& value, unsigned heap);
+  Pointer(const AllocId& alloc, const OpRef& offset, unsigned heap);
 
   AllocId alloc() const;
   const OpRef& offset() const;
+  unsigned heap() const;
 
   /**
    * The absolute value of this pointer.
@@ -184,6 +186,7 @@ public:
    * MemHeap::resolve to go the other way.
    */
   OpRef value(const MemHeap& heap) const;
+  OpRef value(const MemHeapMgr& heapmgr) const;
 
   /**
    * Whether this pointer has been resolved to a specific allocation.
@@ -197,6 +200,7 @@ public:
    * Get an assertion to check if this pointer is a null pointer.
    */
   Assertion check_null(const MemHeap& heap) const;
+  Assertion check_null(const MemHeapMgr& heapmgr) const;
 
   bool operator==(const Pointer& p) const;
   bool operator!=(const Pointer& p) const;
@@ -207,9 +211,14 @@ public:
 class MemHeap {
 private:
   slot_map<Allocation> allocs_;
+  unsigned index_;
 
 public:
-  MemHeap() = default;
+  MemHeap(unsigned index);
+
+  unsigned index() const {
+    return index_;
+  }
 
   Allocation& operator[](const AllocId& alloc);
   const Allocation& operator[](const AllocId& alloc) const;
@@ -247,7 +256,7 @@ public:
    * assertion that the pointer points within one of them.
    */
   Assertion check_valid(const Pointer& value, uint32_t width);
-  Assertion check_valid(const Pointer& value, const OpRef& offset);
+  Assertion check_valid(const Pointer& value, const OpRef& width);
 
   /**
    * Get an assertion that checks whether the provided pointer points to the

--- a/include/caffeine/Solver/Solver.h
+++ b/include/caffeine/Solver/Solver.h
@@ -4,7 +4,6 @@
 #include <iosfwd>
 #include <memory>
 #include <vector>
-#include <iosfwd>
 
 #include "caffeine/ADT/Ref.h"
 #include "caffeine/IR/Value.h"

--- a/include/caffeine/Solver/Solver.h
+++ b/include/caffeine/Solver/Solver.h
@@ -4,6 +4,7 @@
 #include <iosfwd>
 #include <memory>
 #include <vector>
+#include <iosfwd>
 
 #include "caffeine/ADT/Ref.h"
 #include "caffeine/IR/Value.h"

--- a/src/Interpreter/Context.cpp
+++ b/src/Interpreter/Context.cpp
@@ -103,11 +103,11 @@ void Context::pop() {
   CAFFEINE_ASSERT(!stack.empty());
 
   auto& frame = stack.back();
-  for (auto allocid : frame.allocations) {
-    CAFFEINE_ASSERT(heap()[allocid].kind() == AllocationKind::Alloca,
+  for (auto [allocid, heap] : frame.allocations) {
+    CAFFEINE_ASSERT(heaps[heap][allocid].kind() == AllocationKind::Alloca,
                     "found non-stack allocation on the stack");
 
-    heap().deallocate(allocid);
+    heaps[heap].deallocate(allocid);
   }
 
   stack.pop_back();

--- a/src/Interpreter/Context.cpp
+++ b/src/Interpreter/Context.cpp
@@ -104,10 +104,10 @@ void Context::pop() {
 
   auto& frame = stack.back();
   for (auto allocid : frame.allocations) {
-    CAFFEINE_ASSERT(heap[allocid].kind() == AllocationKind::Alloca,
+    CAFFEINE_ASSERT(heap()[allocid].kind() == AllocationKind::Alloca,
                     "found non-stack allocation on the stack");
 
-    heap.deallocate(allocid);
+    heap().deallocate(allocid);
   }
 
   stack.pop_back();

--- a/src/Interpreter/ExprEval.cpp
+++ b/src/Interpreter/ExprEval.cpp
@@ -43,7 +43,7 @@ ExprEvaluator::ExprEvaluator(Context* ctx, Options options)
 OpRef ExprEvaluator::scalarize(const LLVMScalar& scalar) const {
   if (scalar.is_expr())
     return scalar.expr();
-  return scalar.pointer().value(ctx->heap);
+  return scalar.pointer().value(ctx->heap());
 }
 LLVMScalar ExprEvaluator::pointerize(const OpRef& op, bool turn_to_pointer) {
   if (turn_to_pointer)
@@ -340,7 +340,7 @@ LLVMValue ExprEvaluator::visitGlobalVariable(llvm::GlobalVariable& global) {
   auto perms = global.isConstant() ? AllocationPermissions::Write
                                    : AllocationPermissions::ReadWrite;
 
-  auto alloc = ctx->heap.allocate(
+  auto alloc = ctx->heap().allocate(
       array.size(), ConstantInt::Create(llvm::APInt(bitwidth, alignment)), data,
       AllocationKind::Global, perms, *ctx);
 
@@ -365,7 +365,7 @@ OpRef ExprEvaluator::visitGlobalData(llvm::Constant& constant, unsigned AS) {
   Allocation alloc{ConstantInt::CreateZero(bitwidth), size,
                    AllocOp::Create(size, ConstantInt::CreateZero(8)),
                    AllocationKind::Alloca, AllocationPermissions::ReadWrite};
-  alloc.write(ConstantInt::CreateZero(bitwidth), type, value, ctx->heap,
+  alloc.write(ConstantInt::CreateZero(bitwidth), type, value, ctx->heap(),
               layout);
 
   return alloc.data();
@@ -479,7 +479,7 @@ LLVMValue ExprEvaluator::visitICmp(llvm::ICmpInst& icmp) {
   auto as_expr = [&](const LLVMScalar& value) {
     if (value.is_expr())
       return value.expr();
-    return value.pointer().value(ctx->heap);
+    return value.pointer().value(ctx->heap());
   };
 
   return transform_elements(
@@ -565,7 +565,7 @@ LLVMValue ExprEvaluator::visitPtrToInt(llvm::PtrToIntInst& inst) {
   return transform_elements(
       [&](const LLVMScalar& value) {
         return LLVMScalar(UnaryOp::CreateTruncOrZExt(
-            Type::from_llvm(inst.getType()), value.pointer().value(ctx->heap)));
+            Type::from_llvm(inst.getType()), value.pointer().value(ctx->heap())));
       },
       visit(inst.getOperand(0)));
 }
@@ -664,7 +664,7 @@ LLVMValue ExprEvaluator::visitGetElementPtr(llvm::GetElementPtrInst& inst) {
                          ptr.heap());
         } else {
           return Pointer(
-              BinaryOp::CreateAdd(ptr.value(ctx->heap), offset.expr()),
+              BinaryOp::CreateAdd(ptr.value(ctx->heap()), offset.expr()),
               ptr.heap());
         }
       },

--- a/src/Interpreter/Interpreter.cpp
+++ b/src/Interpreter/Interpreter.cpp
@@ -371,7 +371,7 @@ ExecutionResult Interpreter::visitLoadInst(llvm::LoadInst& inst) {
   const Pointer& pointer = operand.scalar().pointer();
 
   auto assertion =
-      ctx->heap().check_valid(pointer, layout.getTypeStoreSize(inst.getType()));
+      ctx->heaps.check_valid(pointer, layout.getTypeStoreSize(inst.getType()));
   if (ctx->check(solver, !assertion) == SolverResult::SAT) {
     logFailure(*ctx, !assertion, "invalid pointer load");
 
@@ -382,11 +382,11 @@ ExecutionResult Interpreter::visitLoadInst(llvm::LoadInst& inst) {
     return ExecutionResult::Dead;
   }
 
-  auto resolved = ctx->heap().resolve(solver, pointer, *ctx);
+  auto resolved = ctx->heaps.resolve(solver, pointer, *ctx);
   auto forks = ctx->fork(resolved.size());
 
   for (auto [fork, ptr] : llvm::zip(forks, resolved)) {
-    Allocation& alloc = fork.heap()[ptr.alloc()];
+    Allocation& alloc = fork.heaps[ptr.heap()][ptr.alloc()];
     fork.add(alloc.check_inbounds(ptr.offset(),
                                   layout.getTypeStoreSize(inst.getType())));
 
@@ -408,7 +408,7 @@ ExecutionResult Interpreter::visitStoreInst(llvm::StoreInst& inst) {
   const llvm::DataLayout& layout = inst.getModule()->getDataLayout();
   const Pointer& pointer = dest.scalar().pointer();
 
-  auto assertion = ctx->heap().check_valid(
+  auto assertion = ctx->heaps.check_valid(
       pointer, layout.getTypeStoreSize(inst.getOperand(0)->getType()));
   if (ctx->check(solver, !assertion) == SolverResult::SAT) {
     logFailure(*ctx, !assertion, "invalid pointer store");
@@ -420,14 +420,14 @@ ExecutionResult Interpreter::visitStoreInst(llvm::StoreInst& inst) {
     return ExecutionResult::Dead;
   }
 
-  auto resolved = ctx->heap().resolve(solver, pointer, *ctx);
+  auto resolved = ctx->heaps.resolve(solver, pointer, *ctx);
   auto forks = ctx->fork(resolved.size());
 
   for (auto [fork, ptr] : llvm::zip(forks, resolved)) {
-    Allocation& alloc = fork.heap()[ptr.alloc()];
+    Allocation& alloc = fork.heaps[ptr.heap()][ptr.alloc()];
     fork.add(
         alloc.check_inbounds(ptr.offset(), layout.getTypeStoreSize(op_ty)));
-    alloc.write(ptr.offset(), op_ty, value, fork.heap(), layout);
+    alloc.write(ptr.offset(), op_ty, value, fork.heaps, layout);
 
     if (!pointer.is_resolved()) {
       fork.backprop(pointer, ptr);
@@ -448,7 +448,7 @@ ExecutionResult Interpreter::visitAllocaInst(llvm::AllocaInst& inst) {
   unsigned ptr_width = layout.getPointerSizeInBits(address_space);
 
   auto size_op = ConstantInt::Create(llvm::APInt(ptr_width, size));
-  auto alloc = ctx->heap().allocate(
+  auto alloc = ctx->heaps[address_space].allocate(
       size_op, ConstantInt::Create(llvm::APInt(ptr_width, align)),
       AllocOp::Create(size_op, ConstantInt::Create(llvm::APInt(8, 0xDD))),
       AllocationKind::Alloca, AllocationPermissions::ReadWrite, *ctx);
@@ -456,7 +456,7 @@ ExecutionResult Interpreter::visitAllocaInst(llvm::AllocaInst& inst) {
   frame.insert(&inst, LLVMValue(Pointer(
                           alloc, ConstantInt::Create(llvm::APInt(ptr_width, 0)),
                           address_space)));
-  frame.allocations.push_back(alloc);
+  frame.allocations.emplace_back(alloc, address_space);
 
   return ExecutionResult::Continue;
 }
@@ -550,7 +550,7 @@ ExecutionResult Interpreter::visitAssert(llvm::CallInst& call) {
 
 std::optional<std::string> readSymbolicName(std::shared_ptr<Solver> solver,
                                             Context* ctx, const Pointer& ptr) {
-  const auto& alloc = ctx->heap()[ptr.alloc()];
+  const auto& alloc = ctx->heaps[ptr.heap()][ptr.alloc()];
 
   auto model = ctx->resolve(solver);
   if (model->result() != SolverResult::SAT) {
@@ -580,7 +580,7 @@ ExecutionResult Interpreter::visitSymbolicAlloca(llvm::CallInst& call) {
   auto size = ctx->lookup(call.getArgOperand(0)).scalar().expr();
   auto name = ctx->lookup(call.getArgOperand(1)).scalar().pointer();
 
-  auto resolved = ctx->heap().resolve(solver, name, *ctx);
+  auto resolved = ctx->heaps.resolve(solver, name, *ctx);
 
   CAFFEINE_ASSERT(!resolved.empty(),
                   "caffeine_make_symbolic called with invalid name pointer");
@@ -594,7 +594,7 @@ ExecutionResult Interpreter::visitSymbolicAlloca(llvm::CallInst& call) {
   unsigned address_space = call.getType()->getPointerAddressSpace();
   unsigned ptr_width = size->type().bitwidth();
 
-  auto alloc = ctx->heap().allocate(
+  auto alloc = ctx->heaps[address_space].allocate(
       size, ConstantInt::Create(llvm::APInt(ptr_width, 1)),
       ConstantArray::Create(Symbol(std::move(*alloc_name)), size),
       AllocationKind::Alloca, AllocationPermissions::ReadWrite, *ctx);
@@ -603,7 +603,7 @@ ExecutionResult Interpreter::visitSymbolicAlloca(llvm::CallInst& call) {
   frame.insert(&call, LLVMValue(Pointer(
                           alloc, ConstantInt::Create(llvm::APInt(ptr_width, 0)),
                           address_space)));
-  frame.allocations.push_back(alloc);
+  frame.allocations.emplace_back(alloc, address_space);
 
   return ExecutionResult::Continue;
 }
@@ -636,7 +636,7 @@ ExecutionResult Interpreter::visitMalloc(llvm::CallInst& call) {
   }
 
   auto size_op = UnaryOp::CreateTruncOrZExt(Type::int_ty(ptr_width), size);
-  auto alloc = ctx->heap().allocate(
+  auto alloc = ctx->heaps[address_space].allocate(
       size_op,
       ConstantInt::Create(llvm::APInt(ptr_width, options.malloc_alignment)),
       AllocOp::Create(size_op, ConstantInt::Create(llvm::APInt(8, 0xDD))),
@@ -673,7 +673,7 @@ ExecutionResult Interpreter::visitCalloc(llvm::CallInst& call) {
   }
 
   auto size_op = UnaryOp::CreateTruncOrZExt(Type::int_ty(ptr_width), size);
-  auto alloc = ctx->heap().allocate(
+  auto alloc = ctx->heaps[address_space].allocate(
       size_op,
       ConstantInt::Create(llvm::APInt(ptr_width, options.malloc_alignment)),
       AllocOp::Create(size_op, ConstantInt::Create(llvm::APInt(8, 0x00))),
@@ -696,24 +696,23 @@ ExecutionResult Interpreter::visitFree(llvm::CallInst& call) {
   CAFFEINE_ASSERT(call.getArgOperand(0)->getType()->isPointerTy(),
                   "Invalid free signature");
 
-  auto& heap = ctx->heap();
   auto memptr = ctx->lookup(call.getArgOperand(0)).scalar().pointer();
 
-  auto is_valid_ptr = heap.check_starts_allocation(memptr);
+  auto is_valid_ptr = ctx->heaps.check_starts_allocation(memptr);
   if (ctx->check(solver, !is_valid_ptr) == SolverResult::SAT) {
     logFailure(*ctx, !is_valid_ptr, "free called with an invalid pointer");
 
     return ExecutionResult::Dead;
   }
 
-  auto resolved = heap.resolve(solver, memptr, *ctx);
+  auto resolved = ctx->heaps.resolve(solver, memptr, *ctx);
 
   auto err_start =
       std::remove_if(resolved.begin(), resolved.end(), [&](const Pointer& ptr) {
-        const Allocation& alloc = ctx->heap()[ptr.alloc()];
+        const Allocation& alloc = ctx->heaps[ptr.heap()][ptr.alloc()];
 
         auto assertion = Assertion(ICmpOp::CreateICmp(
-            ICmpOpcode::EQ, ptr.value(ctx->heap()), alloc.address()));
+            ICmpOpcode::EQ, ptr.value(ctx->heaps), alloc.address()));
         if (ctx->check(solver, !assertion) == SolverResult::SAT) {
           logFailure(*ctx, Assertion::constant(true),
                      "free called with a pointer not allocated by malloc");
@@ -728,10 +727,10 @@ ExecutionResult Interpreter::visitFree(llvm::CallInst& call) {
   auto forks = ctx->fork(resolved.size());
 
   for (auto [fork, ptr] : llvm::zip(forks, resolved)) {
-    Allocation& alloc = fork.heap()[ptr.alloc()];
-    fork.add(ICmpOp::CreateICmp(ICmpOpcode::EQ, ptr.value(fork.heap()),
+    Allocation& alloc = fork.heaps[ptr.heap()][ptr.alloc()];
+    fork.add(ICmpOp::CreateICmp(ICmpOpcode::EQ, ptr.value(fork.heaps),
                                 alloc.address()));
-    fork.heap().deallocate(ptr.alloc());
+    fork.heaps[ptr.heap()].deallocate(ptr.alloc());
   }
 
   return forks;
@@ -745,7 +744,7 @@ ExecutionResult Interpreter::visitBuiltinResolve(llvm::CallInst& call) {
       Type::int_ty(layout.getPointerSizeInBits()),
       ctx->lookup(call.getArgOperand(1)).scalar().expr());
 
-  auto assertion = ctx->heap().check_valid(mem, size);
+  auto assertion = ctx->heaps.check_valid(mem, size);
   if (ctx->check(solver, !assertion) == SolverResult::SAT) {
     logFailure(*ctx, !assertion, "invalid pointer");
 
@@ -756,7 +755,7 @@ ExecutionResult Interpreter::visitBuiltinResolve(llvm::CallInst& call) {
     return ExecutionResult::Dead;
   }
 
-  auto resolved = ctx->heap().resolve(solver, mem, *ctx);
+  auto resolved = ctx->heaps.resolve(solver, mem, *ctx);
 
   if (resolved.size() == 1) {
     ctx->stack_top().insert(&call, LLVMValue(resolved[0]));

--- a/src/Interpreter/Interpreter.cpp
+++ b/src/Interpreter/Interpreter.cpp
@@ -371,7 +371,7 @@ ExecutionResult Interpreter::visitLoadInst(llvm::LoadInst& inst) {
   const Pointer& pointer = operand.scalar().pointer();
 
   auto assertion =
-      ctx->heap.check_valid(pointer, layout.getTypeStoreSize(inst.getType()));
+      ctx->heap().check_valid(pointer, layout.getTypeStoreSize(inst.getType()));
   if (ctx->check(solver, !assertion) == SolverResult::SAT) {
     logFailure(*ctx, !assertion, "invalid pointer load");
 
@@ -382,11 +382,11 @@ ExecutionResult Interpreter::visitLoadInst(llvm::LoadInst& inst) {
     return ExecutionResult::Dead;
   }
 
-  auto resolved = ctx->heap.resolve(solver, pointer, *ctx);
+  auto resolved = ctx->heap().resolve(solver, pointer, *ctx);
   auto forks = ctx->fork(resolved.size());
 
   for (auto [fork, ptr] : llvm::zip(forks, resolved)) {
-    Allocation& alloc = fork.heap[ptr.alloc()];
+    Allocation& alloc = fork.heap()[ptr.alloc()];
     fork.add(alloc.check_inbounds(ptr.offset(),
                                   layout.getTypeStoreSize(inst.getType())));
 
@@ -408,7 +408,7 @@ ExecutionResult Interpreter::visitStoreInst(llvm::StoreInst& inst) {
   const llvm::DataLayout& layout = inst.getModule()->getDataLayout();
   const Pointer& pointer = dest.scalar().pointer();
 
-  auto assertion = ctx->heap.check_valid(
+  auto assertion = ctx->heap().check_valid(
       pointer, layout.getTypeStoreSize(inst.getOperand(0)->getType()));
   if (ctx->check(solver, !assertion) == SolverResult::SAT) {
     logFailure(*ctx, !assertion, "invalid pointer store");
@@ -420,14 +420,14 @@ ExecutionResult Interpreter::visitStoreInst(llvm::StoreInst& inst) {
     return ExecutionResult::Dead;
   }
 
-  auto resolved = ctx->heap.resolve(solver, pointer, *ctx);
+  auto resolved = ctx->heap().resolve(solver, pointer, *ctx);
   auto forks = ctx->fork(resolved.size());
 
   for (auto [fork, ptr] : llvm::zip(forks, resolved)) {
-    Allocation& alloc = fork.heap[ptr.alloc()];
+    Allocation& alloc = fork.heap()[ptr.alloc()];
     fork.add(
         alloc.check_inbounds(ptr.offset(), layout.getTypeStoreSize(op_ty)));
-    alloc.write(ptr.offset(), op_ty, value, fork.heap, layout);
+    alloc.write(ptr.offset(), op_ty, value, fork.heap(), layout);
 
     if (!pointer.is_resolved()) {
       fork.backprop(pointer, ptr);
@@ -448,7 +448,7 @@ ExecutionResult Interpreter::visitAllocaInst(llvm::AllocaInst& inst) {
   unsigned ptr_width = layout.getPointerSizeInBits(address_space);
 
   auto size_op = ConstantInt::Create(llvm::APInt(ptr_width, size));
-  auto alloc = ctx->heap.allocate(
+  auto alloc = ctx->heap().allocate(
       size_op, ConstantInt::Create(llvm::APInt(ptr_width, align)),
       AllocOp::Create(size_op, ConstantInt::Create(llvm::APInt(8, 0xDD))),
       AllocationKind::Alloca, AllocationPermissions::ReadWrite, *ctx);
@@ -550,7 +550,7 @@ ExecutionResult Interpreter::visitAssert(llvm::CallInst& call) {
 
 std::optional<std::string> readSymbolicName(std::shared_ptr<Solver> solver,
                                             Context* ctx, const Pointer& ptr) {
-  const auto& alloc = ctx->heap[ptr.alloc()];
+  const auto& alloc = ctx->heap()[ptr.alloc()];
 
   auto model = ctx->resolve(solver);
   if (model->result() != SolverResult::SAT) {
@@ -580,7 +580,7 @@ ExecutionResult Interpreter::visitSymbolicAlloca(llvm::CallInst& call) {
   auto size = ctx->lookup(call.getArgOperand(0)).scalar().expr();
   auto name = ctx->lookup(call.getArgOperand(1)).scalar().pointer();
 
-  auto resolved = ctx->heap.resolve(solver, name, *ctx);
+  auto resolved = ctx->heap().resolve(solver, name, *ctx);
 
   CAFFEINE_ASSERT(!resolved.empty(),
                   "caffeine_make_symbolic called with invalid name pointer");
@@ -594,7 +594,7 @@ ExecutionResult Interpreter::visitSymbolicAlloca(llvm::CallInst& call) {
   unsigned address_space = call.getType()->getPointerAddressSpace();
   unsigned ptr_width = size->type().bitwidth();
 
-  auto alloc = ctx->heap.allocate(
+  auto alloc = ctx->heap().allocate(
       size, ConstantInt::Create(llvm::APInt(ptr_width, 1)),
       ConstantArray::Create(Symbol(std::move(*alloc_name)), size),
       AllocationKind::Alloca, AllocationPermissions::ReadWrite, *ctx);
@@ -636,7 +636,7 @@ ExecutionResult Interpreter::visitMalloc(llvm::CallInst& call) {
   }
 
   auto size_op = UnaryOp::CreateTruncOrZExt(Type::int_ty(ptr_width), size);
-  auto alloc = ctx->heap.allocate(
+  auto alloc = ctx->heap().allocate(
       size_op,
       ConstantInt::Create(llvm::APInt(ptr_width, options.malloc_alignment)),
       AllocOp::Create(size_op, ConstantInt::Create(llvm::APInt(8, 0xDD))),
@@ -673,7 +673,7 @@ ExecutionResult Interpreter::visitCalloc(llvm::CallInst& call) {
   }
 
   auto size_op = UnaryOp::CreateTruncOrZExt(Type::int_ty(ptr_width), size);
-  auto alloc = ctx->heap.allocate(
+  auto alloc = ctx->heap().allocate(
       size_op,
       ConstantInt::Create(llvm::APInt(ptr_width, options.malloc_alignment)),
       AllocOp::Create(size_op, ConstantInt::Create(llvm::APInt(8, 0x00))),
@@ -696,7 +696,7 @@ ExecutionResult Interpreter::visitFree(llvm::CallInst& call) {
   CAFFEINE_ASSERT(call.getArgOperand(0)->getType()->isPointerTy(),
                   "Invalid free signature");
 
-  auto& heap = ctx->heap;
+  auto& heap = ctx->heap();
   auto memptr = ctx->lookup(call.getArgOperand(0)).scalar().pointer();
 
   auto is_valid_ptr = heap.check_starts_allocation(memptr);
@@ -710,10 +710,10 @@ ExecutionResult Interpreter::visitFree(llvm::CallInst& call) {
 
   auto err_start =
       std::remove_if(resolved.begin(), resolved.end(), [&](const Pointer& ptr) {
-        const Allocation& alloc = ctx->heap[ptr.alloc()];
+        const Allocation& alloc = ctx->heap()[ptr.alloc()];
 
         auto assertion = Assertion(ICmpOp::CreateICmp(
-            ICmpOpcode::EQ, ptr.value(ctx->heap), alloc.address()));
+            ICmpOpcode::EQ, ptr.value(ctx->heap()), alloc.address()));
         if (ctx->check(solver, !assertion) == SolverResult::SAT) {
           logFailure(*ctx, Assertion::constant(true),
                      "free called with a pointer not allocated by malloc");
@@ -728,10 +728,10 @@ ExecutionResult Interpreter::visitFree(llvm::CallInst& call) {
   auto forks = ctx->fork(resolved.size());
 
   for (auto [fork, ptr] : llvm::zip(forks, resolved)) {
-    Allocation& alloc = fork.heap[ptr.alloc()];
-    fork.add(ICmpOp::CreateICmp(ICmpOpcode::EQ, ptr.value(fork.heap),
+    Allocation& alloc = fork.heap()[ptr.alloc()];
+    fork.add(ICmpOp::CreateICmp(ICmpOpcode::EQ, ptr.value(fork.heap()),
                                 alloc.address()));
-    fork.heap.deallocate(ptr.alloc());
+    fork.heap().deallocate(ptr.alloc());
   }
 
   return forks;
@@ -745,7 +745,7 @@ ExecutionResult Interpreter::visitBuiltinResolve(llvm::CallInst& call) {
       Type::int_ty(layout.getPointerSizeInBits()),
       ctx->lookup(call.getArgOperand(1)).scalar().expr());
 
-  auto assertion = ctx->heap.check_valid(mem, size);
+  auto assertion = ctx->heap().check_valid(mem, size);
   if (ctx->check(solver, !assertion) == SolverResult::SAT) {
     logFailure(*ctx, !assertion, "invalid pointer");
 
@@ -756,7 +756,7 @@ ExecutionResult Interpreter::visitBuiltinResolve(llvm::CallInst& call) {
     return ExecutionResult::Dead;
   }
 
-  auto resolved = ctx->heap.resolve(solver, mem, *ctx);
+  auto resolved = ctx->heap().resolve(solver, mem, *ctx);
 
   if (resolved.size() == 1) {
     ctx->stack_top().insert(&call, LLVMValue(resolved[0]));

--- a/src/Memory/MemHeap.cpp
+++ b/src/Memory/MemHeap.cpp
@@ -309,6 +309,10 @@ bool Pointer::operator!=(const Pointer& p) const {
 
 MemHeap::MemHeap(unsigned index) : index_(index) {}
 
+unsigned MemHeap::index() const {
+  return index_;
+}
+
 Allocation& MemHeap::operator[](const AllocId& alloc) {
   return allocs_.at(alloc);
 }

--- a/src/Solver/Solver.cpp
+++ b/src/Solver/Solver.cpp
@@ -4,7 +4,6 @@
 #include "caffeine/IR/Visitor.h"
 #include "caffeine/Interpreter/Context.h"
 
-#include <magic_enum.hpp>
 #include <fmt/format.h>
 #include <magic_enum.hpp>
 

--- a/src/Solver/Solver.cpp
+++ b/src/Solver/Solver.cpp
@@ -132,7 +132,7 @@ Value Model::evaluate(const LLVMScalar& scalar, Context& ctx) const {
   ExprEvaluator evaluator{this};
 
   if (scalar.is_pointer())
-    return evaluator.visit(*scalar.pointer().value(ctx.heap));
+    return evaluator.visit(*scalar.pointer().value(ctx.heap()));
   return evaluator.visit(*scalar.expr());
 }
 

--- a/src/Solver/Solver.cpp
+++ b/src/Solver/Solver.cpp
@@ -4,6 +4,7 @@
 #include "caffeine/IR/Visitor.h"
 #include "caffeine/Interpreter/Context.h"
 
+#include <magic_enum.hpp>
 #include <fmt/format.h>
 #include <magic_enum.hpp>
 

--- a/src/Solver/Solver.cpp
+++ b/src/Solver/Solver.cpp
@@ -132,7 +132,7 @@ Value Model::evaluate(const LLVMScalar& scalar, Context& ctx) const {
   ExprEvaluator evaluator{this};
 
   if (scalar.is_pointer())
-    return evaluator.visit(*scalar.pointer().value(ctx.heap()));
+    return evaluator.visit(*scalar.pointer().value(ctx.heaps));
   return evaluator.visit(*scalar.expr());
 }
 

--- a/src/Solver/Z3Solver.cpp
+++ b/src/Solver/Z3Solver.cpp
@@ -221,7 +221,7 @@ SolverResult Z3Solver::check(AssertionList& assertions,
 
   if (list.unproven().empty())
     return SolverResult::SAT;
-  return resolve(assertions, extra)->result();
+  return resolve(list, Assertion())->result();
 }
 
 std::unique_ptr<Model> Z3Solver::resolve(AssertionList& assertions,


### PR DESCRIPTION
This PR adds support for multiple distinct heaps being used at the same time. This is intended to support the following features:
- LLVM address spaces, where pointers to different heaps don't interact
- A separate function heap, as used in #367 

It does this by introducing a new type, `MemHeapMgr`, which is responsible for mapping heap IDs to the actual heaps. To make things easier it also provides helpers for some methods on `MemHeap` which forward to the correct heap based on the stored heap ID within the pointer. I've then gone through and updated all the locations which interacted with the heap to now work with the correctly-indexed heap (mainly by selecting by either the heap of the existing pointer or via the address space of the LLVM pointer it represents).

/stack #356 