### PR TITLE
Fix race condition for makefile builds

### DIFF
--- a/bench/CMakeLists.txt
+++ b/bench/CMakeLists.txt
@@ -1,5 +1,6 @@
 
 include(LLVMIRUtils)
+include(CaffeineUtils)
 
 function(caffeine_benchmark NAME)
   set(sources "${ARGN}")
@@ -10,21 +11,20 @@ function(caffeine_benchmark NAME)
   llvm_include_directories(${target} PRIVATE "${CMAKE_SOURCE_DIR}/interface")
   llvm_link_libraries     (${target} PRIVATE caffeine-builtins)
 
-  add_custom_command(
+  caffeine_custom_command(
+    TARGET "gen-${target}" ALL
     OUTPUT "${target}.ll"
-    MAIN_DEPENDENCY "${out_dir}/lib.bc"
     COMMAND "${LLVM_OPT}" ARGS
       -O3
       --internalize
       --internalize-public-api-list main
       --globaldce
       -o "${out_dir}/optimized.bc"
-      "${out_dir}/lib.bc"
+      "$<TARGET_PROPERTY:${target},OUTPUT>"
     COMMAND "${LLVM_DIS}" ARGS "${out_dir}/optimized.bc" -o "${target}.ll"
     COMMENT "Optimizing bench-${NAME}"
+    DEPENDS ${target}
   )
-
-  add_custom_target("gen-${target}" ALL DEPENDS "${target}.ll")
 endfunction()
 
 caffeine_benchmark(maze          maze.c)

--- a/cmake/CaffeineUtils.cmake
+++ b/cmake/CaffeineUtils.cmake
@@ -1,0 +1,38 @@
+
+# A wrapper around add_custom_command that also generates a
+# target that wraps the generated file.
+#
+# Takes all the arguments of add_custom_command as well as some
+# extra arguments:
+# - TARGET: The name of the wrapper target to generate.
+# - ALL:    Flag to specify whether the target should be built as
+#           part of the ALL target. 
+function(caffeine_custom_command)
+  cmake_parse_arguments(PARSE_ARGV 0 ARG 
+    "ALL"
+    "TARGET;OUTPUT"
+    "SOURCES"
+  )
+  
+  if (ARG_ALL)
+    set(ARG_ALL ALL)
+  else()
+    set(ARG_ALL "")
+  endif()
+
+  add_custom_command(
+    OUTPUT "${ARG_OUTPUT}"
+    ${ARG_UNPARSED_ARGUMENTS}
+  )
+
+  add_custom_target(
+    "${ARG_TARGET}" ${ARG_ALL}
+    DEPENDS "${ARG_OUTPUT}"
+    SOURCES ${ARG_SOURCES}
+  )
+
+  set_target_properties(
+    "${ARG_TARGET}" PROPERTIES
+    OUTPUT "${ARG_OUTPUT}"
+  )
+endfunction()

--- a/cmake/LLVMIRUtils.cmake
+++ b/cmake/LLVMIRUtils.cmake
@@ -10,6 +10,8 @@
 #   that you would normally use for a library target will work here as
 #   well.
 
+include(CaffeineUtils)
+
 if (NOT DEFINED LLVM_FOUND)
   find_package(LLVM REQUIRED)
 endif()
@@ -109,22 +111,6 @@ function(llvm_library TARGET_NAME)
   set(counter 0)
   set(library "${ARG_OUTPUT}")
   set(linked  "${intermediate_dir}/linked${target_ext}")
-
-  add_custom_target(
-    "${TARGET_NAME}" ALL
-    DEPENDS "${library}"
-    SOURCES ${sources}
-  )
-
-  set_target_properties(
-    "${TARGET_NAME}"
-    PROPERTIES
-    OUTPUT              "${library}"
-    OUTPUT_NAME         "${TARGET_NAME}${target_ext}"
-    LIBRARY_OUTPUT_PATH "${CMAKE_CURRENT_BINARY_DIR}"
-    IS_LLVM_LIBRARY     TRUE
-    LLVM_LINK_DEPENDS   ""
-  )
 
   foreach(source ${sources})
     get_property(source_language SOURCE "${source}" PROPERTY LANGUAGE)
@@ -230,7 +216,9 @@ function(llvm_library TARGET_NAME)
     COMMAND_EXPAND_LISTS
   )
 
-  add_custom_command(
+  caffeine_custom_command(
+    TARGET "${TARGET_NAME}" ALL
+    SOURCES ${sources}
     OUTPUT "${library}"
     COMMAND "${LLVM_OPT}" ARGS
       --load="$<TARGET_FILE:caffeine-opt-plugin>"
@@ -240,6 +228,15 @@ function(llvm_library TARGET_NAME)
     MAIN_DEPENDENCY "${linked}"
     DEPENDS "$<TARGET_FILE:caffeine-opt-plugin>"
     COMMENT "Generating builtin methods for ${library}"
+  )
+
+  set_target_properties(
+    "${TARGET_NAME}"
+    PROPERTIES
+    OUTPUT_NAME         "${TARGET_NAME}${target_ext}"
+    LIBRARY_OUTPUT_PATH "${CMAKE_CURRENT_BINARY_DIR}"
+    IS_LLVM_LIBRARY     TRUE
+    LLVM_LINK_DEPENDS   ""
   )
 endfunction()
 


### PR DESCRIPTION
The problem was that file dependencies can be duplicated by the makefile generator. The solution is to wrap the files generated by add_custom_command calls with a custom target so that they don't get duplicated when cmake generates the makefiles.

The solution and problem explanation can be found on this blog post: https://samthursfield.wordpress.com/2015/11/21/cmake-dependencies-between-targets-and-files-and-custom-commands/

Closes #404 