### PR TITLE
Add the ability to checkpoint and restore an `AssertionList`.

### DIFF
--- a/include/caffeine/ADT/SparseVector.h
+++ b/include/caffeine/ADT/SparseVector.h
@@ -251,7 +251,7 @@ public:
   iterator begin() {
     auto it = elements_.begin();
     if (it != elements_.end() && it->index() != Value)
-      ++it;
+      return std::next(iterator(it, this));
 
     return iterator(it, this);
   }
@@ -261,7 +261,7 @@ public:
   const_iterator begin() const {
     auto it = elements_.begin();
     if (it != elements_.end() && it->index() != Value)
-      ++it;
+      return std::next(const_iterator(it, this));
 
     return const_iterator(it, this);
   }

--- a/include/caffeine/Interpreter/AssertionList.h
+++ b/include/caffeine/Interpreter/AssertionList.h
@@ -98,6 +98,20 @@ public:
                                                 end());
   }
 
+  /**
+   * Create a checkpoint of the current position of the tail of the list. This
+   * allows for items to be temporarily inserted into the list and then removed
+   * once no longer needed.
+   *
+   * The number returned by this method is the index of the end iterator in the
+   * backing array.
+   *
+   * To remove all items inserted since the corresponding checkpoint call the
+   * restore method.
+   */
+  size_t checkpoint() const;
+  void restore(size_t checkpoint);
+
   void DebugPrint() const;
 };
 

--- a/include/caffeine/Interpreter/AssertionList.h
+++ b/include/caffeine/Interpreter/AssertionList.h
@@ -93,10 +93,7 @@ public:
     return list_.end();
   }
 
-  llvm::iterator_range<const_iterator> unproven() const {
-    return llvm::iterator_range<const_iterator>(list_.iterator_at(mark_),
-                                                end());
-  }
+  llvm::iterator_range<const_iterator> unproven() const;
 
   /**
    * Create a checkpoint of the current position of the tail of the list. This

--- a/src/Interpreter/AssertionList.cpp
+++ b/src/Interpreter/AssertionList.cpp
@@ -84,10 +84,19 @@ void AssertionList::restore(size_t checkpoint) {
   if (it != end && !it.valid())
     ++it;
 
-  for(; it != end; ++it) {
+  for (; it != end; ++it) {
     lookup_.erase(*it);
     list_.erase(it);
   }
+}
+
+llvm::iterator_range<AssertionList::const_iterator>
+AssertionList::unproven() const {
+  auto it = list_.iterator_at(mark_);
+  if (it != end() && !it.valid())
+    ++it;
+
+  return llvm::iterator_range<const_iterator>(it, end());
 }
 
 } // namespace caffeine

--- a/src/Interpreter/AssertionList.cpp
+++ b/src/Interpreter/AssertionList.cpp
@@ -73,4 +73,21 @@ void AssertionList::erase(const_iterator it) {
   list_.erase(it.index());
 }
 
+size_t AssertionList::checkpoint() const {
+  return list_.end().index();
+}
+
+void AssertionList::restore(size_t checkpoint) {
+  auto it = list_.iterator_at(checkpoint);
+  auto end = list_.end();
+
+  if (it != end && !it.valid())
+    ++it;
+
+  for(; it != end; ++it) {
+    lookup_.erase(*it);
+    list_.erase(it);
+  }
+}
+
 } // namespace caffeine

--- a/test/unit/Interpreter/AssertionList.cpp
+++ b/test/unit/Interpreter/AssertionList.cpp
@@ -75,3 +75,15 @@ TEST(AssertionListTests, checkpoint_restore_unchanged) {
   size_t checkpoint = list.checkpoint();
   list.restore(checkpoint);
 }
+
+TEST(AssertionListTests, iterate_empty) {
+  AssertionList list;
+  size_t checkpoint = list.checkpoint();
+  list.insert(Assertion(Constant::Create(Type::int_ty(1), 0)));
+  list.insert(Assertion(Constant::Create(Type::int_ty(1), 1)));
+  list.insert(Assertion(Constant::Create(Type::int_ty(1), 2)));
+  list.restore(checkpoint);
+
+  ASSERT_TRUE(list.empty());
+  ASSERT_EQ(list.begin().index(), list.end().index());
+}

--- a/test/unit/Interpreter/AssertionList.cpp
+++ b/test/unit/Interpreter/AssertionList.cpp
@@ -48,3 +48,30 @@ TEST(AssertionListTests, breaks_down_top_level_not_or) {
   ASSERT_EQ(llvm::cast<Constant>(*assertions[1].value()).number(), 1);
   ASSERT_EQ(llvm::cast<Constant>(*assertions[2].value()).number(), 2);
 }
+
+TEST(AssertionListTests, checkpoint_restore) {
+  AssertionList list;
+  list.insert(Assertion(Constant::Create(Type::int_ty(1), 0)));
+  list.insert(Assertion(Constant::Create(Type::int_ty(1), 1)));
+  list.insert(Assertion(Constant::Create(Type::int_ty(1), 2)));
+
+  ASSERT_EQ(list.size(), 3);
+
+  size_t checkpoint = list.checkpoint();
+  list.insert(Assertion(Constant::Create(Type::int_ty(1), 3)));
+  list.insert(Assertion(Constant::Create(Type::int_ty(1), 4)));
+
+  ASSERT_EQ(list.size(), 5);
+
+  list.restore(checkpoint);
+  ASSERT_EQ(list.size(), 3);
+
+  list.insert(Assertion(Constant::Create(Type::int_ty(1), 3)));
+  ASSERT_EQ(list.size(), 4);
+}
+
+TEST(AssertionListTests, checkpoint_restore_unchanged) {
+  AssertionList list;
+  size_t checkpoint = list.checkpoint();
+  list.restore(checkpoint);
+}


### PR DESCRIPTION
This PR adds two helper functions to `AssertionList`.
- `checkpoint` returns a value that can be then fed into
- `restore` which removes all values that have been inserted into the list since the corresponding `checkpoint` call.

This is useful as a general "insert things into the list to see if they're already present" strategy. In this PR, I've used it to simplify `Z3Solver`.

At the same time I ran into bugs in `AssertionList` and `SparseVector` since checkpointing/restoring results in them being in new states. I've included fixes and a test case in this PR as well.