### PR TITLE
Implement context store with better cache locality

### DIFF
--- a/include/caffeine/ADT/Span.h
+++ b/include/caffeine/ADT/Span.h
@@ -63,6 +63,20 @@ public:
     return size() == 0;
   }
 
+  constexpr const T& front() const {
+    return (*this)[0];
+  }
+  constexpr T& front() {
+    return (*this)[0];
+  }
+
+  constexpr const T& back() const {
+    return (*this)[size() - 1];
+  }
+  constexpr T& back() {
+    return (*this)[size() - 1];
+  }
+
   constexpr T& operator[](size_t idx) const {
     assert(idx < size());
     return data()[idx];

--- a/include/caffeine/ADT/ThreadMap.h
+++ b/include/caffeine/ADT/ThreadMap.h
@@ -1,0 +1,43 @@
+#pragma once
+
+#include <shared_mutex>
+#include <thread>
+#include <unordered_map>
+
+namespace caffeine {
+
+template <typename T>
+class ThreadMap {
+public:
+  ThreadMap() = default;
+
+  const T* get() const {
+    auto id = std::this_thread::get_id();
+    auto lock = std::shared_lock(mutex);
+
+    auto it = map.find(id);
+    return it == map.end() ? nullptr : &it->second;
+  }
+  T* get() {
+    return const_cast<T*>(const_cast<const ThreadMap<T>*>(this)->get());
+  }
+
+  T& operator*() {
+    return get_or_insert();
+  }
+
+  T& get_or_insert() {
+    if (auto* ptr = get())
+      return *ptr;
+
+    auto id = std::this_thread::get_id();
+    auto lock = std::unique_lock(mutex);
+    return map[id];
+  }
+
+private:
+  mutable std::shared_mutex mutex;
+  std::unordered_map<std::thread::id, T> map;
+};
+
+} // namespace caffeine

--- a/include/caffeine/Interpreter/Store.h
+++ b/include/caffeine/Interpreter/Store.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "caffeine/ADT/Span.h"
+#include "caffeine/ADT/ThreadMap.h"
 #include "caffeine/Interpreter/Context.h"
 #include <condition_variable>
 #include <mutex>
@@ -72,6 +73,25 @@ private:
 
   bool done = false;
   std::queue<Context> queue;
+};
+
+class ThreadQueuedContextStore : public QueueingContextStore {
+public:
+  static constexpr size_t local_cache_size = 8;
+
+public:
+  explicit ThreadQueuedContextStore(size_t num_readers,
+                                    size_t cache_size = local_cache_size);
+  ~ThreadQueuedContextStore() = default;
+
+  std::optional<Context> next_context() override;
+
+  void add_context(Context&& ctx) override;
+  void add_context_multi(Span<Context> contexts) override;
+
+private:
+  ThreadMap<std::deque<Context>> locals;
+  size_t cache_size;
 };
 
 } // namespace caffeine

--- a/src/Interpreter/Store.cpp
+++ b/src/Interpreter/Store.cpp
@@ -71,4 +71,45 @@ Context QueueingContextStore::dequeue() {
   return ctx;
 }
 
+ThreadQueuedContextStore::ThreadQueuedContextStore(size_t num_readers,
+                                                   size_t cache_size)
+    : QueueingContextStore(num_readers), cache_size(cache_size) {}
+
+std::optional<Context> ThreadQueuedContextStore::next_context() {
+  auto& queue = locals.get_or_insert();
+  if (!queue.empty()) {
+    Context ctx = std::move(queue.back());
+    queue.pop_back();
+    return ctx;
+  }
+
+  return QueueingContextStore::next_context();
+}
+
+void ThreadQueuedContextStore::add_context(Context&& ctx) {
+  auto* queue = locals.get();
+  if (!queue)
+    return QueueingContextStore::add_context(std::move(ctx));
+
+  if (queue->size() >= cache_size) {
+    QueueingContextStore::add_context(std::move(queue->front()));
+    queue->pop_front();
+  }
+
+  queue->push_back(std::move(ctx));
+}
+void ThreadQueuedContextStore::add_context_multi(Span<Context> ctxs) {
+  auto* queue = locals.get();
+  if (!queue)
+    return QueueingContextStore::add_context_multi(ctxs);
+
+  while (queue->size() < cache_size && !ctxs.empty()) {
+    queue->push_back(std::move(ctxs.front()));
+    ctxs = ctxs.subslice(1);
+  }
+
+  if (!ctxs.empty())
+    QueueingContextStore::add_context_multi(ctxs);
+}
+
 } // namespace caffeine


### PR DESCRIPTION
This PR adds an `ExecutionContextStore` which keeps a small thread-local cache of the most recent contexts that will be used first when `next_context` is called. This should hopefully allow the same context to continue to be executed by the same thread while still distributing work to others once there are a bunch of threads.