### PR TITLE
Implement `llvm.umul.with.overflow` intrinsic

### DIFF
--- a/include/caffeine/IR/Operation.h
+++ b/include/caffeine/IR/Operation.h
@@ -473,6 +473,11 @@ public:
   static OpRef CreateFDiv(const OpRef& lhs, const OpRef& rhs);
   static OpRef CreateFRem(const OpRef& lhs, const OpRef& rhs);
 
+  // Overflow checking methods. Return a symbolic boolean indicating whether the
+  // specified operation would overflow or underflow.
+
+  static OpRef CreateUMulOverflow(const OpRef& lhs, const OpRef& rhs);
+
   // Utility methods for creating integer arithmetic when one of the operations
   // is a constant.
 

--- a/include/caffeine/Interpreter/Interpreter.h
+++ b/include/caffeine/Interpreter/Interpreter.h
@@ -104,6 +104,8 @@ public:
 
   ExecutionResult visitDbgInfoIntrinsic(llvm::DbgInfoIntrinsic&);
 
+  ExecutionResult visitUMulWithOverflowIntrinsic(llvm::IntrinsicInst& inst);
+
 private:
   void logFailure(Context& ctx, const Assertion& assertion,
                   std::string_view message = "");

--- a/include/caffeine/Solver/Z3Solver.h
+++ b/include/caffeine/Solver/Z3Solver.h
@@ -5,6 +5,12 @@
 
 #include <memory>
 
+namespace z3 {
+class context;
+class solver;
+class expr;
+} // namespace z3
+
 namespace caffeine {
 
 class Model;
@@ -29,6 +35,10 @@ public:
 
   SolverResult resolve(AssertionList& assertions,
                        const Assertion& extra) override;
+
+  // Evaluate an expression to a z3::expr. This is exposed for testing purposes.
+  z3::context& context();
+  z3::expr evaluate(const OpRef& expr, z3::solver& solver);
 };
 
 } // namespace caffeine

--- a/src/IR/Operation.h
+++ b/src/IR/Operation.h
@@ -533,4 +533,11 @@ OpRef constant_fold(T&& value) {
   return fold(value);
 }
 
+OpRef extract_bit(const OpRef& op, uint32_t bit) {
+  CAFFEINE_ASSERT(op->type().is_int());
+  CAFFEINE_ASSERT(bit < op->type().bitwidth());
+
+  return UnaryOp::CreateTrunc(Type::int_ty(1), BinaryOp::CreateLShr(op, bit));
+}
+
 } // namespace caffeine

--- a/src/Interpreter/Interpreter.cpp
+++ b/src/Interpreter/Interpreter.cpp
@@ -366,6 +366,8 @@ ExecutionResult Interpreter::visitIntrinsicInst(llvm::IntrinsicInst& intrin) {
   case Intrinsic::lifetime_start:
   case Intrinsic::lifetime_end:
     return ExecutionResult::Continue;
+  case Intrinsic::umul_with_overflow:
+    return visitUMulWithOverflowIntrinsic(intrin);
   default:
     break;
   }

--- a/src/Interpreter/Interpreter/llvm.umul.with.overflow.cpp
+++ b/src/Interpreter/Interpreter/llvm.umul.with.overflow.cpp
@@ -1,0 +1,25 @@
+#include "caffeine/Interpreter/Interpreter.h"
+
+namespace caffeine {
+
+ExecutionResult
+Interpreter::visitUMulWithOverflowIntrinsic(llvm::IntrinsicInst& inst) {
+  auto a = ctx->lookup(inst.getArgOperand(0));
+  auto b = ctx->lookup(inst.getArgOperand(1));
+
+  auto vals = transform_exprs(
+      [&](const auto& a, const auto& b) { return BinaryOp::CreateMul(a, b); },
+      a, b);
+  auto overflow = transform_exprs(
+      [&](const auto& a, const auto& b) {
+        return BinaryOp::CreateUMulOverflow(a, b);
+      },
+      a, b);
+
+  ctx->stack_top().insert(&inst,
+                          LLVMValue(llvm::ArrayRef<LLVMValue>{vals, overflow}));
+
+  return ExecutionResult::Continue;
+}
+
+} // namespace caffeine

--- a/src/Solver/Z3Solver.cpp
+++ b/src/Solver/Z3Solver.cpp
@@ -287,6 +287,17 @@ SolverResult Z3Solver::resolve(AssertionList& assertions,
   }
 }
 
+z3::context& Z3Solver::context() {
+  return impl->ctx;
+}
+z3::expr Z3Solver::evaluate(const OpRef& expr, z3::solver& solver) {
+  CAFFEINE_ASSERT(&solver.ctx() == &context());
+  Z3Model::ConstMap constMap;
+  Z3OpVisitor visitor{&solver, constMap};
+
+  return normalize_to_bool(visitor.visit(*expr));
+}
+
 /***************************************************
  * Z3OpVisitor                                     *
  ***************************************************/

--- a/test/run-pass/intrin/umul.with.overflow/check-oversized-ints.c
+++ b/test/run-pass/intrin/umul.with.overflow/check-oversized-ints.c
@@ -22,6 +22,8 @@ void test() {
   caffeine_make_symbolic(&b, sizeof(b), "b");
 
   caffeine_assume(ilog2(a) + ilog2(b) >= 32);
+  // This is a clang builtin. Documentation here:
+  // https://clang.llvm.org/docs/LanguageExtensions.html#builtin-functions
   caffeine_assert(__builtin_umul_overflow(a, b, &r));
   caffeine_assert(r == a * b);
 }

--- a/test/run-pass/intrin/umul.with.overflow/check-oversized-ints.c
+++ b/test/run-pass/intrin/umul.with.overflow/check-oversized-ints.c
@@ -1,0 +1,27 @@
+#include "caffeine.h"
+#include <stdint.h>
+
+// ilog2 implementation from http://graphics.stanford.edu/~seander/bithacks.html
+__attribute__((noinline)) unsigned ilog2(unsigned v) {
+  unsigned int r, shift;
+
+  // clang-format off
+  r =     (v > 0xFFFF) << 4; v >>= r;
+  shift = (v > 0xFF  ) << 3; v >>= shift; r |= shift;
+  shift = (v > 0xF   ) << 2; v >>= shift; r |= shift;
+  shift = (v > 0x3   ) << 1; v >>= shift; r |= shift;
+                                          r |= (v >> 1);
+  // clang-format on
+
+  return r;
+}
+
+void test() {
+  unsigned a, b, r;
+  caffeine_make_symbolic(&a, sizeof(a), "a");
+  caffeine_make_symbolic(&b, sizeof(b), "b");
+
+  caffeine_assume(ilog2(a) + ilog2(b) >= 32);
+  caffeine_assert(__builtin_umul_overflow(a, b, &r));
+  caffeine_assert(r == a * b);
+}

--- a/test/unit/IR/Operation.cpp
+++ b/test/unit/IR/Operation.cpp
@@ -1,6 +1,8 @@
 
 #include "caffeine/IR/Operation.h"
+#include "caffeine/Solver/Z3Solver.h"
 #include <gtest/gtest.h>
+#include <z3++.h>
 
 using namespace caffeine;
 
@@ -19,4 +21,29 @@ TEST(OperationTests, const_div_by_0_does_not_fault) {
   auto value = BinaryOp::CreateUDiv(1, ConstantInt::CreateZero(64));
 
   ASSERT_TRUE(llvm::isa<ConstantInt>(*value));
+}
+
+TEST(OperationTests, umul_overflow_is_valid) {
+  Z3Solver solver;
+  z3::context& ctx = solver.context();
+  z3::solver z3solver{ctx};
+
+  for (uint32_t bitwidth = 1; bitwidth <= 128; bitwidth += (bitwidth + 2) / 3) {
+    auto c1 = Constant::Create(Type::int_ty(bitwidth), "a");
+    auto c2 = Constant::Create(Type::int_ty(bitwidth), "b");
+    auto ovf = BinaryOp::CreateUMulOverflow(c1, c2);
+    auto new_expr = solver.evaluate(ovf, z3solver);
+
+    auto ref_expr = !z3::bvmul_no_overflow(ctx.bv_const("a", bitwidth),
+                                           ctx.bv_const("b", bitwidth), false);
+
+    z3solver.add(new_expr != ref_expr);
+    z3solver.add(new_expr == ctx.bool_const("new"));
+    z3solver.add(ref_expr == ctx.bool_const("ref"));
+
+    z3::check_result res = z3solver.check();
+
+    ASSERT_EQ(res, z3::unsat) << "model:\n" << z3solver.get_model();
+    z3solver.reset();
+  }
 }


### PR DESCRIPTION
As in title. As any test case that's going to use this will involve the `extractvalue` instruction I'm stacking it on top of #417. Since `Interpreter.cpp` is getting large I've decided to put the implementation for this method into it's own file. I've also added a test case that verifies some of the behaviour.

The implementation of overflow checking is based of the technique described in the paper [here](https://citeseerx.ist.psu.edu/viewdoc/download?doi=10.1.1.37.4513&rep=rep1&type=pdf). It is a similar technique to what Z3 uses. I did this to avoid having to introduce a new opcode. I've included a test case showing that it is equivalent to the version Z3 has which should be enough to show that it is correct.

/stack #417
Closes #337 