### PR TITLE
Simplify evaluation of zeroinitializer globals

### DIFF
--- a/src/Interpreter/Interpreter.cpp
+++ b/src/Interpreter/Interpreter.cpp
@@ -5,6 +5,7 @@
 #include "caffeine/Interpreter/Store.h"
 #include "caffeine/Interpreter/Value.h"
 #include "caffeine/Support/Assert.h"
+#include "caffeine/Support/UnsupportedOperation.h"
 
 #include <boost/range/adaptor/transformed.hpp>
 #include <boost/range/combine.hpp>
@@ -646,8 +647,8 @@ ExecutionResult Interpreter::visitSymbolicAlloca(llvm::CallInst& call) {
                   "caffeine_make_symbolic called with symbolic name");
 
   auto alloc_name = readSymbolicName(solver, ctx, resolved.front());
-  if (!alloc_name.has_value())
-    return ExecutionResult::Stop;
+  CAFFEINE_UASSERT(alloc_name.has_value(),
+                   "Unable to read name argument of caffeine_make_symbolic");
 
   unsigned address_space = call.getType()->getPointerAddressSpace();
   unsigned ptr_width = size->type().bitwidth();

--- a/tools/opt-plugin/test-main/plugin.cpp
+++ b/tools/opt-plugin/test-main/plugin.cpp
@@ -66,7 +66,8 @@ namespace {
         name = fmt::format("arg{}", i);
       }
 
-      auto value = ConstantDataArray::getRaw(name, name.size(),
+      // Note: need to include the nul terminator
+      auto value = ConstantDataArray::getRaw(name, name.size() + 1,
                                              Type::getInt8Ty(m->getContext()));
       auto ident = new GlobalVariable(*m, value->getType(), true,
                                       GlobalVariable::InternalLinkage, value);


### PR DESCRIPTION
In this case we already know exactly what value the global will have so there's no need to go an evaluate each sub-expression since we know the final result will just be zeroed memory.

This also fixes an issue where allocations would be 8 times larger than they needed to be (due to using size in bits instead of size in bytes) as well as an issue where the pass to generate `main` for test cases was not nul-terminating strings.