### PR TITLE
Construct z3::tactic at solver creation time

### DIFF
--- a/include/caffeine/Solver/Z3Solver.h
+++ b/include/caffeine/Solver/Z3Solver.h
@@ -5,10 +5,6 @@
 
 #include <memory>
 
-namespace z3 {
-class context;
-}
-
 namespace caffeine {
 
 class Model;
@@ -16,12 +12,17 @@ class Assertion;
 
 class Z3Solver : public Solver {
 private:
+  class Impl;
+
   // Use a unique_ptr here so we don't have to include z3++.h
-  std::unique_ptr<z3::context> ctx;
+  std::unique_ptr<Impl> impl;
 
 public:
   Z3Solver();
   ~Z3Solver();
+
+  Z3Solver(Z3Solver&& solver) noexcept;
+  Z3Solver& operator=(Z3Solver&& solver) noexcept;
 
   SolverResult check(AssertionList& assertions,
                      const Assertion& extra) override;
@@ -45,9 +46,6 @@ public:
    */
   std::unique_ptr<Model> resolve(AssertionList& assertions,
                                  const Assertion& extra) override;
-
-  Z3Solver(Z3Solver&&) = default;
-  Z3Solver& operator=(Z3Solver&&) = default;
 };
 
 } // namespace caffeine

--- a/src/Solver/Z3Solver.h
+++ b/src/Solver/Z3Solver.h
@@ -17,6 +17,21 @@
 
 namespace caffeine {
 
+class Z3Solver::Impl {
+public:
+  z3::context ctx;
+  z3::tactic tactic;
+
+  Impl() : tactic(ctx, "default") {
+    // We want z3 to generate models
+    ctx.set("model", true);
+    // Automatically select and configure the solver
+    ctx.set("auto_config", true);
+    // Z3 will set a SIGINT handler unless we tell it not to
+    ctx.set("ctrl_c", false);
+  }
+};
+
 class Z3Model : public Model {
 public:
   using SymbolName = std::variant<std::string, uint64_t>;


### PR DESCRIPTION
As it turns out, constructing a z3::tactic is rather expensive. Tracing data shows it as taking ~100ms each and every time we do it. This commit creates exactly one tactic at startup and then uses it to create all of the solvers later on.

Some basic benchmarking shows a 25% improvement on the `bench-maze` benchmark.