### PR TITLE
Improve cmake config and Dockerfile

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -77,7 +77,7 @@ if (CAFFEINE_ENABLE_BUILD)
 
   # LLVM Requires an exact version specification so we need to do one
   # find_package call for each LLVM version we want to support
-  find_package(LLVM 11.1)
+  find_package(LLVM 11.1 QUIET)
   if (NOT LLVM_FOUND)
     find_package(LLVM 11.0 REQUIRED)
   endif()
@@ -101,7 +101,7 @@ if (CAFFEINE_ENABLE_BUILD)
 
   make_directory("${CMAKE_BINARY_DIR}/gen/caffeine")
   configure_file(Config.h.in "${CMAKE_BINARY_DIR}/gen/caffeine/Config.h")
-  
+
   if (CAFFEINE_ENABLE_TESTS)
     enable_testing()
   endif()

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,4 +29,3 @@ RUN apt-get update \
         pkg-config \
     && update-alternatives --install /usr/local/bin/llvm-config llvm-config /usr/bin/llvm-config-11 20 \
     && rm -rf /var/lib/apt/lists/*
-RUN update-alternatives --install /usr/local/bin/llvm-config llvm-config /usr/bin/llvm-config-11 20


### PR DESCRIPTION
This commit:
* Adds the QUIET flag to a find_package call in a cmake file because if
that call fails it's not an error
* Removes a redundant update-alternatives command which is performed as
a part of the previous build step