### PR TITLE
Cover more of `Operation.cpp` and `Value.cpp`

### DIFF
--- a/src/IR/Operation.cpp
+++ b/src/IR/Operation.cpp
@@ -775,14 +775,7 @@ OpRef ICmpOp::CreateICmp(ICmpOpcode cmp, int64_t lhs, const OpRef& rhs) {
       rhs);
 }
 OpRef ICmpOp::CreateICmp(ICmpOpcode cmp, const OpRef& lhs, int64_t rhs) {
-  CAFFEINE_ASSERT(lhs, "rhs was null");
-  CAFFEINE_ASSERT(lhs->type().is_int(),
-                  "icmp can only be created with integer operands");
-
-  auto literal = llvm::APInt(64, static_cast<uint64_t>(rhs));
-  return ICmpOp::CreateICmp(
-      cmp, lhs,
-      ConstantInt::Create(literal.sextOrTrunc(lhs->type().bitwidth())));
+  return ICmpOp::CreateICmp(cmp, rhs, lhs);
 }
 
 /***************************************************

--- a/test/unit/IR/Value.cpp
+++ b/test/unit/IR/Value.cpp
@@ -51,8 +51,7 @@ TEST(ir_value, sdiv_invalid_does_not_fault) {
 
 TEST(ir_value, print_int) {
   auto ci = ConstantInt::Create(llvm::APInt(32, 1337));
-  auto constant_int = llvm::dyn_cast<ConstantInt>(
-      ci.get());
+  auto constant_int = llvm::dyn_cast<ConstantInt>(ci.get());
   ASSERT_TRUE(constant_int);
 
   std::stringstream output;
@@ -62,8 +61,7 @@ TEST(ir_value, print_int) {
 
 TEST(ir_value, print_float) {
   auto cf = ConstantFloat::Create(llvm::APFloat(0.5));
-  auto constant_float = llvm::dyn_cast<ConstantFloat>(
-      cf.get());
+  auto constant_float = llvm::dyn_cast<ConstantFloat>(cf.get());
   ASSERT_TRUE(constant_float);
 
   std::stringstream output;

--- a/test/unit/IR/Value.cpp
+++ b/test/unit/IR/Value.cpp
@@ -1,4 +1,5 @@
 #include "caffeine/IR/Value.h"
+#include "caffeine/IR/Operation.h"
 #include "caffeine/IR/Type.h"
 
 #include <gtest/gtest.h>
@@ -46,4 +47,46 @@ TEST(ir_value, sdiv_invalid_does_not_fault) {
   Value b{llvm::APInt::getAllOnesValue(32)};
 
   Value::bvsdiv(a, b);
+}
+
+TEST(ir_value, print_int) {
+  auto ci = ConstantInt::Create(llvm::APInt(32, 1337));
+  auto constant_int = llvm::dyn_cast<ConstantInt>(
+      ci.get());
+  ASSERT_TRUE(constant_int);
+
+  std::stringstream output;
+  output << Value(*constant_int);
+  ASSERT_EQ(output.str(), "1337");
+}
+
+TEST(ir_value, print_float) {
+  auto cf = ConstantFloat::Create(llvm::APFloat(0.5));
+  auto constant_float = llvm::dyn_cast<ConstantFloat>(
+      cf.get());
+  ASSERT_TRUE(constant_float);
+
+  std::stringstream output;
+  output << Value(*constant_float);
+
+  // Choose a floating point number which can be stored
+  // accurately to avoid anything like 0.5100000000000000089
+  ASSERT_EQ(output.str(), "0.5");
+}
+
+TEST(ir_value, print_array) {
+  std::stringstream output;
+  output << Value(SharedArray({0, 0, 0}), Type::int_ty(32));
+  // This is temporary, but if anyone implements that
+  // it will help them update the testcase
+  ASSERT_EQ(output.str(), "<array>");
+}
+
+TEST(ir_value, print_vector) {
+  std::stringstream output;
+  std::vector<Value> data;
+  output << Value(data);
+  // This is temporary, but if anyone implements that
+  // it will help them update the testcase
+  ASSERT_EQ(output.str(), "<vector>");
 }


### PR DESCRIPTION
This PR adds more tests to cover `Operation.cpp`

Closes #427