### PR TITLE
Add `proven` accessor to AssertionList

### DIFF
--- a/include/caffeine/Interpreter/AssertionList.h
+++ b/include/caffeine/Interpreter/AssertionList.h
@@ -94,6 +94,7 @@ public:
   }
 
   llvm::iterator_range<const_iterator> unproven() const;
+  llvm::iterator_range<const_iterator> proven() const;
 
   /**
    * Create a checkpoint of the current position of the tail of the list. This

--- a/src/Interpreter/AssertionList.cpp
+++ b/src/Interpreter/AssertionList.cpp
@@ -99,4 +99,13 @@ AssertionList::unproven() const {
   return llvm::iterator_range<const_iterator>(it, end());
 }
 
+llvm::iterator_range<AssertionList::const_iterator>
+AssertionList::proven() const {
+  auto it = list_.iterator_at(mark_);
+  if (it != end() && !it.valid())
+    ++it;
+
+  return llvm::iterator_range<const_iterator>(begin(), it);
+}
+
 } // namespace caffeine


### PR DESCRIPTION
As in title. This is similar to the `unproven` accessor but it returns all the assertions that are proven.