### PR TITLE
Add optional extra Assertion to `on_path_complete`

### DIFF
--- a/include/caffeine/Interpreter/Policy.h
+++ b/include/caffeine/Interpreter/Policy.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "caffeine/IR/Assertion.h"
+
 namespace caffeine {
 
 class Context;
@@ -52,7 +54,7 @@ public:
   //
   // Note that when the exit status is `Fail` the context will continue to be
   // used for the non-failure path if it is valid.
-  virtual void on_path_complete(const Context& ctx, ExitStatus status);
+  virtual void on_path_complete(const Context& ctx, ExitStatus status, const Assertion& assertion = Assertion());
 
 protected:
   ExecutionPolicy(ExecutionPolicy&&) = default;

--- a/include/caffeine/Interpreter/Policy.h
+++ b/include/caffeine/Interpreter/Policy.h
@@ -54,7 +54,8 @@ public:
   //
   // Note that when the exit status is `Fail` the context will continue to be
   // used for the non-failure path if it is valid.
-  virtual void on_path_complete(const Context& ctx, ExitStatus status, const Assertion& assertion = Assertion());
+  virtual void on_path_complete(const Context& ctx, ExitStatus status,
+                                const Assertion& assertion = Assertion());
 
 protected:
   ExecutionPolicy(ExecutionPolicy&&) = default;

--- a/src/Interpreter/Interpreter.cpp
+++ b/src/Interpreter/Interpreter.cpp
@@ -43,7 +43,7 @@ void Interpreter::logFailure(Context& ctx, const Assertion& assertion,
     return;
 
   logger->log_failure(result.model(), ctx, Failure(assertion, message));
-  policy->on_path_complete(ctx, ExecutionPolicy::Fail);
+  policy->on_path_complete(ctx, ExecutionPolicy::Fail, assertion);
 }
 void Interpreter::queueContext(Context&& ctx) {
   policy->on_path_forked(ctx);

--- a/src/Interpreter/Policy.cpp
+++ b/src/Interpreter/Policy.cpp
@@ -5,7 +5,8 @@ namespace caffeine {
 
 void ExecutionPolicy::on_path_forked(Context&) {}
 void ExecutionPolicy::on_path_dequeued(Context&) {}
-void ExecutionPolicy::on_path_complete(const Context&, ExitStatus, const Assertion&) {}
+void ExecutionPolicy::on_path_complete(const Context&, ExitStatus,
+                                       const Assertion&) {}
 
 bool AlwaysAllowExecutionPolicy::should_queue_path(const Context&) {
   return true;

--- a/src/Interpreter/Policy.cpp
+++ b/src/Interpreter/Policy.cpp
@@ -5,7 +5,7 @@ namespace caffeine {
 
 void ExecutionPolicy::on_path_forked(Context&) {}
 void ExecutionPolicy::on_path_dequeued(Context&) {}
-void ExecutionPolicy::on_path_complete(const Context&, ExitStatus) {}
+void ExecutionPolicy::on_path_complete(const Context&, ExitStatus, const Assertion&) {}
 
 bool AlwaysAllowExecutionPolicy::should_queue_path(const Context&) {
   return true;


### PR DESCRIPTION
This PR adds an optional Assertion to `ExecutionPolicy::on_path_complete`
which will allow us to simplify the error handling of Policies (making
use of the `logFailure` handler unnecessary).

Closes #401 