### PR TITLE
Implement `extractvalue` and `insertvalue` instructions

### DIFF
--- a/include/caffeine/Interpreter/ExprEval.h
+++ b/include/caffeine/Interpreter/ExprEval.h
@@ -136,6 +136,7 @@ public:
   LLVMValue visitInsertElement(llvm::InsertElementInst& inst);
   LLVMValue visitExtractElement(llvm::ExtractElementInst& inst);
   LLVMValue visitShuffleVector(llvm::ShuffleVectorInst& inst);
+  LLVMValue visitExtractValue(llvm::ExtractValueInst& inst);
 
 private:
   OpRef scalarize(const LLVMScalar& scalar) const;

--- a/include/caffeine/Interpreter/ExprEval.h
+++ b/include/caffeine/Interpreter/ExprEval.h
@@ -137,6 +137,7 @@ public:
   LLVMValue visitExtractElement(llvm::ExtractElementInst& inst);
   LLVMValue visitShuffleVector(llvm::ShuffleVectorInst& inst);
   LLVMValue visitExtractValue(llvm::ExtractValueInst& inst);
+  LLVMValue visitInsertValue(llvm::InsertValueInst& inst);
 
 private:
   OpRef scalarize(const LLVMScalar& scalar) const;

--- a/include/caffeine/Interpreter/Interpreter.h
+++ b/include/caffeine/Interpreter/Interpreter.h
@@ -96,6 +96,7 @@ public:
   ExecutionResult visitShuffleVectorInst(llvm::ShuffleVectorInst& inst);
   ExecutionResult visitAllocaInst(llvm::AllocaInst& inst);
   ExecutionResult visitExtractValueInst(llvm::ExtractValueInst& inst);
+  ExecutionResult visitInsertValueInst(llvm::InsertValueInst& inst);
 
   ExecutionResult visitMemCpyInst(llvm::MemCpyInst& memcpy);
   ExecutionResult visitMemMoveInst(llvm::MemMoveInst& memmove);

--- a/include/caffeine/Interpreter/Interpreter.h
+++ b/include/caffeine/Interpreter/Interpreter.h
@@ -95,6 +95,7 @@ public:
   ExecutionResult visitExtractElementInst(llvm::ExtractElementInst& inst);
   ExecutionResult visitShuffleVectorInst(llvm::ShuffleVectorInst& inst);
   ExecutionResult visitAllocaInst(llvm::AllocaInst& inst);
+  ExecutionResult visitExtractValueInst(llvm::ExtractValueInst& inst);
 
   ExecutionResult visitMemCpyInst(llvm::MemCpyInst& memcpy);
   ExecutionResult visitMemMoveInst(llvm::MemMoveInst& memmove);

--- a/include/caffeine/Interpreter/Value.h
+++ b/include/caffeine/Interpreter/Value.h
@@ -1,6 +1,7 @@
 #ifndef CAFFEINE_INTERP_VALUE_H
 #define CAFFEINE_INTERP_VALUE_H
 
+#include "caffeine/ADT/Span.h"
 #include "caffeine/IR/Operation.h"
 #include "caffeine/Memory/MemHeap.h"
 
@@ -80,17 +81,24 @@ public:
   bool is_vector() const;
   bool is_aggregate() const;
 
+  LLVMScalar& scalar();
+  Span<LLVMScalar> vector();
+  Span<LLVMValue> aggregate();
   const LLVMScalar& scalar() const;
   llvm::ArrayRef<LLVMScalar> vector() const;
   llvm::ArrayRef<LLVMValue> aggregate() const;
 
   size_t num_elements() const;
+  LLVMScalar& element(size_t idx);
   const LLVMScalar& element(size_t idx) const;
   llvm::ArrayRef<LLVMScalar> elements() const;
+  Span<LLVMScalar> elements();
 
   size_t num_members() const;
+  LLVMValue& member(size_t idx);
   const LLVMValue& member(size_t idx) const;
   llvm::ArrayRef<LLVMValue> members() const;
+  Span<LLVMValue> members();
 
 public:
   explicit operator ContextValue() const;

--- a/include/caffeine/Interpreter/Value.inl
+++ b/include/caffeine/Interpreter/Value.inl
@@ -58,6 +58,19 @@ inline bool LLVMValue::is_aggregate() const {
   return inner_.index() == Aggregate;
 }
 
+inline LLVMScalar& LLVMValue::scalar() {
+  CAFFEINE_ASSERT(is_scalar());
+  return vector()[0];
+}
+inline Span<LLVMScalar> LLVMValue::vector() {
+  CAFFEINE_ASSERT(is_vector());
+  return std::get<Vector>(inner_);
+}
+inline Span<LLVMValue> LLVMValue::aggregate() {
+  CAFFEINE_ASSERT(is_aggregate());
+  return std::get<Aggregate>(inner_);
+}
+
 inline const LLVMScalar& LLVMValue::scalar() const {
   CAFFEINE_ASSERT(is_scalar());
   return vector()[0];
@@ -74,20 +87,32 @@ inline llvm::ArrayRef<LLVMValue> LLVMValue::aggregate() const {
 inline size_t LLVMValue::num_elements() const {
   return vector().size();
 }
+inline LLVMScalar& LLVMValue::element(size_t idx) {
+  return vector()[idx];
+}
 inline const LLVMScalar& LLVMValue::element(size_t idx) const {
   return vector()[idx];
 }
 inline llvm::ArrayRef<LLVMScalar> LLVMValue::elements() const {
   return vector();
 }
+inline Span<LLVMScalar> LLVMValue::elements() {
+  return vector();
+}
 
 inline size_t LLVMValue::num_members() const {
   return aggregate().size();
+}
+inline LLVMValue& LLVMValue::member(size_t idx) {
+  return aggregate()[idx];
 }
 inline const LLVMValue& LLVMValue::member(size_t idx) const {
   return aggregate()[idx];
 }
 inline llvm::ArrayRef<LLVMValue> LLVMValue::members() const {
+  return aggregate();
+}
+inline Span<LLVMValue> LLVMValue::members() {
   return aggregate();
 }
 

--- a/src/Interpreter/ExprEval.cpp
+++ b/src/Interpreter/ExprEval.cpp
@@ -802,4 +802,15 @@ LLVMValue ExprEvaluator::visitShuffleVector(llvm::ShuffleVectorInst& inst) {
   return LLVMValue(std::move(results));
 }
 
+LLVMValue ExprEvaluator::visitExtractValue(llvm::ExtractValueInst& inst) {
+  LLVMValue result = visit(inst.getAggregateOperand());
+
+  for (unsigned idx : inst.indices()) {
+    LLVMValue member = result.member(idx);
+    result = std::move(member);
+  }
+
+  return result;
+}
+
 } // namespace caffeine

--- a/src/Interpreter/ExprEval.cpp
+++ b/src/Interpreter/ExprEval.cpp
@@ -812,5 +812,17 @@ LLVMValue ExprEvaluator::visitExtractValue(llvm::ExtractValueInst& inst) {
 
   return result;
 }
+LLVMValue ExprEvaluator::visitInsertValue(llvm::InsertValueInst& inst) {
+  LLVMValue agg = visit(inst.getAggregateOperand());
+  LLVMValue val = visit(inst.getInsertedValueOperand());
+
+  LLVMValue* ptr = &agg;
+  for (unsigned idx : inst.indices()) {
+    ptr = &ptr->member(idx);
+  }
+
+  *ptr = val;
+  return agg;
+}
 
 } // namespace caffeine

--- a/src/Interpreter/Interpreter.cpp
+++ b/src/Interpreter/Interpreter.cpp
@@ -138,6 +138,7 @@ DEF_SIMPLE_OP(InsertElementInst, InsertElementInst);
 DEF_SIMPLE_OP(ExtractElementInst, ExtractElementInst);
 DEF_SIMPLE_OP(ShuffleVectorInst, ShuffleVectorInst);
 DEF_SIMPLE_OP(ExtractValueInst, ExtractValueInst);
+DEF_SIMPLE_OP(InsertValueInst, InsertValueInst);
 
 ExecutionResult Interpreter::visitUDiv(llvm::BinaryOperator& op) {
   StackFrame& frame = ctx->stack_top();

--- a/src/Interpreter/Interpreter.cpp
+++ b/src/Interpreter/Interpreter.cpp
@@ -137,6 +137,7 @@ DEF_SIMPLE_OP(GetElementPtrInst, GetElementPtrInst);
 DEF_SIMPLE_OP(InsertElementInst, InsertElementInst);
 DEF_SIMPLE_OP(ExtractElementInst, ExtractElementInst);
 DEF_SIMPLE_OP(ShuffleVectorInst, ShuffleVectorInst);
+DEF_SIMPLE_OP(ExtractValueInst, ExtractValueInst);
 
 ExecutionResult Interpreter::visitUDiv(llvm::BinaryOperator& op) {
   StackFrame& frame = ctx->stack_top();

--- a/test/run-pass/inst/extractvalue/nested.ll
+++ b/test/run-pass/inst/extractvalue/nested.ll
@@ -1,0 +1,19 @@
+target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128"
+target triple = "x86_64-pc-linux-gnu"
+
+define void @test(i32 %x) {
+  %a = insertvalue  {{{{{{{ i32 }}}}}}} undef, i32 %x, 0, 0, 0, 0, 0, 0, 0
+  %c = extractvalue {{{{{{{ i32 }}}}}}} %a,            0, 0, 0, 0, 0, 0, 0
+  %d = icmp eq i32 %c, %x
+  call void @caffeine_assert(i1 %d)
+  ret void
+}
+
+declare dso_local void @caffeine_assume(i1 zeroext) local_unnamed_addr
+declare dso_local void @caffeine_assert(i1 zeroext) local_unnamed_addr
+
+!llvm.module.flags = !{!0}
+!llvm.ident = !{!1}
+
+!0 = !{i32 1, !"wchar_size", i32 4}
+!1 = !{!"clang version 10.0.0-4ubuntu1 "}

--- a/test/run-pass/inst/extractvalue/roundtrip.ll
+++ b/test/run-pass/inst/extractvalue/roundtrip.ll
@@ -1,0 +1,23 @@
+target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128"
+target triple = "x86_64-pc-linux-gnu"
+
+define void @test(i32 %x) {
+  %a = insertvalue { i32, i8 } undef, i32 %x, 0
+  %b = insertvalue { i32, i8 } %a, i8 1, 1
+  %c = extractvalue { i32, i8 } %b, 0
+  %d = icmp eq i32 %c, %x
+  call void @caffeine_assert(i1 %d)
+  %e = extractvalue { i32, i8 } %b, 1
+  %f = icmp eq i8 %e, 1
+  call void @caffeine_assert(i1 %f)
+  ret void
+}
+
+declare dso_local void @caffeine_assume(i1 zeroext) local_unnamed_addr
+declare dso_local void @caffeine_assert(i1 zeroext) local_unnamed_addr
+
+!llvm.module.flags = !{!0}
+!llvm.ident = !{!1}
+
+!0 = !{i32 1, !"wchar_size", i32 4}
+!1 = !{!"clang version 10.0.0-4ubuntu1 "}


### PR DESCRIPTION
These instructions allow you to interact with literal struct fields within LLVM. They're not used by most code but code generated as a result of some builtins makes use of them.

### Full Changes
- Implement `extractvalue`/`insertvalue` in `ExprEvaluator`
- Add non-const accessors to `LLVMValue` so that they can be used for `insertvalue`
- Add two test cases covering the easy case for the implementation