### PR TITLE
Various fixups to afl-guided-mutator

### DIFF
--- a/include/caffeine/ADT/Span.h
+++ b/include/caffeine/ADT/Span.h
@@ -52,8 +52,10 @@ public:
   template <typename Traits, typename Alloc>
   constexpr Span(std::basic_string<T, Traits, Alloc>& str)
       : Span(str.data(), str.size()) {}
-  template <typename Traits, bool is_const = std::is_const_v<T>,
-            typename U = std::enable_if_t<is_const>>
+  template <typename Traits,
+            bool is_valid = std::is_const_v<T> &&
+                            (sizeof(std::char_traits<T>) > 0),
+            typename U = std::enable_if_t<is_valid>>
   constexpr Span(std::basic_string_view<std::remove_const_t<T>, Traits> view)
       : Span(view.data(), view.size()) {}
 
@@ -101,10 +103,14 @@ public:
     return std::make_reverse_iterator(begin());
   }
 
-  constexpr std::basic_string_view<T> view() const {
-    return std::basic_string_view<T>(data(), size());
+  template <bool is_valid = std::is_same_v<std::remove_const_t<T>, char>,
+            typename = std::enable_if_t<is_valid>>
+  constexpr std::string_view view() const {
+    return std::string_view(data(), size());
   }
-  constexpr operator std::basic_string_view<T>() const {
+  template <bool is_valid = std::is_same_v<std::remove_const_t<T>, char>,
+            typename = std::enable_if_t<is_valid>>
+  constexpr operator std::string_view() const {
     return view();
   }
 

--- a/include/caffeine/ADT/Span.h
+++ b/include/caffeine/ADT/Span.h
@@ -8,6 +8,7 @@
 #include <initializer_list>
 #include <iterator>
 #include <string>
+#include <type_traits>
 #include <vector>
 
 #include <llvm/ADT/SmallVector.h>
@@ -51,6 +52,10 @@ public:
   template <typename Traits, typename Alloc>
   constexpr Span(std::basic_string<T, Traits, Alloc>& str)
       : Span(str.data(), str.size()) {}
+  template <typename Traits, bool is_const = std::is_const_v<T>,
+            typename U = std::enable_if_t<is_const>>
+  constexpr Span(std::basic_string_view<std::remove_const_t<T>, Traits> view)
+      : Span(view.data(), view.size()) {}
 
   constexpr size_t size() const {
     return size_;
@@ -94,6 +99,13 @@ public:
   }
   constexpr reverse_iterator rend() const {
     return std::make_reverse_iterator(begin());
+  }
+
+  constexpr std::basic_string_view<T> view() const {
+    return std::basic_string_view<T>(data(), size());
+  }
+  constexpr operator std::basic_string_view<T>() const {
+    return view();
   }
 
   // Get a new span that is a subsection of this span.

--- a/tools/guided-fuzzing/include/CaffeineMutator.h
+++ b/tools/guided-fuzzing/include/CaffeineMutator.h
@@ -16,7 +16,7 @@ extern "C" {
 
 namespace caffeine {
 
-typedef std::vector<SharedArray> TestCaseStorage;
+typedef std::vector<std::string> TestCaseStorage;
 typedef std::shared_ptr<TestCaseStorage> TestCaseStoragePtr;
 
 struct CaffeineMutator {
@@ -30,6 +30,8 @@ private:
   std::mutex termination_mutex;
   bool terminated = false;
   TestCaseStoragePtr cases = std::make_shared<TestCaseStorage>();
+
+  std::string last_case;
 
 public:
   std::shared_ptr<Solver> solver;

--- a/tools/guided-fuzzing/include/GuidedExecutionPolicy.h
+++ b/tools/guided-fuzzing/include/GuidedExecutionPolicy.h
@@ -20,11 +20,11 @@ namespace caffeine {
 class GuidedExecutionPolicy : public ExecutionPolicy {
   CaffeineMutator* mutator;
   TestCaseStoragePtr cases;
-  caffeine::Span<char> data;
+  std::string data;
   std::string symbol_name;
 
 public:
-  GuidedExecutionPolicy(caffeine::Span<char> data, std::string symbol_name,
+  GuidedExecutionPolicy(std::string_view data, std::string symbol_name,
                         CaffeineMutator* mutator, TestCaseStoragePtr cases);
   ~GuidedExecutionPolicy() = default;
 

--- a/tools/guided-fuzzing/src/GuidedExecutionPolicy.cpp
+++ b/tools/guided-fuzzing/src/GuidedExecutionPolicy.cpp
@@ -23,7 +23,6 @@ GuidedExecutionPolicy::GuidedExecutionPolicy(std::string_view data,
 }
 
 bool GuidedExecutionPolicy::should_queue_path(const Context& ctx) {
-  auto traceblock = CAFFEINE_TRACE_SPAN("should_queue_path");
   auto symbolic_buffer = ctx.constants.find(symbol_name);
   if (symbolic_buffer == nullptr) {
     // Since our symbolic allocation is currently not in scope we just continue

--- a/tools/guided-fuzzing/src/GuidedExecutionPolicy.cpp
+++ b/tools/guided-fuzzing/src/GuidedExecutionPolicy.cpp
@@ -1,24 +1,20 @@
 #include "GuidedExecutionPolicy.h"
 
 #include "caffeine/Interpreter/Interpreter.h"
+#include "caffeine/Support/Tracing.h"
 
 #include <iostream>
 
 namespace caffeine {
 
-Assertion create_size_assertion(const OpRef* data, size_t size) {
-  auto fixed_array = llvm::dyn_cast<FixedArray>(data->get());
-  if (fixed_array) {
-    return Assertion(ICmpOp::CreateICmpEQ(fixed_array->size(), size));
-  }
+Assertion create_size_assertion(const OpRef& data, size_t size) {
+  auto array = llvm::dyn_cast<ArrayBase>(data.get());
+  CAFFEINE_ASSERT(array, "OpRef `data` must be an array type");
 
-  auto constant_array = llvm::dyn_cast<ConstantArray>(data->get());
-  CAFFEINE_ASSERT(constant_array,
-                  "OpRef `data` must be either a FixedArray or ConstantArray");
-  return Assertion(ICmpOp::CreateICmpEQ(constant_array->size(), size));
+  return Assertion(ICmpOp::CreateICmpEQ(array->size(), size));
 }
 
-GuidedExecutionPolicy::GuidedExecutionPolicy(caffeine::Span<char> data,
+GuidedExecutionPolicy::GuidedExecutionPolicy(std::string_view data,
                                              std::string symbol_name,
                                              CaffeineMutator* mutator,
                                              TestCaseStoragePtr cases)
@@ -27,6 +23,7 @@ GuidedExecutionPolicy::GuidedExecutionPolicy(caffeine::Span<char> data,
 }
 
 bool GuidedExecutionPolicy::should_queue_path(const Context& ctx) {
+  auto traceblock = CAFFEINE_TRACE_SPAN("should_queue_path");
   auto symbolic_buffer = ctx.constants.find(symbol_name);
   if (symbolic_buffer == nullptr) {
     // Since our symbolic allocation is currently not in scope we just continue
@@ -34,58 +31,37 @@ bool GuidedExecutionPolicy::should_queue_path(const Context& ctx) {
   }
 
   AssertionList combined = ctx.assertions;
-  combined.insert(create_size_assertion(symbolic_buffer, data.size()));
+  combined.insert(create_size_assertion(*symbolic_buffer, data.size()));
 
   const llvm::DataLayout& layout = ctx.mod->getDataLayout();
   unsigned bitwidth = layout.getPointerSizeInBits();
 
-  // Small hack: if we have a FixedArray, and AFL tries to pass in a
-  // larger testcase, we get an assertion failure. To fix this, we take
-  // the minimum of the AFL data, and the FixedArray length.
-  size_t array_len = data.size();
-  auto fixed_array = llvm::dyn_cast<FixedArray>(symbolic_buffer->get());
-  if (fixed_array && fixed_array->data().size() > data.size()) {
-    return false;
-  } else if (fixed_array) {
-    array_len = std::min(array_len, fixed_array->data().size());
-  }
-
-  for (size_t i = 0; i < array_len; i++) {
+  for (size_t i = 0; i < data.size(); i++) {
     combined.insert(Assertion(ICmpOp::CreateICmpEQ(
         LoadOp::Create(*symbolic_buffer,
                        ConstantInt::Create(llvm::APInt(bitwidth, i))),
-        data.data()[i])));
+        (uint8_t)data[i])));
   }
 
-  auto all_assertions_sat = mutator->solver->resolve(combined);
-  if (all_assertions_sat.kind() == SolverResult::Kind::SAT) {
-    all_assertions_sat.evaluate(*ctx.constants.find(symbol_name)->get())
-        .array();
-    cases->push_back(mutator->model_to_testcase(all_assertions_sat.model(), ctx,
-                                                symbol_name));
-    return true;
-  }
-
-  AssertionList assertions_copy = ctx.assertions;
-  SolverResult partial = mutator->solver->resolve(assertions_copy);
-  if (partial.kind() == SolverResult::Kind::SAT) {
-    partial.evaluate(*ctx.constants.find(symbol_name)->get()).array();
-    cases->push_back(
-        mutator->model_to_testcase(partial.model(), ctx, symbol_name));
-  }
-
-  return false;
+  return mutator->solver->check(combined) == SolverResult::SAT;
 }
 
-void GuidedExecutionPolicy::on_path_complete(const Context& ctx,
-                                             ExitStatus status,
+void GuidedExecutionPolicy::on_path_complete(const Context& ctx, ExitStatus,
                                              const Assertion& assertion) {
-  if (status == ExitStatus::Fail) {
-    Context ctx_copy = ctx;
-    cases->push_back(mutator->model_to_testcase(
-        ctx_copy.resolve(mutator->solver, assertion).model(), ctx_copy,
-        symbol_name));
-  }
+  auto assertions = ctx.assertions;
+  auto result = mutator->solver->resolve(assertions, assertion);
+
+  if (result != SolverResult::SAT)
+    return;
+
+  auto tc = mutator->model_to_testcase(result.model(), ctx, symbol_name);
+  std::string_view tcdata(tc.data(), tc.size());
+
+  // Don't mutate to a no-change test case
+  if (tcdata == data)
+    return;
+
+  cases->emplace_back(tcdata);
 }
 
 } // namespace caffeine

--- a/tools/guided-fuzzing/src/SymbolicMutator.cpp
+++ b/tools/guided-fuzzing/src/SymbolicMutator.cpp
@@ -3,12 +3,12 @@ extern "C" {
 }
 
 #include <cstdlib>
-#include <fstream>
-#include <iostream>
 #include <string>
 
 #include "CaffeineMutator.h"
 #include "caffeine/ADT/Span.h"
+
+unsigned count = 0;
 
 extern "C" {
 
@@ -21,10 +21,9 @@ caffeine::CaffeineMutator* afl_custom_init(afl_state_t* afl, unsigned int) {
   return mut;
 }
 
-size_t afl_custom_fuzz(caffeine::CaffeineMutator* data, unsigned char* in_buf,
-                       size_t, unsigned char** out_buf, unsigned char*, size_t,
+size_t afl_custom_fuzz(caffeine::CaffeineMutator* data, unsigned char*, size_t,
+                       unsigned char** out_buf, unsigned char*, size_t,
                        size_t max_size) {
-  *out_buf = in_buf; // Prevent AFL from thinking there was an error
   return data->get_testcase(out_buf, max_size);
 }
 


### PR DESCRIPTION
I spent at least 6 hours debugging why this didn't work only to discover it was mainly due to different optimization settings when building the test case. However I also made a bunch of changes that I felt were worth having.

## Detailed List of Changes
- Add conversions between `Span` and `std::string_view`. (not really a part of the change but I don't really want to make a separate PR for this)
- Test cases are now stored as `std::string` instances instead of `SharedArray`
- There is now a separate entry point `__caffeine_entry_point` instead of calling `main`.  This allows us to set the size of the symbolic constant appropriately without having to resort to a symbolic size. It also means that it should be able to be linked into a real program without too much of an issue.
- Put the slicing solver into the solver stack. (We should probably have a builder for this)
- Moved test case generation from `should_queue_path` to `on_path_complete` since it's guaranteed to be called for every path.
- Added a check that prevents us from performing an empty mutation since just returning the same test case really isn't that useful.
- Fixed a memory leak due to allocating a buffer with `malloc` and assuming that AFL frees it when it does not.