### PR TITLE
Fix some issues with test coverage generation

### DIFF
--- a/.github/workflows/find-coverage.yml
+++ b/.github/workflows/find-coverage.yml
@@ -26,11 +26,7 @@ jobs:
           cmake -B build \
             -DCAFFEINE_CI=ON \
             -DCMAKE_BUILD_TYPE=RelWithDebInfo \
-            -DCAFFEINE_ENABLE_UBSAN=ON \
-            -DCAFFEINE_ENABLE_LIBC=ON \
-            -DCAFFEINE_ENABLE_ASAN=ON \
-            -DCAFFEINE_ENABLE_COVERAGE=ON \
-            -DCMAKE_BUILD_TYPE=Debug
+            -DCAFFEINE_ENABLE_COVERAGE=ON
 
       - name: Build
         run: cmake --build "build" -j$(nproc)
@@ -49,7 +45,8 @@ jobs:
           cd build
           find . -name "*.profraw"
           llvm-profdata-11 merge -sparse `find . -name "*.profraw"` -o default.profdata
-          llvm-cov-11 show -instr-profile ./default.profdata bin/caffeine-unittest -format=text > coverage.txt
+          llvm-cov-11 show -instr-profile default.profdata bin/caffeine-unittest caffeine \
+            -format=text > coverage.txt
           apt update && apt install curl # this is a bandaid until we get curl in the container
           curl -s https://codecov.io/bash > codecov.sh
           bash codecov.sh -t $CODECOV_TOKEN

--- a/cmake/CaffeineTestUtils.cmake
+++ b/cmake/CaffeineTestUtils.cmake
@@ -148,7 +148,7 @@ function(declare_test TEST_NAME_OUT test EXPECTED)
       add_test(
         NAME "${test_name}"
         COMMAND "${CMAKE_COMMAND}" -E env 
-          "LLVM_PROFILE_FILE=${test_target}.profraw"
+          "LLVM_PROFILE_FILE=${test_target}.%p.profraw"
         "$<TARGET_FILE:caffeine-bin>" ${TEST_FLAGS} "${DIS_OUT}"
       )
     else()

--- a/cmake/CaffeineTestUtils.cmake
+++ b/cmake/CaffeineTestUtils.cmake
@@ -144,10 +144,19 @@ function(declare_test TEST_NAME_OUT test EXPECTED)
       COMMAND skip-test "${DIS_OUT}"
     )
   else()
-    add_test(
-      NAME "${test_name}"
-      COMMAND caffeine-bin ${TEST_FLAGS} "${DIS_OUT}"
-    )
+    if (CAFFEINE_ENABLE_COVERAGE)
+      add_test(
+        NAME "${test_name}"
+        COMMAND "${CMAKE_COMMAND}" -E env 
+          "LLVM_PROFILE_FILE=${test_target}.profraw"
+        "$<TARGET_FILE:caffeine-bin>" ${TEST_FLAGS} "${DIS_OUT}"
+      )
+    else()
+      add_test(
+        NAME "${test_name}"
+        COMMAND caffeine-bin ${TEST_FLAGS} "${DIS_OUT}"
+      )
+    endif()
   endif()
 
   set("${TEST_NAME_OUT}" "${test_name}" PARENT_SCOPE)

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -18,7 +18,7 @@ target_include_directories(caffeine-unittest PRIVATE "${CMAKE_CURRENT_SOURCE_DIR
 target_include_directories(caffeine-unittest PRIVATE "${CMAKE_SOURCE_DIR}")
 target_include_directories(caffeine-unittest PRIVATE "${CMAKE_BINARY_DIR}/gen/")
 
-if (${CMAKE_VERSION} VERSION_LESS "3.10.0")
+if (${CMAKE_VERSION} VERSION_LESS "3.10.0" OR CAFFEINE_ENABLE_COVERAGE)
   add_test(NAME unit-tests COMMAND caffeine-unittest)
 else()
   # This lists all the tests individually

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -18,7 +18,14 @@ target_include_directories(caffeine-unittest PRIVATE "${CMAKE_CURRENT_SOURCE_DIR
 target_include_directories(caffeine-unittest PRIVATE "${CMAKE_SOURCE_DIR}")
 target_include_directories(caffeine-unittest PRIVATE "${CMAKE_BINARY_DIR}/gen/")
 
-if (${CMAKE_VERSION} VERSION_LESS "3.10.0" OR CAFFEINE_ENABLE_COVERAGE)
+if (CAFFEINE_ENABLE_COVERAGE)
+  add_test(
+    NAME unit-tests 
+    COMMAND "${CMAKE_COMMAND}" -E env
+      "LLVM_PROFILE_FILE=default.%p.profraw"
+      "$<TARGET_FILE:caffeine-unittest>"
+  )
+elseif (${CMAKE_VERSION} VERSION_LESS "3.10.0")
   add_test(NAME unit-tests COMMAND caffeine-unittest)
 else()
   # This lists all the tests individually


### PR DESCRIPTION
Previously the generated `default.profraw` file for all the test cases would all overwrite each other when being executed. In larger parallel builds this usually led to corrupted coverage info. Even if it worked it would result in the reports missing data for the other test cases.

This fixes that by doing a couple of different things:
1. When coverage is enabled we run caffeine-unittest all at once instead of generating a different cmake test case for each contained test.
2. We use the `LLVM_PROFDATA_FILE` env var to make the run-file tests generate their profiling data with a different filename for  test.

There's still some holes in this (googletest death tests don't properly generate coverage at the moment) but it should be better than the status quo.