### PR TITLE
Implement helpers for creating ICmpOp instances with a specific comparison

### DIFF
--- a/include/caffeine/IR/Operation.h
+++ b/include/caffeine/IR/Operation.h
@@ -587,6 +587,30 @@ public:
   static OpRef CreateICmp(ICmpOpcode cmp, int64_t lhs, const OpRef& rhs);
   static OpRef CreateICmp(ICmpOpcode cmp, const OpRef& lhs, int64_t rhs);
 
+#define CAFFEINE_DECL_ICMP_CREATE_VARIANT(opcode)                              \
+  static OpRef CreateICmp##opcode(const OpRef& lhs, const OpRef& rhs) {        \
+    return CreateICmp(ICmpOpcode::opcode, lhs, rhs);                           \
+  }                                                                            \
+  static OpRef CreateICmp##opcode(int64_t lhs, const OpRef& rhs) {             \
+    return CreateICmp(ICmpOpcode::opcode, lhs, rhs);                           \
+  }                                                                            \
+  static OpRef CreateICmp##opcode(const OpRef& lhs, int64_t rhs) {             \
+    return CreateICmp(ICmpOpcode::opcode, lhs, rhs);                           \
+  }                                                                            \
+  static_assert(true)
+
+  CAFFEINE_DECL_ICMP_CREATE_VARIANT(EQ);
+  CAFFEINE_DECL_ICMP_CREATE_VARIANT(NE);
+  CAFFEINE_DECL_ICMP_CREATE_VARIANT(UGT);
+  CAFFEINE_DECL_ICMP_CREATE_VARIANT(UGE);
+  CAFFEINE_DECL_ICMP_CREATE_VARIANT(ULT);
+  CAFFEINE_DECL_ICMP_CREATE_VARIANT(ULE);
+  CAFFEINE_DECL_ICMP_CREATE_VARIANT(SGT);
+  CAFFEINE_DECL_ICMP_CREATE_VARIANT(SGE);
+  CAFFEINE_DECL_ICMP_CREATE_VARIANT(SLT);
+  CAFFEINE_DECL_ICMP_CREATE_VARIANT(SLE);
+
+#undef CAFFEINE_DECL_ICMP_CREATE_VARIANT
   static bool classof(const Operation* op);
 };
 

--- a/src/Interpreter/ExprEval.cpp
+++ b/src/Interpreter/ExprEval.cpp
@@ -733,8 +733,8 @@ LLVMValue ExprEvaluator::visitInsertElement(llvm::InsertElementInst& inst) {
   LLVMValue::OpVector result;
   result.reserve(vec.size());
   for (size_t i = 0; i < vec.size(); ++i) {
-    result.emplace_back(SelectOp::Create(
-        ICmpOp::CreateICmp(ICmpOpcode::EQ, idx, i), elt, scalarize(vec[i])));
+    result.emplace_back(
+        SelectOp::Create(ICmpOp::CreateICmpEQ(idx, i), elt, scalarize(vec[i])));
   }
 
   return LLVMValue(std::move(result));
@@ -747,8 +747,8 @@ LLVMValue ExprEvaluator::visitExtractElement(llvm::ExtractElementInst& inst) {
 
   OpRef result = Undef::Create(Type::from_llvm(inst.getType()));
   for (size_t i = 0; i < vec.size(); ++i) {
-    result = SelectOp::Create(ICmpOp::CreateICmp(ICmpOpcode::EQ, idx, i),
-                              scalarize(vec[i]), result);
+    result = SelectOp::Create(ICmpOp::CreateICmpEQ(idx, i), scalarize(vec[i]),
+                              result);
   }
 
   return LLVMValue(result);

--- a/src/Interpreter/Interpreter.cpp
+++ b/src/Interpreter/Interpreter.cpp
@@ -139,7 +139,7 @@ ExecutionResult Interpreter::visitUDiv(llvm::BinaryOperator& op) {
 
   auto result = transform_exprs(
       [&](const auto& lhs, const auto& rhs) {
-        Assertion assertion = ICmpOp::CreateICmp(ICmpOpcode::NE, rhs, 0);
+        Assertion assertion = ICmpOp::CreateICmpNE(rhs, 0);
         if (ctx->check(solver, !assertion) == SolverResult::SAT)
           logFailure(*ctx, !assertion, "udiv by 0");
         ctx->add(assertion);
@@ -160,12 +160,11 @@ ExecutionResult Interpreter::visitSDiv(llvm::BinaryOperator& op) {
 
   auto result = transform_exprs(
       [&](const auto& lhs, const auto& rhs) {
-        auto cmp1 = ICmpOp::CreateICmp(ICmpOpcode::EQ, rhs, 0);
-        auto cmp2 = ICmpOp::CreateICmp(
-            ICmpOpcode::EQ, lhs,
-            ConstantInt::Create(
-                llvm::APInt::getSignedMinValue(lhs->type().bitwidth())));
-        auto cmp3 = ICmpOp::CreateICmp(ICmpOpcode::EQ, rhs, -1);
+        auto cmp1 = ICmpOp::CreateICmpEQ(rhs, 0);
+        auto cmp2 = ICmpOp::CreateICmpEQ(
+            lhs, ConstantInt::Create(
+                     llvm::APInt::getSignedMinValue(lhs->type().bitwidth())));
+        auto cmp3 = ICmpOp::CreateICmpEQ(rhs, -1);
 
         // lhs == 0 || (lhs == INT_MIN && rhs == -1)
         Assertion assertion =
@@ -190,12 +189,11 @@ ExecutionResult Interpreter::visitSRem(llvm::BinaryOperator& op) {
 
   auto result = transform_exprs(
       [&](const auto& lhs, const auto& rhs) {
-        auto cmp1 = ICmpOp::CreateICmp(ICmpOpcode::EQ, rhs, 0);
-        auto cmp2 = ICmpOp::CreateICmp(
-            ICmpOpcode::EQ, lhs,
-            ConstantInt::Create(
-                llvm::APInt::getSignedMinValue(lhs->type().bitwidth())));
-        auto cmp3 = ICmpOp::CreateICmp(ICmpOpcode::EQ, rhs, -1);
+        auto cmp1 = ICmpOp::CreateICmpEQ(rhs, 0);
+        auto cmp2 = ICmpOp::CreateICmpEQ(
+            lhs, ConstantInt::Create(
+                     llvm::APInt::getSignedMinValue(lhs->type().bitwidth())));
+        auto cmp3 = ICmpOp::CreateICmpEQ(rhs, -1);
 
         // lhs == 0 || (lhs == INT_MIN && rhs == -1)
         Assertion assertion =
@@ -220,7 +218,7 @@ ExecutionResult Interpreter::visitURem(llvm::BinaryOperator& op) {
 
   auto result = transform_exprs(
       [&](const auto& lhs, const auto& rhs) {
-        Assertion assertion = ICmpOp::CreateICmp(ICmpOpcode::NE, rhs, 0);
+        Assertion assertion = ICmpOp::CreateICmpNE(rhs, 0);
         if (ctx->check(solver, !assertion) == SolverResult::SAT)
           logFailure(*ctx, !assertion, "urem fault (div by 0)");
         ctx->add(assertion);
@@ -308,9 +306,8 @@ ExecutionResult Interpreter::visitSwitchInst(llvm::SwitchInst& inst) {
   Context def = ctx->fork_once();
 
   for (auto value : inst.cases()) {
-    auto assertion = Assertion(ICmpOp::CreateICmp(
-        ICmpOpcode::EQ, cond,
-        ConstantInt::Create(value.getCaseValue()->getValue())));
+    auto assertion = Assertion(ICmpOp::CreateICmpEQ(
+        cond, ConstantInt::Create(value.getCaseValue()->getValue())));
     def.add(!assertion);
 
     if (ctx->check(solver, assertion) == SolverResult::UNSAT)
@@ -769,8 +766,8 @@ ExecutionResult Interpreter::visitFree(llvm::CallInst& call) {
       std::remove_if(resolved.begin(), resolved.end(), [&](const Pointer& ptr) {
         const Allocation& alloc = ctx->heaps[ptr.heap()][ptr.alloc()];
 
-        auto assertion = Assertion(ICmpOp::CreateICmp(
-            ICmpOpcode::EQ, ptr.value(ctx->heaps), alloc.address()));
+        auto assertion = Assertion(
+            ICmpOp::CreateICmpEQ(ptr.value(ctx->heaps), alloc.address()));
         if (ctx->check(solver, !assertion) == SolverResult::SAT) {
           logFailure(*ctx, Assertion::constant(true),
                      "free called with a pointer not allocated by malloc");
@@ -786,8 +783,7 @@ ExecutionResult Interpreter::visitFree(llvm::CallInst& call) {
 
   for (auto [fork, ptr] : llvm::zip(forks, resolved)) {
     Allocation& alloc = fork.heaps[ptr.heap()][ptr.alloc()];
-    fork.add(ICmpOp::CreateICmp(ICmpOpcode::EQ, ptr.value(fork.heaps),
-                                alloc.address()));
+    fork.add(ICmpOp::CreateICmpEQ(ptr.value(fork.heaps), alloc.address()));
     fork.heaps[ptr.heap()].deallocate(ptr.alloc());
   }
 

--- a/test/unit/Memory/MemHeap.cpp
+++ b/test/unit/Memory/MemHeap.cpp
@@ -53,7 +53,7 @@ TEST_F(MemHeapTests, resolve_pointer_single) {
       AllocationKind::Alloca, AllocationPermissions::ReadWrite, context);
   auto offset = Constant::Create(Type::int_ty(index_size), "offset");
 
-  context.add(ICmpOp::CreateICmp(ICmpOpcode::ULT, offset, size));
+  context.add(ICmpOp::CreateICmpULT(offset, size));
 
   auto ptr = Pointer(BinaryOp::CreateAdd(heaps[0][alloc].address(), offset), 0);
 


### PR DESCRIPTION
This was something that LLVM has for `ICmpInst` and I found it quite useful. This PR does the same and then replaces all the cases where it could be used.