### PR TITLE
Simplify signal handling and print symbolic call stack on signal

### DIFF
--- a/include/caffeine/Support/Signal.h
+++ b/include/caffeine/Support/Signal.h
@@ -1,0 +1,12 @@
+#pragma once
+
+namespace caffeine {
+
+// Register a global signal handler that augments the existing one registered by
+// LLVM to also print out the symbolic call stack.
+//
+// On linux systems this will also ensure that the signal handler aborts
+// appropriately (the LLVM one will not exit in cases such as SIGQUIT.)
+void RegisterSignalHandlers();
+
+} // namespace caffeine

--- a/include/caffeine/Support/UnsupportedOperation.h
+++ b/include/caffeine/Support/UnsupportedOperation.h
@@ -30,6 +30,10 @@ public:
   class ContextGuard;
   friend class ContextGuard;
 
+  static const Context* CurrentContextUnsafe() noexcept {
+    return CurrentContext;
+  }
+
   [[noreturn]] static void Abort(const char* condition, const char* function,
                                  unsigned int line, const char* file,
                                  std::string_view message);

--- a/src/Interpreter/Executor.cpp
+++ b/src/Interpreter/Executor.cpp
@@ -40,6 +40,11 @@ Executor::Executor(ExecutionPolicy* policy, ExecutionContextStore* store,
     : policy(policy), store(store), logger(logger), options(options) {}
 
 void Executor::run() {
+  if (options.num_threads == 1) {
+    run_worker(this, logger, store);
+    return;
+  }
+
   std::vector<std::thread> threads;
 
   for (uint32_t i = 0; i < options.num_threads; i++) {

--- a/src/Solver/Z3Solver.cpp
+++ b/src/Solver/Z3Solver.cpp
@@ -205,6 +205,8 @@ Z3Solver::Z3Solver() : ctx(std::make_unique<z3::context>()) {
   ctx->set("model", true);
   // Automatically select and configure the solver
   ctx->set("auto_config", true);
+  // Z3 will set a SIGINT handler unless we tell it not to
+  ctx->set("ctrl_c", false);
 }
 
 Z3Solver::~Z3Solver() {}

--- a/src/Support/Signal.cpp
+++ b/src/Support/Signal.cpp
@@ -1,0 +1,86 @@
+#include "caffeine/Support/Signal.h"
+#include "caffeine/Interpreter/Context.h"
+#include "caffeine/Support/UnsupportedOperation.h"
+#include <initializer_list>
+#include <llvm/Support/Signals.h>
+#include <llvm/Support/raw_os_ostream.h>
+#include <sstream>
+
+#ifdef __unix__
+#include <signal.h>
+#endif
+
+namespace caffeine {
+namespace {
+#ifdef __unix__
+  // clang-format off
+  static constexpr const int signals[] = {
+    SIGHUP, SIGINT, SIGTERM, SIGUSR2,
+    SIGILL, SIGTRAP, SIGABRT, SIGFPE, SIGBUS, SIGSEGV, SIGQUIT
+#ifdef SIGSYS
+    , SIGSYS
+#endif
+#ifdef SIGXCPU
+    , SIGXCPU
+#endif
+#ifdef SIGXFSZ
+    , SIGXFSZ
+#endif
+#ifdef SIGEMT
+    , SIGEMT
+#endif
+  };
+  // clang-format on
+
+  static constexpr int max_signal =
+      *std::max_element(std::begin(signals), std::end(signals));
+  struct sigaction sigactions[max_signal + 1] = {};
+
+  void signal_handler(int sig) {
+    alarm(30);
+
+    if (sigactions[sig].sa_handler)
+      sigactions[sig].sa_handler(sig);
+
+    if (sigactions[sig].sa_flags & SA_RESETHAND)
+      raise(sig);
+  }
+#endif
+
+  void dump_symbolic_backtrace(void*) {
+    try {
+      if (const auto* context =
+              caffeine::UnsupportedOperation::CurrentContextUnsafe()) {
+        std::stringstream output;
+        output << "\nSymbolic Backtrace\n";
+        context->print_backtrace(output);
+        llvm::errs() << output.rdbuf();
+      }
+    } catch (...) {
+      llvm::errs() << "ERROR: Exception was thrown while attempting to print "
+                      "backtraces\n";
+    }
+    llvm::errs().flush();
+  }
+
+} // namespace
+
+void RegisterSignalHandlers() {
+  llvm::sys::AddSignalHandler(&dump_symbolic_backtrace, nullptr);
+
+#if __unix__
+  // Wrap all existing signal handlers with one that reraises the signal with
+  // the default handler at the end if it is a fatal signal.
+  std::memset(sigactions, 0, sizeof(sigactions));
+  for (int sig : signals) {
+    sigaction(sig, nullptr, &sigactions[sig]);
+
+    struct sigaction new_handler;
+    new_handler.sa_handler = signal_handler;
+    new_handler.sa_flags = sigactions[sig].sa_flags;
+    sigaction(sig, &new_handler, nullptr);
+  }
+#endif
+}
+
+} // namespace caffeine

--- a/test/unit/main.cpp
+++ b/test/unit/main.cpp
@@ -1,53 +1,35 @@
 
 #include <gtest/gtest.h>
 
+#include "caffeine/Interpreter/Context.h"
+#include "caffeine/Support/UnsupportedOperation.h"
 #include <boost/core/demangle.hpp>
 #include <llvm/Support/InitLLVM.h>
+#include <llvm/Support/Signals.h>
+#include <llvm/Support/raw_os_ostream.h>
 #include <z3++.h>
 
-std::terminate_handler llvm_handler = nullptr;
-
-// z3::exception doesn't inherit from std::exception so we need to special case
-// it so we can print the contained message.
-static void custom_terminate_handler() {
+static void signal_handler(void*) {
   try {
-    // special-case handling to print the contained message
-    try {
-      auto current = std::current_exception();
-
-      if (!current) {
-        llvm_handler();
-        std::abort();
-      }
-
-      std::rethrow_exception(current);
-    } catch (std::exception& e) {
-      const auto& ty = typeid(e);
-      std::cerr << "std::terminate called after throwing an instance of '"
-                << boost::core::demangle(ty.name()) << "' and message\n  "
-                << e.what() << std::endl;
-      throw;
-    } catch (z3::exception& e) {
-      // Why oh why does z3::exception not inherit from std::exception??? :(
-      const auto& ty = typeid(e);
-      std::cerr << "std::terminate called after throwing an instance of '"
-                << boost::core::demangle(ty.name()) << "' and message\n  "
-                << e.msg() << std::endl;
-      throw;
+    if (const auto* context =
+            caffeine::UnsupportedOperation::CurrentContextUnsafe()) {
+      std::stringstream output;
+      output << "\nSymbolic Backtrace\n";
+      context->print_backtrace(output);
+      llvm::errs() << output.rdbuf();
     }
   } catch (...) {
-    // Use default llvm handling logic for the rest
-    if (llvm_handler)
-      llvm_handler();
+    llvm::errs()
+        << "ERROR: Exception was thrown while attempting to print backtraces\n";
   }
-  std::abort();
+  llvm::errs().flush();
 }
 
 int main(int argc, char** argv) {
   ::testing::InitGoogleTest(&argc, argv);
   llvm::InitLLVM X(argc, argv);
 
-  llvm_handler = std::set_terminate(custom_terminate_handler);
+  llvm::sys::AddSignalHandler(signal_handler, nullptr);
 
   return RUN_ALL_TESTS();
 }

--- a/test/unit/main.cpp
+++ b/test/unit/main.cpp
@@ -1,35 +1,14 @@
 
 #include <gtest/gtest.h>
 
-#include "caffeine/Interpreter/Context.h"
-#include "caffeine/Support/UnsupportedOperation.h"
-#include <boost/core/demangle.hpp>
+#include "caffeine/Support/Signal.h"
 #include <llvm/Support/InitLLVM.h>
-#include <llvm/Support/Signals.h>
-#include <llvm/Support/raw_os_ostream.h>
-#include <z3++.h>
-
-static void signal_handler(void*) {
-  try {
-    if (const auto* context =
-            caffeine::UnsupportedOperation::CurrentContextUnsafe()) {
-      std::stringstream output;
-      output << "\nSymbolic Backtrace\n";
-      context->print_backtrace(output);
-      llvm::errs() << output.rdbuf();
-    }
-  } catch (...) {
-    llvm::errs()
-        << "ERROR: Exception was thrown while attempting to print backtraces\n";
-  }
-  llvm::errs().flush();
-}
 
 int main(int argc, char** argv) {
   ::testing::InitGoogleTest(&argc, argv);
   llvm::InitLLVM X(argc, argv);
 
-  llvm::sys::AddSignalHandler(signal_handler, nullptr);
+  caffeine::RegisterSignalHandlers();
 
   return RUN_ALL_TESTS();
 }


### PR DESCRIPTION
This PR simplifies the printing of error messages to better take advantage of what LLVM offers. Here's what's included in this PR
1. Strip out terminate and signal handlers that duplicate functionality from LLVM
2. Print out a symbolic backtrace if we're currently within a context
3. Attempt to prevent Z3 from registering it's own signal handler

This PR still hasn't quite solved how to get `SIGINT` handling working correctly but I don't think that's a huge issue at the moment.