### PR TITLE
Add some simple benchmarks 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -94,6 +94,7 @@ if (CAFFEINE_ENABLE_BUILD)
   add_subdirectory(src)
   add_subdirectory(libraries)
   add_subdirectory(tools)
+  add_subdirectory(bench)
 
   if (CAFFEINE_ENABLE_TESTS)
     add_subdirectory(test)

--- a/bench/CMakeLists.txt
+++ b/bench/CMakeLists.txt
@@ -1,0 +1,4 @@
+
+llvm_library(bench-maze maze.c)
+llvm_include_directories(bench-maze PRIVATE "${CMAKE_SOURCE_DIR}/interface")
+llvm_link_libraries     (bench-maze PRIVATE caffeine-builtins)

--- a/bench/CMakeLists.txt
+++ b/bench/CMakeLists.txt
@@ -1,4 +1,31 @@
 
-llvm_library(bench-maze maze.c)
-llvm_include_directories(bench-maze PRIVATE "${CMAKE_SOURCE_DIR}/interface")
-llvm_link_libraries     (bench-maze PRIVATE caffeine-builtins)
+include(LLVMIRUtils)
+
+function(caffeine_benchmark NAME)
+  set(sources "${ARGN}")
+  set(target "bench-${NAME}")
+  set(out_dir "${CMAKE_CURRENT_BINARY_DIR}/CMakeFiles/bench-${NAME}.dir")
+
+  llvm_library(${target} ${sources} OUTPUT "${out_dir}/lib.bc")
+  llvm_include_directories(${target} PRIVATE "${CMAKE_SOURCE_DIR}/interface")
+  llvm_link_libraries     (${target} PRIVATE caffeine-builtins)
+
+  add_custom_command(
+    OUTPUT "${target}.ll"
+    MAIN_DEPENDENCY "${out_dir}/lib.bc"
+    COMMAND "${LLVM_OPT}" ARGS
+      -O3
+      --internalize
+      --internalize-public-api-list main
+      --globaldce
+      -o "${out_dir}/optimized.bc"
+      "${out_dir}/lib.bc"
+    COMMAND "${LLVM_DIS}" ARGS "${out_dir}/optimized.bc" -o "${target}.ll"
+    COMMENT "Optimizing bench-${NAME}"
+  )
+
+  add_custom_target("gen-${target}" ALL DEPENDS "${target}.ll")
+endfunction()
+
+caffeine_benchmark(maze          maze.c)
+caffeine_benchmark(maze-symbolic maze-symbolic.c)

--- a/bench/maze-symbolic.c
+++ b/bench/maze-symbolic.c
@@ -1,0 +1,57 @@
+
+#include "caffeine.h"
+
+/**
+ * This is a variant on KLEE's maze example which does everything symbolically.
+ */
+
+#define H 7
+#define W 11
+
+int main(int argc, char* argv[]) {
+  int x, y;   // Player position
+  int ox, oy; // Old player position
+  int i = 0;  // Iteration number
+#define ITERS 28
+  char program[ITERS];
+
+  // clang-format off
+  char maze[H][W] = { 
+    "+-+---+---+",
+    "| |     |#|",
+    "| | --+ | |",
+    "| |   | | |",
+    "| +-- | | |",
+    "|     |   |",
+    "+-----+---+"};
+  // clang-format on
+
+  x = 1;
+  y = 1;
+  maze[y][x] = 'X';
+
+  caffeine_make_symbolic(program, sizeof(program), "program");
+
+  while (i < ITERS) {
+    ox = x; // Save old player position
+    oy = y;
+
+    caffeine_assume(program[i] == 'w' || program[i] == 's' ||
+                    program[i] == 'a' || program[i] == 'd');
+    y += program[i] == 'w' ? -1 : program[i] == 's' ? 1 : 0;
+    x += program[i] == 'a' ? -1 : program[i] == 'd' ? 1 : 0;
+
+    // Make caffeine print the solution when we reach the end
+    caffeine_assert(maze[y][x] != '#');
+
+    caffeine_assume((x >= 0) & (x < W));
+    caffeine_assume((y >= 0) & (y < H));
+    caffeine_assume((maze[y][x] == ' ') | ((y == 2) & (maze[y][x] == '|')));
+
+    maze[y][x] = 'X';
+
+    i++;
+  }
+
+  caffeine_assume(false);
+}

--- a/bench/maze.c
+++ b/bench/maze.c
@@ -1,6 +1,11 @@
 
 #include "caffeine.h"
 
+/**
+ * This benchmark is a direct translation of klee's maze example. It has a bunch
+ * of branches but all values end up being concrete on any of those branches.
+ */
+
 #define H 7
 #define W 11
 

--- a/bench/maze.c
+++ b/bench/maze.c
@@ -4,6 +4,8 @@
 /**
  * This benchmark is a direct translation of klee's maze example. It has a bunch
  * of branches but all values end up being concrete on any of those branches.
+ * 
+ * Example: https://feliam.wordpress.com/2010/10/07/the-symbolic-maze/
  */
 
 #define H 7

--- a/bench/maze.c
+++ b/bench/maze.c
@@ -1,0 +1,74 @@
+
+#include "caffeine.h"
+
+#define H 7
+#define W 11
+
+// clang-format off
+char maze[H][W] = { 
+  "+-+---+---+",
+  "| |     |#|",
+  "| | --+ | |",
+  "| |   | | |",
+  "| +-- | | |",
+  "|     |   |",
+  "+-----+---+"};
+// clang-format on
+
+int main(int argc, char* argv[]) {
+  int x, y;   // Player position
+  int ox, oy; // Old player position
+  int i = 0;  // Iteration number
+#define ITERS 28
+  char program[ITERS];
+
+  x = 1;
+  y = 1;
+  maze[y][x] = 'X';
+
+  caffeine_make_symbolic(program, sizeof(program), "program");
+
+  while (i < ITERS) {
+    ox = x; // Save old player position
+    oy = y;
+
+    switch (program[i]) {
+    case 'w':
+      y--;
+      break;
+    case 's':
+      y++;
+      break;
+    case 'a':
+      x--;
+      break;
+    case 'd':
+      x++;
+      break;
+    default:
+      // Wrong command! (we only accept w,s,a,d)
+      // We don't want to consider these cases
+      caffeine_assume(false);
+      break;
+    }
+
+    // Make caffeine print the solution when we reach the end
+    caffeine_assert(maze[y][x] != '#');
+
+    if (maze[y][x] != ' ' &&
+        !((y == 2 && maze[y][x] == '|' && x > 0 && x < W))) {
+      x = ox;
+      y = oy;
+    }
+
+    if (ox == x && oy == y) {
+      caffeine_assume(false);
+    }
+
+    maze[y][x] = 'X';
+
+    i++;
+  }
+
+  caffeine_assume(false);
+}

--- a/cmake/CaffeineTestUtils.cmake
+++ b/cmake/CaffeineTestUtils.cmake
@@ -115,6 +115,7 @@ function(declare_test TEST_NAME_OUT test EXPECTED)
       --caffeine-gen-test-main
       --caffeine-gen-builtins
       --internalize
+      --internalize-public-api-list main
       --globaldce
       -o <OUTPUT> <MAIN_DEPENDENCY>
     COMMENT "Optimizing ${test_target}"

--- a/cmake/LLVMIRUtils.cmake
+++ b/cmake/LLVMIRUtils.cmake
@@ -128,8 +128,9 @@ function(llvm_library TARGET_NAME)
 
   foreach(source ${sources})
     get_property(source_language SOURCE "${source}" PROPERTY LANGUAGE)
-    get_filename_component(source_ext "${source}" LAST_EXT)
-    get_filename_component(source_base "${source}" NAME)
+    get_filename_component(source_ext   "${source}" LAST_EXT)
+    get_filename_component(source_base  "${source}" NAME)
+    get_filename_component(source       "${source}" ABSOLUTE)
 
     if (source_ext STREQUAL .ll OR source_ext STREQUAL .bc)
       list(APPEND objects "${source}")

--- a/tools/opt-plugin/builtins/memcpy.cpp
+++ b/tools/opt-plugin/builtins/memcpy.cpp
@@ -148,8 +148,7 @@ llvm::Function* generateMemcpy(llvm::Module* m, llvm::Function* decl) {
   // We only need to generate this comparison if the pointers are in the same
   // address space. Otherwise they're guaranteed not to overlap.
   if (arg_dst->getType()->getPointerAddressSpace() ==
-          arg_src->getType()->getPointerAddressSpace() &&
-      false) {
+      arg_src->getType()->getPointerAddressSpace()) {
     auto iptr = layout.getIntPtrType(arg_dst->getType());
     auto off_dst = entry.CreateGEP(res_dst, ArrayRef<Value*>{arg_len});
     auto off_src = entry.CreateGEP(res_src, ArrayRef<Value*>{arg_len});

--- a/tools/opt-plugin/test-main/plugin.cpp
+++ b/tools/opt-plugin/test-main/plugin.cpp
@@ -89,8 +89,6 @@ namespace {
     builder.CreateCall(function, args);
     builder.CreateRet(ConstantInt::get(Type::getInt32Ty(m->getContext()),
                                        APInt::getNullValue(32)));
-
-    appendToUsed(*m, {main});
   }
 } // namespace
 


### PR DESCRIPTION
This PR adds a `bench` folder along with two benchmarks lifted out of a KLEE tutorial. The two benchmarks added right now are
1. The maze example from the KLEE tutorial. This benchmark is composed mainly of concrete variables with the exception of the input. Currently this takes 1m 23s of total CPU time.
2. A symbolic version of the maze example. This benchmark makes everything symbolic. This benchmark currently takes > 1h 45m of total CPU time (I didn't wait to see how long it would take)

If you read the examples closely you'll note that there's a bug in the maze algorithm. This means that there are multiple possible paths through the maze. I've also cleaned up the internal cmake setup somewhat.

This is part of #335 and closes #203. Feel free to suggest more benchmarks you think we should add :)