### PR TITLE
Implement arbitrary tracing support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,6 +18,7 @@ option(CAFFEINE_ENABLE_FORMAT   "Enable formatting targets" ON)
 option(CAFFEINE_BUILD_BITCODE   "If true compile tests and libraries down to bitcode, otherwise compile them to text IR" OFF)
 option(CAFFEINE_ENABLE_IR_TESTS "Enable tests which involve handwritten LLVM IR" ON)
 option(CAFFEINE_ENABLE_LIBC     "Build a bitcode libc for use in tests" OFF)
+option(CAFFEINE_ENABLE_TRACING  "Enable tracing support within caffeine" OFF)
 
 # Optimization settings
 set(CAFFEINE_ENABLE_LTO OFF CACHE STRING "Enable link-time-optimizations. Valid values: ON, OFF, FULL, THIN")
@@ -98,6 +99,9 @@ if (CAFFEINE_ENABLE_BUILD)
   include(CaffeineFlags)
   include(LLVMIRUtils)
 
+  make_directory("${CMAKE_BINARY_DIR}/gen/caffeine")
+  configure_file(Config.h.in "${CMAKE_BINARY_DIR}/gen/caffeine/Config.h")
+  
   if (CAFFEINE_ENABLE_TESTS)
     enable_testing()
   endif()

--- a/Config.h.in
+++ b/Config.h.in
@@ -1,0 +1,6 @@
+#ifndef CAFFEINE_CONFIG_H
+#define CAFFEINE_CONFIG_H
+
+#cmakedefine01 CAFFEINE_ENABLE_TRACING
+
+#endif

--- a/include/caffeine/Support/Assert.h
+++ b/include/caffeine/Support/Assert.h
@@ -1,6 +1,7 @@
 #ifndef CAFFEINE_MACROS_H
 #define CAFFEINE_MACROS_H
 
+#include "caffeine/Support/Macros.h"
 #include <string_view>
 
 namespace caffeine::detail {
@@ -50,12 +51,6 @@ struct message {
                         const char* file, message message);
 
 } // namespace caffeine::detail
-
-#ifdef __PRETTY_FUNCTION__
-#define CAFFEINE_FUNCTION __PRETTY_FUNCTION__
-#else
-#define CAFFEINE_FUNCTION __FUNCTION__
-#endif
 
 /**
  * Abort the process if the condition is not true.

--- a/include/caffeine/Support/Macros.h
+++ b/include/caffeine/Support/Macros.h
@@ -41,4 +41,10 @@
       CAFFEINE_CONCAT(macro, 1)(__VA_ARGS__),                                  \
       CAFFEINE_CONCAT(macro, 0)(__VA_ARGS__)))
 
+#ifdef __PRETTY_FUNCTION__
+#define CAFFEINE_FUNCTION __PRETTY_FUNCTION__
+#else
+#define CAFFEINE_FUNCTION __FUNCTION__
+#endif
+
 #endif

--- a/include/caffeine/Support/Macros.h
+++ b/include/caffeine/Support/Macros.h
@@ -14,6 +14,9 @@
 #define CAFFEINE_CONCAT_(x, y) x##y
 #define CAFFEINE_CONCAT(x, y) CAFFEINE_CONCAT_(x, y)
 
+#define CAFFEINE_STRINGIFY_(x) #x
+#define CAFFEINE_STRINGIFY(x) CAFFEINE_STRINGIFY_(x)
+
 #define CAFFEINE_EXPAND(x) x
 
 #define CAFFEINE_FIRST(x, ...) x

--- a/include/caffeine/Support/Tracing.h
+++ b/include/caffeine/Support/Tracing.h
@@ -1,0 +1,182 @@
+#pragma once
+
+#include "caffeine/Config.h"
+#include "caffeine/Support/Macros.h"
+#include <memory>
+#include <string_view>
+
+namespace caffeine::tracing {
+
+class TraceSink;
+
+/**
+ * Open a new tracing context.
+ *
+ * This initializes a new global tracing context that is tied to the lifetime of
+ * the created TraceContext object. If there is no global tracing context that
+ * is current then no spans will be recorded.
+ *
+ * It is an error to try and create a tracing context when another one already
+ * exists.
+ */
+class TraceContext {
+public:
+#if CAFFEINE_ENABLE_TRACING
+  std::unique_ptr<TraceSink> impl;
+#endif
+
+public:
+#if CAFFEINE_ENABLE_TRACING
+  TraceContext(const char* output_file);
+  ~TraceContext();
+
+  bool is_enabled() const;
+#else
+  TraceContext(const char*) {}
+  ~TraceContext() = default;
+
+  bool is_enabled() const {
+    return false;
+  }
+#endif
+public:
+  TraceContext(TraceContext&&) = delete;
+  TraceContext(const TraceContext&) = delete;
+  TraceContext& operator=(TraceContext&&) = delete;
+  TraceContext& operator=(const TraceContext&) = delete;
+};
+
+/**
+ * An individual span within the recorded trace of the program.
+ *
+ * In our model, a span is a named window of time with arbitrary user-added
+ * annotations. An AutoTraceBlock creates a span that is automatically closed
+ * when the block is destroyed. Currently this is the only way to create a trace
+ * span.
+ *
+ * Note that the recommended way to create a trace span is by using the
+ * CAFFENE_TRACE_SPAN macro.
+ *
+ * Performance
+ * ===========
+ * When tracing is disabled at compile time, all the methods of AutoTraceBlock
+ * are stubbed out and should be completely optimized away, making it zero-cost.
+ * Otherwise, there is a runtime check when creating the block.
+ *
+ * If creating an annotation would be expensive then you can use is_enabled to
+ * check whether this block will record anything and only emit the annotation if
+ * it would.
+ *
+ * Annotations
+ * ===========
+ * Annotations are a collection of string key-value pairs. They (should) be
+ * shown along with each span when the log is transformed into whatever final
+ * format is applicable.
+ *
+ * Annotations are meant to be used to store whatever context-relevant
+ * information one would want to properly interpret the span.
+ */
+class AutoTraceBlock {
+private:
+#if CAFFEINE_ENABLE_TRACING
+  struct Impl;
+
+  std::unique_ptr<Impl> impl;
+#endif
+
+public:
+  // Limit annotation size to 32KB to keep the annotation file size from
+  // exploding.
+  //
+  // Note that chrome can only load at most 256MB of trace data so raising this
+  // limit can cause problems for traces with large annotations.
+  static constexpr size_t MAX_ANNOTATION_SIZE = 32 * 1024;
+
+#if CAFFEINE_ENABLE_TRACING
+  AutoTraceBlock(std::string_view name);
+  ~AutoTraceBlock();
+
+  AutoTraceBlock(AutoTraceBlock&&);
+  AutoTraceBlock& operator=(AutoTraceBlock&&);
+#else
+  AutoTraceBlock(std::string_view) {}
+  ~AutoTraceBlock() = default;
+
+  AutoTraceBlock(AutoTraceBlock&&) = default;
+  AutoTraceBlock& operator=(AutoTraceBlock&&) = default;
+#endif
+
+#if CAFFEINE_ENABLE_TRACING
+  bool is_enabled() const;
+#else
+  bool is_enabled() const {
+    return false;
+  }
+#endif
+
+#if CAFFEINE_ENABLE_TRACING
+  /**
+   * End the span early. Normally the span is ended when the destructor is
+   * called but if the lifetime you're trying to trace isn't directly linked to
+   * a scope then it may be easier to just call this method instead.
+   *
+   * Note: Any annotations added after calling close will not be recorded.
+   */
+  void close();
+#else
+  void close() {}
+#endif
+
+  AutoTraceBlock& annotate(std::string_view name, std::string_view value) & {
+    annotate_detail(name, value);
+    return *this;
+  }
+  AutoTraceBlock&& annotate(std::string_view name, std::string_view value) && {
+    annotate_detail(name, value);
+    return std::move(*this);
+  }
+
+private:
+#if CAFFEINE_ENABLE_TRACING
+  void annotate_detail(std::string_view name, std::string_view value);
+#else
+  void annotate_detail(std::string_view, std::string_view) {}
+#endif
+
+public:
+  template <typename F>
+  AutoTraceBlock& annotate_func(F&& func) & {
+    if (is_enabled())
+      func(*this);
+    return *this;
+  }
+  template <typename F>
+  AutoTraceBlock&& annotate_func(F&& func) && {
+    if (is_enabled())
+      func(*this);
+    return std::move(*this);
+  }
+
+public:
+  AutoTraceBlock(const AutoTraceBlock&) = delete;
+  AutoTraceBlock& operator=(const AutoTraceBlock&) = delete;
+};
+
+namespace detail {
+  void annotate_tid(AutoTraceBlock& block);
+}
+
+/**
+ * Open a trace block and record some common trace metadata.
+ *
+ * This is the recommended way of opening a trace span. It returns an
+ * AutoTraceBlock instance that you can add custom annotations to.
+ */
+#define CAFFEINE_TRACE_SPAN(name)                                              \
+  ::caffeine::tracing::AutoTraceBlock(name)                                    \
+      .annotate("line", CAFFEINE_STRINGIFY(__LINE__))                          \
+      .annotate("file", __FILE__)                                              \
+      .annotate("func", CAFFEINE_FUNCTION)                                     \
+      .annotate_func(::caffeine::tracing::detail::annotate_tid)
+
+} // namespace caffeine::tracing

--- a/src/Protos/tracepoint.capnp
+++ b/src/Protos/tracepoint.capnp
@@ -1,0 +1,19 @@
+@0xe1240261ad88790c;
+
+using Cxx = import "/capnp/c++.capnp";
+$Cxx.namespace("caffeine::tracing");
+
+struct TraceSpan @0x9a020f3b6538255f {
+  start @0 :UInt64; # Starting time of this span
+  end   @1 :UInt64; # Ending time of this span
+  name  @2 :Text;   # Name associated with this span
+
+  annotations @3 :List(Annotation);
+  # Arbitrary annotations added by the implementation. Semantically this is a
+  # map but the implementation doesn't guarantee that names don't repeat.
+
+  struct Annotation {
+    name  @0 :Text;
+    value @1 :Text;
+  }
+}

--- a/src/Support/Tracing.cpp
+++ b/src/Support/Tracing.cpp
@@ -1,0 +1,162 @@
+#include "caffeine/Support/Tracing.h"
+#include "caffeine/Protos/tracepoint.capnp.h"
+#include "caffeine/Support/Assert.h"
+#include <capnp/message.h>
+#include <capnp/orphan.h>
+#include <capnp/serialize-packed.h>
+#include <chrono>
+#include <cstdio>
+#include <fmt/format.h>
+#include <fmt/ostream.h>
+#include <llvm/ADT/SmallVector.h>
+#include <thread>
+#include <vector>
+
+namespace caffeine::tracing {
+
+namespace detail {
+  void annotate_tid(AutoTraceBlock& block) {
+    block.annotate("tid", fmt::format("{}", std::this_thread::get_id()));
+  }
+} // namespace detail
+
+#if CAFFEINE_ENABLE_TRACING
+
+namespace {
+  static TraceSink* trace_sink = nullptr;
+
+  void build_string(capnp::Text::Builder&& builder, std::string_view string) {
+    CAFFEINE_ASSERT(builder.size() == string.size());
+    std::copy(string.begin(), string.end(), builder.asArray().begin());
+  }
+} // namespace
+
+class TraceSink {
+private:
+  FILE* output;
+
+public:
+  TraceSink(FILE* output) : output(output) {
+    CAFFEINE_ASSERT(output);
+  }
+  ~TraceSink() {
+    fclose(output);
+  }
+
+  FILE* file() const {
+    return output;
+  }
+};
+
+TraceContext::TraceContext(const char* output_file) {
+  FILE* file = fopen(output_file, "wb");
+  if (!file)
+    throw std::runtime_error("Unable to open trace file");
+
+  CAFFEINE_ASSERT(!trace_sink, "Tried to create a new TraceContext while "
+                               "another one was already current.");
+
+  impl = std::make_unique<TraceSink>(file);
+  trace_sink = impl.get();
+}
+TraceContext::~TraceContext() {
+  if (impl)
+    trace_sink = nullptr;
+}
+
+bool TraceContext::is_enabled() const {
+  return !!impl;
+}
+
+struct AutoTraceBlock::Impl {
+  capnp::MallocMessageBuilder message;
+  llvm::SmallVector<
+      std::pair<capnp::Orphan<capnp::Text>, capnp::Orphan<capnp::Text>>, 16>
+      annotations;
+  TraceSpan::Builder span;
+
+  Impl() : span(message.initRoot<TraceSpan>()) {
+    annotations.reserve(16);
+  }
+
+  void emit() {
+    auto sink = trace_sink;
+    if (!sink)
+      return;
+
+    span.setEnd(std::chrono::system_clock::now().time_since_epoch().count());
+
+    auto list = span.initAnnotations(annotations.size());
+    size_t i = 0;
+    for (auto&& [name, value] : annotations) {
+      list[i].adoptName(std::move(name));
+      list[i].adoptValue(std::move(value));
+
+      i += 1;
+    }
+
+    kj::VectorOutputStream stream;
+    capnp::writePackedMessage(stream, message);
+
+    auto data = stream.getArray();
+    fwrite(data.begin(), data.size(), 1, sink->file());
+  }
+};
+
+AutoTraceBlock::AutoTraceBlock(std::string_view name) {
+  if (trace_sink) {
+    impl = std::make_unique<Impl>();
+    build_string(impl->span.initName(name.size()), name);
+
+    impl->span.setStart(
+        std::chrono::system_clock::now().time_since_epoch().count());
+  }
+}
+AutoTraceBlock::~AutoTraceBlock() {
+  if (!impl)
+    return;
+
+  impl->emit();
+}
+
+AutoTraceBlock::AutoTraceBlock(AutoTraceBlock&& block)
+    : impl(std::move(block.impl)) {}
+AutoTraceBlock& AutoTraceBlock::operator=(AutoTraceBlock&& block) {
+  impl = std::move(block.impl);
+  return *this;
+}
+
+bool AutoTraceBlock::is_enabled() const {
+  return impl && trace_sink;
+}
+
+void AutoTraceBlock::close() {
+  if (impl)
+    impl->emit();
+  impl = nullptr;
+}
+
+void AutoTraceBlock::annotate_detail(std::string_view name,
+                                     std::string_view value) {
+  if (!impl)
+    return;
+
+  auto orphanage = impl->message.getOrphanage();
+
+  if (name.size() > MAX_ANNOTATION_SIZE)
+    name = std::string_view(name.data(), MAX_ANNOTATION_SIZE);
+  if (value.size() > MAX_ANNOTATION_SIZE)
+    value = std::string_view(value.data(), MAX_ANNOTATION_SIZE);
+
+  auto oname = orphanage.newOrphan<capnp::Text>(name.size());
+  auto ovalue = orphanage.newOrphan<capnp::Text>(value.size());
+
+  build_string(oname.get(), name);
+  build_string(ovalue.get(), value);
+
+  impl->annotations.emplace_back(std::move(oname), std::move(ovalue));
+}
+
+#endif
+
+} // namespace caffeine::tracing


### PR DESCRIPTION
This PR adds a small tracing library that can be used to log arbitrary spans while caffeine is running. This is meant to allow for easier performance analysis. I've already used it to diagnose one performance improvement (#386).

If disabled at compile time, the tracing support should optimize away to nothing. If not, it has to check one global variable to see if it's enabled. I've put the existing tools I've written to work with it [here](https://github.com/insufficiently-caffeinated/tracing-tools).

## Details
This required a few changes to more than just setting up tracing. Here are the detailed changes:
- We now have a config header that is configured based on cmake options passed to the cmake configure step. The template for this is `Config.h.in` in the root of the repo.
- There is now a `CAFFEINE_ENABLE_TRACING` option to disable tracing at compile time
- I've added a capnp message for serialized trace data
- `caffeine/Support/Tracing.(h|cpp)` contains all the tracing code

I've also set up a global trace handler in the main binary as well as some recording of trace spans for calls to the Z3 solver.