### PR TITLE
Simplify select operations where both conditions are identical

### DIFF
--- a/src/IR/Operation.h
+++ b/src/IR/Operation.h
@@ -355,6 +355,8 @@ public:
   OpRef visitSelectOp(const SelectOp& op) {
     if (const auto* vcond = llvm::dyn_cast<ConstantInt>(op.condition().get()))
       return vcond->value() == 1 ? op.true_value() : op.false_value();
+    if (op.true_value() == op.false_value())
+      return op.true_value();
 
     return this->visitOperation(op);
   }


### PR DESCRIPTION
If we have an operation like `(select cond x x)` then it will always return `x` and so we can simplify it to just `x`. This change does so.