### PR TITLE
Avoid causing segfaults when constant folding divide-by-0 expressions

### DIFF
--- a/include/caffeine/IR/Operation.h
+++ b/include/caffeine/IR/Operation.h
@@ -56,7 +56,9 @@ namespace detail {
 } // namespace detail
 
 class Operation;
-typedef ref<const Operation> OpRef;
+class Value;
+
+using OpRef = std::shared_ptr<const Operation>;
 
 enum class ICmpOpcode : uint8_t {
   // Note: The values here need to be kept in sync with the ones in
@@ -373,10 +375,13 @@ private:
 public:
   const llvm::APInt& value() const;
 
+  Value as_value() const;
+
   static OpRef Create(const llvm::APInt& iconst);
   static OpRef Create(llvm::APInt&& iconst);
   // Specialization for creating boolean constants
   static OpRef Create(bool value);
+  static OpRef Create(const Value& value);
 
   static OpRef CreateZero(unsigned bitwidth);
 

--- a/include/caffeine/IR/Value.h
+++ b/include/caffeine/IR/Value.h
@@ -108,6 +108,9 @@ public:
   static Value bvadd(const Value& lhs, const Value& rhs);
   static Value bvsub(const Value& lhs, const Value& rhs);
   static Value bvmul(const Value& lhs, const Value& rhs);
+
+  // Note: These return bogus values in cases where they would fault (e.g. div
+  //       by 0) so that constant evaluation on dead paths doesn't cause crashes
   static Value bvudiv(const Value& lhs, const Value& rhs);
   static Value bvsdiv(const Value& lhs, const Value& rhs);
   static Value bvurem(const Value& lhs, const Value& rhs);

--- a/src/IR/Operation.cpp
+++ b/src/IR/Operation.cpp
@@ -1,6 +1,7 @@
 #include "caffeine/IR/Operation.h"
 #include "Operation.h"
 #include "caffeine/IR/Type.h"
+#include "caffeine/IR/Value.h"
 
 #include <boost/algorithm/string.hpp>
 #include <boost/container_hash/hash.hpp>
@@ -335,6 +336,10 @@ ConstantInt::ConstantInt(llvm::APInt&& iconst)
     : Operation(Opcode::ConstantInt, Type::type_of(iconst), std::move(iconst)) {
 }
 
+Value ConstantInt::as_value() const {
+  return Value(value());
+}
+
 OpRef ConstantInt::Create(const llvm::APInt& iconst) {
   return OpRef(new ConstantInt(iconst));
 }
@@ -343,6 +348,9 @@ OpRef ConstantInt::Create(llvm::APInt&& iconst) {
 }
 OpRef ConstantInt::Create(bool value) {
   return ConstantInt::Create(llvm::APInt(1, static_cast<uint64_t>(value)));
+}
+OpRef ConstantInt::Create(const Value& value) {
+  return Create(value.apint());
 }
 
 OpRef ConstantInt::CreateZero(unsigned bitwidth) {

--- a/src/IR/Operation.h
+++ b/src/IR/Operation.h
@@ -2,6 +2,7 @@
 
 #include "caffeine/IR/Matching.h"
 #include "caffeine/IR/Operation.h"
+#include "caffeine/IR/Value.h"
 #include "caffeine/IR/Visitor.h"
 #include <llvm/Support/MathExtras.h>
 #include <memory>

--- a/src/IR/Operation.h
+++ b/src/IR/Operation.h
@@ -186,7 +186,11 @@ public:
     if (is_constant_int(op.lhs(), 0) || is_constant_int(*op.rhs(), 1))
       return op.lhs();
 
-    TRY_CONST_INT(ConstantInt::Create(lhs.value().udiv(rhs.value())));
+    if (auto args = as_const_int(op.lhs(), op.rhs())) {
+      auto [lhs, rhs] = args.value();
+      return ConstantInt::Create(
+          Value::bvudiv(lhs->as_value(), rhs->as_value()));
+    }
 
     return this->visitBinaryOp(op);
   }
@@ -196,7 +200,11 @@ public:
     if (is_constant_int(op.rhs(), 1) && op.type().bitwidth() > 1)
       return op.lhs();
 
-    TRY_CONST_INT(ConstantInt::Create(lhs.value().sdiv(rhs.value())));
+    if (auto args = as_const_int(op.lhs(), op.rhs())) {
+      auto [lhs, rhs] = args.value();
+      return ConstantInt::Create(
+          Value::bvsdiv(lhs->as_value(), rhs->as_value()));
+    }
 
     return this->visitBinaryOp(op);
   }
@@ -206,7 +214,11 @@ public:
     if (is_constant_int(op.rhs(), 1))
       return ConstantInt::Create(llvm::APInt(op.type().bitwidth(), 0));
 
-    TRY_CONST_INT(ConstantInt::Create(lhs.value().urem(rhs.value())));
+    if (auto args = as_const_int(op.lhs(), op.rhs())) {
+      auto [lhs, rhs] = args.value();
+      return ConstantInt::Create(
+          Value::bvurem(lhs->as_value(), rhs->as_value()));
+    }
 
     return this->visitBinaryOp(op);
   }
@@ -216,7 +228,11 @@ public:
     if (is_constant_int(op.rhs(), 1) && op.type().bitwidth() > 1)
       return ConstantInt::Create(llvm::APInt(op.type().bitwidth(), 0));
 
-    TRY_CONST_INT(ConstantInt::Create(lhs.value().srem(rhs.value())));
+    if (auto args = as_const_int(op.lhs(), op.rhs())) {
+      auto [lhs, rhs] = args.value();
+      return ConstantInt::Create(
+          Value::bvsrem(lhs->as_value(), rhs->as_value()));
+    }
 
     return this->visitBinaryOp(op);
   }
@@ -444,6 +460,22 @@ public:
   }
 
 private:
+  template <typename... Ts>
+  std::optional<std::array<const ConstantInt*, sizeof...(Ts)>>
+  as_const_int(const Ts&... args) {
+    static_assert((... && std::is_same_v<Ts, OpRef>));
+
+    std::array<const ConstantInt*, sizeof...(Ts)> result = {
+        llvm::dyn_cast<ConstantInt>(args.get())...};
+
+    for (const ConstantInt* arg : result) {
+      if (!arg)
+        return std::nullopt;
+    }
+
+    return result;
+  }
+
   template <typename F>
   OpRef try_const_int(const OpRef& lhs, const OpRef& rhs, F&& func) {
     const auto* lhs_int = llvm::dyn_cast<ConstantInt>(lhs.get());

--- a/src/IR/Value.cpp
+++ b/src/IR/Value.cpp
@@ -129,15 +129,25 @@ Value Value::bvmul(const Value& lhs, const Value& rhs) {
   return lhs.apint() * rhs.apint();
 }
 Value Value::bvudiv(const Value& lhs, const Value& rhs) {
+  if (rhs.apint().isNullValue())
+    return llvm::APInt::getMaxValue(lhs.type().bitwidth());
   return lhs.apint().udiv(rhs.apint());
 }
 Value Value::bvsdiv(const Value& lhs, const Value& rhs) {
+  if (rhs.apint().isNullValue())
+    return llvm::APInt::getSignedMaxValue(lhs.type().bitwidth());
+  if (lhs.apint().isMinSignedValue() && rhs.apint().isAllOnesValue())
+    return llvm::APInt::getSignedMaxValue(lhs.type().bitwidth());
   return lhs.apint().sdiv(rhs.apint());
 }
 Value Value::bvurem(const Value& lhs, const Value& rhs) {
+  if (rhs.apint().isNullValue())
+    return lhs;
   return lhs.apint().urem(rhs.apint());
 }
 Value Value::bvsrem(const Value& lhs, const Value& rhs) {
+  if (rhs.apint().isNullValue())
+    return lhs;
   return lhs.apint().srem(rhs.apint());
 }
 

--- a/test/unit/IR/Operation.cpp
+++ b/test/unit/IR/Operation.cpp
@@ -14,3 +14,9 @@ TEST(OperationTests, vtable_is_copied) {
   ASSERT_EQ(fixed_array->num_operands(), 1);
   ASSERT_EQ(copy->num_operands(), fixed_array->num_operands());
 }
+
+TEST(OperationTests, const_div_by_0_does_not_fault) {
+  auto value = BinaryOp::CreateUDiv(1, ConstantInt::CreateZero(64));
+
+  ASSERT_TRUE(llvm::isa<ConstantInt>(*value));
+}

--- a/test/unit/IR/Value.cpp
+++ b/test/unit/IR/Value.cpp
@@ -33,3 +33,17 @@ TEST(ir_value, bitcast_roundtrip) {
 
   ASSERT_EQ(a, b);
 }
+
+TEST(ir_value, div_by_0_does_not_fault) {
+  Value a{llvm::APInt(64, 1)};
+  Value b{llvm::APInt(64, 0)};
+
+  Value::bvudiv(a, b);
+}
+
+TEST(ir_value, sdiv_invalid_does_not_fault) {
+  Value a{llvm::APInt::getSignedMinValue(32)};
+  Value b{llvm::APInt::getAllOnesValue(32)};
+
+  Value::bvsdiv(a, b);
+}


### PR DESCRIPTION
This can happen with a concrete allocator when the alignment of the allocation is 0. To avoid having this issue I've changed the `Value` operations to have valid, if somewhat arbitrary, values when calculating the remainder and then changed the const folding code to use them when applicable.

I've also added some test cases that cover this issue.