### PR TITLE
Correction to build instructions on Linux and Docker setup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,6 @@ RUN apt-get update \
     && apt-get -y install \
         llvm-11-dev \
         clang-11 \
-        clang++-11 \
         clang-format \
         libz-dev \
         build-essential \

--- a/README.md
+++ b/README.md
@@ -31,7 +31,6 @@ apt-get update \
     && apt-get -y install \
         llvm-11-dev \
         clang-11 \
-        clang++-11 \
         libz-dev \
         build-essential \
         gcc-9 \


### PR DESCRIPTION
Removed instances of `clang++-11` from the required packages since it's not a package ( [link](https://packages.ubuntu.com/focal-updates/) )