### PR TITLE
Fix error when changing generators without removing all files

### DIFF
--- a/cmake/CaffeineDependencies.cmake
+++ b/cmake/CaffeineDependencies.cmake
@@ -32,6 +32,15 @@ function(caffeine_dependency PACKAGE VERSION)
   set(SUB_DIR "${CMAKE_BINARY_DIR}/_deps/${PACKAGE}/populate")
   set(PREFIX  "${CMAKE_BINARY_DIR}/_deps/${PACKAGE}")
 
+  set(old_generator "${CAFFEINE_DEPENDENCY_${PACKAGE}_GENERATOR}")
+  if (NOT "${old_generator}" STREQUAL "${CMAKE_GENERATOR}")
+    execute_process(
+      COMMAND "${CMAKE_COMMAND}" -E rm -rf "${PREFIX}"
+    )
+  endif()
+
+  set("CAFFEINE_DEPENDENCY_${PACKAGE}_GENERATOR" "${GENERATOR}" CACHE INTERNAL "")
+
   make_directory("${SUB_DIR}")
 
   set(QUOTED_ARGS "")


### PR DESCRIPTION
If you change the generator for the cmake build directory without deleting all the files in the build directory then you'd run into errors for the packages downloaded by caffeine_dependency as they would still be using the old generator. This fixes that by deleting them if the generator has changed since the last time cmake ran.

Ultimately, it's a pretty rare error so it doesn't matter too much if it gets fixed but it's the right thing to do.