### PR TITLE
Implement `llvm.smul.with.overflow` intrinsic

### DIFF
--- a/include/caffeine/IR/Operation.h
+++ b/include/caffeine/IR/Operation.h
@@ -477,6 +477,7 @@ public:
   // specified operation would overflow or underflow.
 
   static OpRef CreateUMulOverflow(const OpRef& lhs, const OpRef& rhs);
+  static OpRef CreateSMulOverflow(const OpRef& lhs, const OpRef& rhs);
 
   // Utility methods for creating integer arithmetic when one of the operations
   // is a constant.

--- a/include/caffeine/Interpreter/Interpreter.h
+++ b/include/caffeine/Interpreter/Interpreter.h
@@ -105,6 +105,7 @@ public:
   ExecutionResult visitDbgInfoIntrinsic(llvm::DbgInfoIntrinsic&);
 
   ExecutionResult visitUMulWithOverflowIntrinsic(llvm::IntrinsicInst& inst);
+  ExecutionResult visitSMulWithOverflowIntrinsic(llvm::IntrinsicInst& inst);
 
 private:
   void logFailure(Context& ctx, const Assertion& assertion,

--- a/src/Interpreter/Interpreter.cpp
+++ b/src/Interpreter/Interpreter.cpp
@@ -368,6 +368,8 @@ ExecutionResult Interpreter::visitIntrinsicInst(llvm::IntrinsicInst& intrin) {
     return ExecutionResult::Continue;
   case Intrinsic::umul_with_overflow:
     return visitUMulWithOverflowIntrinsic(intrin);
+  case Intrinsic::smul_with_overflow:
+    return visitSMulWithOverflowIntrinsic(intrin);
   default:
     break;
   }

--- a/src/Interpreter/Interpreter/llvm.smul.with.overflow.cpp
+++ b/src/Interpreter/Interpreter/llvm.smul.with.overflow.cpp
@@ -1,0 +1,25 @@
+#include "caffeine/Interpreter/Interpreter.h"
+
+namespace caffeine {
+
+ExecutionResult
+Interpreter::visitSMulWithOverflowIntrinsic(llvm::IntrinsicInst& inst) {
+  auto a = ctx->lookup(inst.getArgOperand(0));
+  auto b = ctx->lookup(inst.getArgOperand(1));
+
+  auto vals = transform_exprs(
+      [&](const auto& a, const auto& b) { return BinaryOp::CreateMul(a, b); },
+      a, b);
+  auto overflow = transform_exprs(
+      [&](const auto& a, const auto& b) {
+        return BinaryOp::CreateSMulOverflow(a, b);
+      },
+      a, b);
+
+  ctx->stack_top().insert(&inst,
+                          LLVMValue(llvm::ArrayRef<LLVMValue>{vals, overflow}));
+
+  return ExecutionResult::Continue;
+}
+
+} // namespace caffeine


### PR DESCRIPTION
As in title. This is pretty similar to the `llvm.umul.with.overflow` intrinsic and the actual bitwise logic used to calculate it is pulled from the same paper as with the unsigned version.

/stack #418 
Closes #414