### PR TITLE
Mark Guard destructor as `noexcept(false)`

### DIFF
--- a/include/caffeine/ADT/Guard.h
+++ b/include/caffeine/ADT/Guard.h
@@ -21,7 +21,7 @@ namespace detail {
     constexpr ScopeGuard(F&& func) : F(std::move(func)) {}
     constexpr ScopeGuard(const F& func) : F(func) {}
 
-    ~ScopeGuard() {
+    ~ScopeGuard() noexcept(false) {
       if (!dismissed) {
         (*this)();
       }


### PR DESCRIPTION
This gives a more accurate stack trace when an exception gets thrown as part of the guard destructor.