### PR TITLE
Rework solver API to split models from solver results

### DIFF
--- a/include/caffeine/Interpreter/Context.h
+++ b/include/caffeine/Interpreter/Context.h
@@ -122,9 +122,8 @@ public:
    *
    * See the docs on Solver::resolve for more details.
    */
-  std::unique_ptr<Model>
-  resolve(std::shared_ptr<Solver> solver,
-          const Assertion& extra = Assertion::constant(true));
+  SolverResult resolve(std::shared_ptr<Solver> solver,
+                       const Assertion& extra = Assertion::constant(true));
 
   /**
    * Replaces instances of the unresolved pointer within the top stack frame

--- a/include/caffeine/Interpreter/FailureLogger.h
+++ b/include/caffeine/Interpreter/FailureLogger.h
@@ -23,7 +23,7 @@ public:
   FailureLogger() = default;
   virtual ~FailureLogger() = default;
 
-  virtual void log_failure(const Model& model, const Context& context,
+  virtual void log_failure(const Model* model, const Context& context,
                            const Failure& failure) = 0;
 
 protected:
@@ -42,7 +42,7 @@ private:
 public:
   PrintingFailureLogger(std::ostream& os);
 
-  void log_failure(const Model& model, const Context& context,
+  void log_failure(const Model* model, const Context& context,
                    const Failure& failure) override;
 };
 

--- a/include/caffeine/Solver/CanonicalizingSolver.h
+++ b/include/caffeine/Solver/CanonicalizingSolver.h
@@ -18,11 +18,8 @@ class CanonicalizingSolver final : public Solver {
 public:
   CanonicalizingSolver() = default;
 
-  SolverResult check(AssertionList& assertions,
-                     const Assertion& extra) override;
-
-  std::unique_ptr<Model> resolve(AssertionList& assertions,
-                                 const Assertion& extra) override;
+  SolverResult resolve(AssertionList& assertions,
+                       const Assertion& extra) override;
 };
 
 } // namespace caffeine

--- a/include/caffeine/Solver/SimplifyingSolver.h
+++ b/include/caffeine/Solver/SimplifyingSolver.h
@@ -18,11 +18,8 @@ class SimplifyingSolver final : public Solver {
 public:
   SimplifyingSolver() = default;
 
-  SolverResult check(AssertionList& assertions,
-                     const Assertion& extra) override;
-
-  std::unique_ptr<Model> resolve(AssertionList& assertions,
-                                 const Assertion& extra) override;
+  SolverResult resolve(AssertionList& assertions,
+                       const Assertion& extra) override;
 };
 
 } // namespace caffeine

--- a/include/caffeine/Solver/Z3Solver.h
+++ b/include/caffeine/Solver/Z3Solver.h
@@ -26,26 +26,9 @@ public:
 
   SolverResult check(AssertionList& assertions,
                      const Assertion& extra) override;
-  /**
-   * Validate whether the set of assertions combined with the extra assertion,
-   * if it isn't empty, is satisfiable and return a model.
-   *
-   * Solvers are free to perform any modifications to the assertions vector
-   * provided as long as they
-   * 1. don't change the satisfiability of the end result or the space of valid
-   *    models, and
-   * 2. don't incorporate any information from `extra`. As an example, if the
-   *    assertion vector contains `x < 5` and `x = 2` then it would be valid to
-   *    simplify that to `true` and `x = 2`. But if extra is `x = 2` then it
-   *    wouldn't be valid to perform that simplification. Note, however, that
-   *    the final SAT/UNSAT result should take extra into account.
-   *
-   * This includes modifying the backing expression trees and so on. Note that
-   * care must be taken not to modify expressions that have multiple references
-   * (refcount > 1) as that could modify unrelated expressions.
-   */
-  std::unique_ptr<Model> resolve(AssertionList& assertions,
-                                 const Assertion& extra) override;
+
+  SolverResult resolve(AssertionList& assertions,
+                       const Assertion& extra) override;
 };
 
 } // namespace caffeine

--- a/src/Interpreter/Context.cpp
+++ b/src/Interpreter/Context.cpp
@@ -146,12 +146,12 @@ SolverResult Context::check(std::shared_ptr<Solver> solver,
     assertions.mark_sat();
   return result;
 }
-std::unique_ptr<Model> Context::resolve(std::shared_ptr<Solver> solver,
-                                        const Assertion& extra) {
-  auto model = solver->resolve(assertions, extra);
-  if (model->result() == SolverResult::SAT)
+SolverResult Context::resolve(std::shared_ptr<Solver> solver,
+                              const Assertion& extra) {
+  auto result = solver->resolve(assertions, extra);
+  if (result == SolverResult::SAT)
     assertions.mark_sat();
-  return model;
+  return result;
 }
 
 uint64_t Context::next_constant() {

--- a/src/Interpreter/Executor.cpp
+++ b/src/Interpreter/Executor.cpp
@@ -29,7 +29,7 @@ void run_worker(Executor* exec, FailureLogger* logger,
       //       parent program.
 
       logger->log_failure(
-          caffeine::EmptyModel(SolverResult::Unknown), ctx.value(),
+          nullptr, ctx.value(),
           Failure(Assertion(), "internal error: unsupported operation"));
     }
   }

--- a/src/Interpreter/Interpreter.cpp
+++ b/src/Interpreter/Interpreter.cpp
@@ -42,7 +42,7 @@ void Interpreter::logFailure(Context& ctx, const Assertion& assertion,
   if (model->result() != SolverResult::SAT)
     return;
 
-  logger->log_failure(*model, ctx, Failure(assertion, message));
+  logger->log_failure(model.get(), ctx, Failure(assertion, message));
   policy->on_path_complete(ctx, ExecutionPolicy::Fail);
 }
 void Interpreter::queueContext(Context&& ctx) {

--- a/src/Interpreter/PrintingFailureLogger.cpp
+++ b/src/Interpreter/PrintingFailureLogger.cpp
@@ -57,21 +57,22 @@ namespace {
 
 PrintingFailureLogger::PrintingFailureLogger(std::ostream& os) : os(&os) {}
 
-void PrintingFailureLogger::log_failure(const Model& model, const Context& ctx,
+void PrintingFailureLogger::log_failure(const Model* model, const Context& ctx,
                                         const Failure& failure) {
   std::stringstream ss;
   ss << "Found assertion failure:\n";
 
-  if (model.result() == SolverResult::SAT) {
+  if (model) {
     for (const auto& [name, constant] : ctx.constants) {
       ss << "  " << name << " = ";
-      print_value(ss, model.evaluate(*constant));
+      print_value(ss, model->evaluate(*constant));
       ss << '\n';
     }
 
     ss << "Backtrace:\n";
     ctx.print_backtrace(ss);
   }
+
   if (!failure.message.empty())
     ss << "Reason:\n  " << failure.message << '\n';
 

--- a/src/Solver/CanonicalizingSolver.cpp
+++ b/src/Solver/CanonicalizingSolver.cpp
@@ -10,15 +10,10 @@
 
 namespace caffeine {
 
-SolverResult CanonicalizingSolver::check(AssertionList& assertions,
-                                         const Assertion&) {
+SolverResult CanonicalizingSolver::resolve(AssertionList& assertions,
+                                           const Assertion&) {
   transforms::canonicalize(assertions);
   return SolverResult::Unknown;
-}
-std::unique_ptr<Model> CanonicalizingSolver::resolve(AssertionList& assertions,
-                                                     const Assertion&) {
-  transforms::canonicalize(assertions);
-  return std::make_unique<EmptyModel>(SolverResult::Unknown);
 }
 
 } // namespace caffeine

--- a/src/Solver/SimplifyingSolver.cpp
+++ b/src/Solver/SimplifyingSolver.cpp
@@ -10,15 +10,10 @@
 
 namespace caffeine {
 
-SolverResult SimplifyingSolver::check(AssertionList& assertions,
-                                      const Assertion&) {
+SolverResult SimplifyingSolver::resolve(AssertionList& assertions,
+                                        const Assertion&) {
   transforms::simplify(assertions);
   return SolverResult::Unknown;
-}
-std::unique_ptr<Model> SimplifyingSolver::resolve(AssertionList& assertions,
-                                                  const Assertion&) {
-  transforms::simplify(assertions);
-  return std::make_unique<EmptyModel>(SolverResult::Unknown);
 }
 
 } // namespace caffeine

--- a/src/Solver/Z3Solver.h
+++ b/src/Solver/Z3Solver.h
@@ -42,8 +42,8 @@ private:
   ConstMap constants;
 
 public:
-  Z3Model(SolverResult result, const z3::model& model, const ConstMap& map);
-  Z3Model(SolverResult result, const z3::model& model, ConstMap&& map);
+  Z3Model(const z3::model& model, const ConstMap& map);
+  Z3Model(const z3::model& model, ConstMap&& map);
 
   Value lookup(const Symbol& symbol, std::optional<size_t> size) const override;
 };

--- a/src/bin/caffeine.cpp
+++ b/src/bin/caffeine.cpp
@@ -36,7 +36,7 @@ public:
   CountingFailureLogger(std::ostream& os, llvm::Function* func)
       : PrintingFailureLogger(os), func{func} {}
 
-  void log_failure(const caffeine::Model& model, const caffeine::Context& ctx,
+  void log_failure(const caffeine::Model* model, const caffeine::Context& ctx,
                    const caffeine::Failure& failure) override {
     num_failures += 1;
     caffeine::PrintingFailureLogger::log_failure(model, ctx, failure);

--- a/tools/guided-fuzzing/src/GuidedExecutionPolicy.cpp
+++ b/tools/guided-fuzzing/src/GuidedExecutionPolicy.cpp
@@ -5,7 +5,7 @@ namespace caffeine {
 GuidedExecutionPolicy::GuidedExecutionPolicy(AssertionList& list,
                                              std::shared_ptr<Solver> solver)
     : requiredAssertions_{list}, solver_{solver} {
-  if (solver_->check(list) == UNSAT) {
+  if (solver_->check(list) == SolverResult::UNSAT) {
     CAFFEINE_ABORT("GuidedExecutionPolicy requires satisfiable premise");
   }
 }
@@ -17,7 +17,7 @@ bool GuidedExecutionPolicy::should_queue_path(const Context& ctx) {
     combined.insert(i);
   }
 
-  return solver_->check(combined) != UNSAT;
+  return solver_->check(combined) != SolverResult::UNSAT;
 }
 
 } // namespace caffeine


### PR DESCRIPTION
One thing that's been bugging me for a while is that `Model` basically has two responsibilities: it's a result from a solver (e.g. SAT, UNSAT) and it's model that can be used to get concrete values for random expressions. These are distinct responsibilities. This PR is an attempt to change things so that responsibilities are distributed in a cleaner fashion.

This PR is meant to be an RFC. If we can think of a better way of refactoring things here then I'd love to hear about it so that I can implement it :)

## Details
The main new changes from this are
- `SolverResult` has been converted from an enum to a class. Logically, it is now a result from a solver with an optional model if it is `SAT`.
- `Model` is now just a model. It no longer has an associated solver result and is instead just responsible for evaluating expressions to concrete values.
- Both `Solver::check` and `Solver::resolve` now return `SolverResult`. The only difference between the two is that `Solver::resolve` must return `SolverResult` with a model if the query is satisfiable.

Now, to make the changes work there's some follow on refactoring that had to be done
- All solvers had to be updated to use the new API
- Some downstream consumers had to be updated to work with the new `SolverResult` instead of directly receiving a model.
- `EmptyModel` can now be deleted since it was basically a shim to present an `UNSAT` model.
- Since models are now always `SAT`, `FailureLogger` now takes an optional model. Note that the only case in which there is no model in a failure is if caffeine encounters a recoverable internal error.
- Some follow-on documentation updates.