### PR TITLE
Change command line entry point to no longer be a mandatory argument

### DIFF
--- a/cmake/CaffeineTestUtils.cmake
+++ b/cmake/CaffeineTestUtils.cmake
@@ -148,7 +148,7 @@ function(declare_test TEST_NAME_OUT test EXPECTED)
   else()
     add_test(
       NAME "${test_name}"
-      COMMAND caffeine-bin ${TEST_FLAGS} "${DIS_OUT}" main
+      COMMAND caffeine-bin ${TEST_FLAGS} "${DIS_OUT}"
     )
   endif()
 

--- a/include/caffeine/Interpreter/Context.h
+++ b/include/caffeine/Interpreter/Context.h
@@ -36,6 +36,8 @@ private:
 
 public:
   Context(llvm::Function* func);
+  Context(llvm::Function* func,
+          const std::unordered_map<llvm::Value*, OpRef>& args);
 
   /**
    * Create a new context that is independent from this
@@ -143,6 +145,8 @@ public:
   void print_backtrace(std::ostream& OS) const;
 
 private:
+  void init_args(const std::unordered_map<llvm::Value*, OpRef>& args);
+
   // TODO: Temporary until context redesign is completed
   friend class ExprEvaluator;
 };

--- a/include/caffeine/Interpreter/Context.h
+++ b/include/caffeine/Interpreter/Context.h
@@ -36,6 +36,12 @@ private:
 
 public:
   Context(llvm::Function* func);
+  // Create a context for a function and provide initial values for it's
+  // arguments. This is necessary if you want to symbolically execute a function
+  // with arguments as the inital function.
+  //
+  // Note that main is currently special-cased by the other constructor so it
+  // can be run without having to provide arguments.
   Context(llvm::Function* func, llvm::ArrayRef<OpRef> args);
 
   /**

--- a/include/caffeine/Interpreter/Context.h
+++ b/include/caffeine/Interpreter/Context.h
@@ -36,8 +36,7 @@ private:
 
 public:
   Context(llvm::Function* func);
-  Context(llvm::Function* func,
-          const std::unordered_map<llvm::Value*, OpRef>& args);
+  Context(llvm::Function* func, llvm::ArrayRef<OpRef> args);
 
   /**
    * Create a new context that is independent from this
@@ -145,7 +144,7 @@ public:
   void print_backtrace(std::ostream& OS) const;
 
 private:
-  void init_args(const std::unordered_map<llvm::Value*, OpRef>& args);
+  void init_args(llvm::ArrayRef<OpRef> args);
 
   // TODO: Temporary until context redesign is completed
   friend class ExprEvaluator;

--- a/scripts/gen-yarpgen-tests.sh
+++ b/scripts/gen-yarpgen-tests.sh
@@ -86,7 +86,7 @@ llvm_compile_options    ("yarpgen-${testname}" PRIVATE -O3 -w)
 
 add_test(
   NAME "yarpgen/${testname}"
-  COMMAND caffeine-bin "$<TARGET_PROPERTY:yarpgen-${testname},OUTPUT>" main
+  COMMAND caffeine-bin "$<TARGET_PROPERTY:yarpgen-${testname},OUTPUT>"
 )
 EOM
 

--- a/src/Interpreter/Context.cpp
+++ b/src/Interpreter/Context.cpp
@@ -12,31 +12,15 @@
 
 namespace caffeine {
 
-static void assert_valid_arg(llvm::Type* type) {
-  if (type->isIntegerTy() || type->isFloatingPointTy()) {
-    return;
-  }
-
-  std::string message;
-  llvm::raw_string_ostream os{message};
-  os << "Unsupported LLVM type: ";
-  type->print(os);
-
-  CAFFEINE_ABORT(message);
-}
-
 Context::Context(llvm::Function* function,
                  const std::unordered_map<llvm::Value*, OpRef>& args)
     : mod(function->front().getModule()) {
   stack.emplace_back(function);
-  StackFrame& frame = stack_top();
-
   init_args(args);
 }
 Context::Context(llvm::Function* function)
     : mod(function->front().getModule()) {
   stack.emplace_back(function);
-  StackFrame& frame = stack_top();
 
   const llvm::DataLayout& layout = mod->getDataLayout();
   if (function->getName() == "main" && function->arg_size() == 2) {
@@ -65,7 +49,7 @@ void Context::init_args(const std::unordered_map<llvm::Value*, OpRef>& args) {
                   "entry-point function");
 
   auto& frame = stack_top();
-  for (auto arg : function->args()) {
+  for (auto& arg : function->args()) {
     auto it = args.find(&arg);
     CAFFEINE_ASSERT(
         it != args.end(),

--- a/tools/caffeine/main.cpp
+++ b/tools/caffeine/main.cpp
@@ -42,7 +42,9 @@ public:
 
 cl::opt<std::string> input_filename{cl::Positional};
 cl::opt<std::string> entry{
-    "entry", cl::desc("Entry method that will be executed by caffeine. [default = main]"),
+    "entry",
+    cl::desc(
+        "Entry method that will be executed by caffeine. [default = main]"),
     cl::value_desc("function"), cl::init("main")};
 cl::opt<bool> invert_exitcode{
     "invert-exitcode",

--- a/tools/caffeine/main.cpp
+++ b/tools/caffeine/main.cpp
@@ -41,7 +41,9 @@ public:
 };
 
 cl::opt<std::string> input_filename{cl::Positional};
-cl::opt<std::string> target_method{cl::Positional};
+cl::opt<std::string> entry{
+    "entry", cl::desc("Entry method that will be executed by caffeine. [default = main]"),
+    cl::value_desc("function"), cl::init("main")};
 cl::opt<bool> invert_exitcode{
     "invert-exitcode",
     cl::desc("invert the exit code. 0 if the program returns a failure, 1 "
@@ -111,10 +113,10 @@ int main(int argc, char** argv) {
     return 2;
   }
 
-  auto function = module->getFunction(target_method.getValue());
+  auto function = module->getFunction(entry.getValue());
   if (!function) {
     errs() << argv[0] << ": ";
-    WithColor::error() << " no method '" << target_method.getValue() << "'\n";
+    WithColor::error() << " no method '" << entry.getValue() << "'\n";
     return 2;
   }
 


### PR DESCRIPTION
Previously the entry point was a mandatory positional argument. However, we almost always want to use `main` as the entry point so it doesn't make sense for it to be a required argument. This PR changes it to be a flag `--entry` with the default value of `main`.

I've also removed the code that will automatically generate symbolic constants for the arguments of the entry point method. I have, however, left the special casing for `main` so that existing tests continue to work.