### PR TITLE
Optimize constant-size symbolic arrays

### DIFF
--- a/include/caffeine/IR/Type.h
+++ b/include/caffeine/IR/Type.h
@@ -16,6 +16,7 @@ class Type;
 class FunctionType;
 class LLVMContext;
 class DataLayout;
+class fltSemantics;
 } // namespace llvm
 
 namespace caffeine {
@@ -74,6 +75,7 @@ public:
   uint32_t bitwidth() const;
   uint32_t mantissa_bits() const;
   uint32_t exponent_bits() const;
+  const llvm::fltSemantics* llvm_flt_semantics() const;
 
   /**
    * Size of the current type in bytes under the given data layout.

--- a/include/caffeine/Interpreter/Context.h
+++ b/include/caffeine/Interpreter/Context.h
@@ -6,12 +6,11 @@
 #include "caffeine/Interpreter/StackFrame.h"
 #include "caffeine/Memory/MemHeap.h"
 #include "caffeine/Solver/Solver.h"
-
+#include <immer/map.hpp>
+#include <iosfwd>
 #include <llvm/ADT/SmallVector.h>
 #include <llvm/IR/Constant.h>
 #include <llvm/IR/Function.h>
-
-#include <iosfwd>
 #include <memory>
 #include <optional>
 #include <unordered_map>
@@ -28,6 +27,7 @@ public:
   std::unordered_map<llvm::GlobalValue*, LLVMValue> globals;
   MemHeapMgr heaps;
   AssertionList assertions;
+  immer::map<std::string, OpRef> constants;
 
   llvm::Module* mod;
 

--- a/src/Interpreter/Interpreter.cpp
+++ b/src/Interpreter/Interpreter.cpp
@@ -626,7 +626,7 @@ std::optional<std::string> readSymbolicName(std::shared_ptr<Solver> solver,
   const char* start = values + offset;
   const char* end = (const char*)std::memchr(start, 0, size - offset);
   if (!end) {
-    CAFFEINE_UNSUPPORTED("Symbolic name was not nul-terminated");
+    CAFFEINE_UNSUPPORTED("Symbolic name was not null-terminated");
     return std::nullopt;
   }
 

--- a/src/Interpreter/Interpreter.cpp
+++ b/src/Interpreter/Interpreter.cpp
@@ -19,6 +19,12 @@
 
 namespace caffeine {
 
+namespace {
+  // The maximum size for which a fixed-size symbolic constant will be optimized
+  // to a fixed array of smaller constants.
+  static uint64_t MAX_FIXED_CONSTANT_SIZE = 10 * 1024 * 1024;
+} // namespace
+
 ExecutionResult::ExecutionResult(Status status) : status_(status) {}
 ExecutionResult::ExecutionResult(llvm::SmallVector<Context, 2>&& contexts)
     : status_(Dead), contexts_(std::move(contexts)) {}
@@ -605,6 +611,7 @@ std::optional<std::string> readSymbolicName(std::shared_ptr<Solver> solver,
 
   auto model = ctx->resolve(solver);
   if (model->result() != SolverResult::SAT) {
+    CAFFEINE_UNSUPPORTED("Unable to resolve symbolic name");
     return std::nullopt;
   }
 
@@ -616,15 +623,14 @@ std::optional<std::string> readSymbolicName(std::shared_ptr<Solver> solver,
   name.reserve(size - offset);
 
   const char* values = array.data();
-  for (size_t i = offset; i < size; ++i) {
-    if (values[i] == 0)
-      return name;
-    name.push_back(values[i]);
+  const char* start = values + offset;
+  const char* end = (const char*)std::memchr(start, 0, size - offset);
+  if (!end) {
+    CAFFEINE_UNSUPPORTED("Symbolic name was not nul-terminated");
+    return std::nullopt;
   }
 
-  // TODO: This should really be an error when we would read beyond the end of
-  //       the array.
-  return std::nullopt;
+  return std::string(start, end);
 }
 
 ExecutionResult Interpreter::visitSymbolicAlloca(llvm::CallInst& call) {
@@ -645,9 +651,28 @@ ExecutionResult Interpreter::visitSymbolicAlloca(llvm::CallInst& call) {
   unsigned address_space = call.getType()->getPointerAddressSpace();
   unsigned ptr_width = size->type().bitwidth();
 
+  OpRef data;
+
+  auto csize = llvm::dyn_cast<ConstantInt>(size.get());
+  if (csize && csize->value().getLimitedValue() < MAX_FIXED_CONSTANT_SIZE) {
+    size_t data_size = csize->value().getLimitedValue();
+    std::vector<OpRef> constants;
+    constants.reserve(data_size);
+
+    for (size_t i = 0; i < data_size; ++i) {
+      constants.push_back(
+          Constant::Create(Type::int_ty(8), Symbol(ctx->next_constant())));
+    }
+
+    data = FixedArray::Create(size->type(), PersistentArray<OpRef>(constants));
+  } else {
+    data = ConstantArray::Create(Symbol(*alloc_name), size);
+  }
+
+  ctx->constants =
+      std::move(ctx->constants).insert({std::move(*alloc_name), data});
   auto alloc = ctx->heaps[address_space].allocate(
-      size, ConstantInt::Create(llvm::APInt(ptr_width, 1)),
-      ConstantArray::Create(Symbol(std::move(*alloc_name)), size),
+      size, ConstantInt::Create(llvm::APInt(ptr_width, 1)), data,
       AllocationKind::Alloca, AllocationPermissions::ReadWrite, *ctx);
 
   auto& frame = ctx->stack_top();

--- a/src/Interpreter/PrintingFailureLogger.cpp
+++ b/src/Interpreter/PrintingFailureLogger.cpp
@@ -63,18 +63,11 @@ void PrintingFailureLogger::log_failure(const Model& model, const Context& ctx,
   ss << "Found assertion failure:\n";
 
   if (model.result() == SolverResult::SAT) {
-    // ConstantPrinter printer{ss, &model};
-
     for (const auto& [name, constant] : ctx.constants) {
       ss << "  " << name << " = ";
       print_value(ss, model.evaluate(*constant));
       ss << '\n';
     }
-
-    // for (const auto& assertion : ctx.assertions) {
-    //   printer.visit(*assertion.value());
-    // }
-    // printer.visit(*failure.check.value());
 
     ss << "Backtrace:\n";
     ctx.print_backtrace(ss);

--- a/src/Interpreter/PrintingFailureLogger.cpp
+++ b/src/Interpreter/PrintingFailureLogger.cpp
@@ -8,53 +8,20 @@
 
 namespace caffeine {
 
-class ConstantPrinter : public ConstOpVisitor<ConstantPrinter> {
-private:
-  std::ostream& os;
-  const Model* model;
-  std::unordered_set<std::string_view> seen;
-
-public:
-  ConstantPrinter(std::ostream& os, const Model* model)
-      : os(os), model(model) {}
-
-  void visitOperation(const Operation& op) {
-    for (const auto& operand : op.operands()) {
-      visit(operand);
-    }
+namespace {
+  static char inttohex(uint8_t value) {
+    if (value < 10)
+      return '0' + value;
+    return ('A' - 10) + value;
   }
 
-  void visitConstant(const Constant& c) {
-    // TODO: Figure out how to print numbered constants and whether we'd want
-    //       to.
-    if (!c.is_named())
-      return;
+  void print_value(std::ostream& os, const Value& value) {
+    CAFFEINE_ASSERT(value.is_array());
 
-    // We've already printed this constant.
-    if (!seen.insert(c.name()).second)
-      return;
+    const auto& array = value.array();
+    os << '\"';
 
-    auto value = model->evaluate(c);
-
-    os << "  " << c.name() << " = " << value << "\n";
-  }
-
-  void visitConstantArray(const ConstantArray& c) {
-    const auto& symbol = c.symbol();
-    if (!symbol.is_named())
-      return;
-
-    if (!seen.insert(symbol.name()).second)
-      return;
-
-    auto array = model->evaluate(c).array();
-    char* data = array.data();
-
-    os << "  " << symbol.name() << " = \"";
-
-    for (size_t i = 0; i < array.size(); ++i) {
-      uint8_t value = data[i];
-
+    for (uint8_t value : array) {
       if (std::isprint(value)) {
         os << (char)value;
       } else {
@@ -80,16 +47,9 @@ public:
         }
       }
     }
-    os << "\"\n";
+    os << '\"';
   }
-
-private:
-  static char inttohex(uint8_t value) {
-    if (value < 10)
-      return '0' + value;
-    return ('A' - 10) + value;
-  }
-};
+} // namespace
 
 /***************************************************
  * PrintingFailureLogger                           *
@@ -103,12 +63,18 @@ void PrintingFailureLogger::log_failure(const Model& model, const Context& ctx,
   ss << "Found assertion failure:\n";
 
   if (model.result() == SolverResult::SAT) {
-    ConstantPrinter printer{ss, &model};
+    // ConstantPrinter printer{ss, &model};
 
-    for (const auto& assertion : ctx.assertions) {
-      printer.visit(*assertion.value());
+    for (const auto& [name, constant] : ctx.constants) {
+      ss << "  " << name << " = ";
+      print_value(ss, model.evaluate(*constant));
+      ss << '\n';
     }
-    printer.visit(*failure.check.value());
+
+    // for (const auto& assertion : ctx.assertions) {
+    //   printer.visit(*assertion.value());
+    // }
+    // printer.visit(*failure.check.value());
 
     ss << "Backtrace:\n";
     ctx.print_backtrace(ss);

--- a/src/Memory/MemHeap.cpp
+++ b/src/Memory/MemHeap.cpp
@@ -532,8 +532,8 @@ void MemHeapMgr::set_concrete(bool concrete) {
 }
 
 MemHeap& MemHeapMgr::operator[](unsigned index) {
-  return heaps_.try_emplace(index, index, heaps_are_concrete_)
-      .first->getSecond();
+  auto it = heaps_.try_emplace(index, index, heaps_are_concrete_).first;
+  return it->getSecond();
 }
 const MemHeap& MemHeapMgr::operator[](unsigned index) const {
   auto it = heaps_.find(index);


### PR DESCRIPTION
Currently, we use a symbolic array to represent the arrays emitted `caffeine_make_symbolic`. This is quite slow. This PR replaces this with allocating a `FixedArray` of byte constants. To make this work, I've changed `Context` to have a map of symbol names to constant values.

## Performance
This change improves the peformance on the `maze-symbolic` benchmark by at least 100x. I haven't actually had the time to run that benchmark to completion on the old version of the code so it might be more.

## Detailed Changes
- Change `Model::evaluate` to automatically decide the values of constants that are not mentioned in the model (these are ones where we don't care about their value).
- Change `PrintingFailureLogger` to directly use the new way of exposing named constants.
- Add a map of string constant names -> expressions for their values to `Context`.
- Change `caffeine_builtin_alloc_symbolic` to allocate a fixed array of symbolic bytes when the size is a reasonably-sized concrete value.

This PR is part of #335 

cc @brookedolny The changes to `Context` in this PR will probably affect the code you'll have to write for writing test cases to the serialized representation.