### PR TITLE
Fix `insertelement` and `extractelement` instructions on vectors of pointers

### DIFF
--- a/include/caffeine/Interpreter/ExprEval.h
+++ b/include/caffeine/Interpreter/ExprEval.h
@@ -141,6 +141,8 @@ public:
 
 private:
   OpRef scalarize(const LLVMScalar& scalar) const;
+  LLVMScalar select(const LLVMScalar& cond, const LLVMScalar& t_val,
+                    const LLVMScalar& f_val) const;
 
 private:
   Context* ctx;

--- a/src/IR/Operation.cpp
+++ b/src/IR/Operation.cpp
@@ -2,6 +2,7 @@
 #include "Operation.h"
 #include "caffeine/IR/Type.h"
 #include "caffeine/IR/Value.h"
+#include "caffeine/Support/Macros.h"
 
 #include <boost/algorithm/string.hpp>
 #include <boost/container_hash/hash.hpp>
@@ -15,10 +16,12 @@
 
 namespace caffeine {
 
-#define ASSERT_SAME_TYPES(v1, v2)                                              \
-  CAFFEINE_ASSERT((v1)->type() == (v2)->type(),                                \
-                  fmt::format("arguments had different types: {} != {}",       \
-                              (v1)->type(), (v2)->type()))
+#define ASSERT_SAME_TYPES_2(v1, v2)                                            \
+  ASSERT_SAME_TYPES_3(v1, v2, "arguments had different types")
+#define ASSERT_SAME_TYPES_3(t1, t2, msg)                                       \
+  CAFFEINE_ASSERT((t1) == (t2), fmt::format("{}: {} != {}", (msg), (t1), (t2)))
+#define ASSERT_SAME_TYPES(...)                                                 \
+  CAFFEINE_INVOKE_NUMBERED(ASSERT_SAME_TYPES_, __VA_ARGS__)
 
 Operation::Operation() : opcode_(Invalid), type_(Type::void_ty()) {}
 
@@ -736,9 +739,8 @@ OpRef SelectOp::Create(const OpRef& cond, const OpRef& true_value,
   CAFFEINE_ASSERT(
       cond->type() == Type::int_ty(1),
       fmt::format("select condition was not an i1, it was {}", cond->type()));
-
-  CAFFEINE_ASSERT(true_value->type() == false_value->type(),
-                  "select values had different types");
+  ASSERT_SAME_TYPES(true_value->type(), false_value->type(),
+                    "select values had different types");
 
   return constant_fold(
       SelectOp(true_value->type(), cond, true_value, false_value));

--- a/test/run-pass/inst/extractelement/extract-ptr-vector.ll
+++ b/test/run-pass/inst/extractelement/extract-ptr-vector.ll
@@ -1,0 +1,25 @@
+source_filename = "manual test"
+target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128"
+target triple = "x86_64-pc-linux-gnu"
+
+declare dso_local void @caffeine_assume(i1 zeroext) local_unnamed_addr #1
+declare dso_local void @caffeine_assert(i1 zeroext) local_unnamed_addr #1
+
+@data = internal global [32 x [4 x i32]] zeroinitializer, align 4
+
+define dso_local void @test() local_unnamed_addr #0 {
+  %a = extractelement <2 x i8*> zeroinitializer, i32 0
+  %b = ptrtoint i8* %a to i64
+  %c = icmp eq i64 %b, 0
+  call void @caffeine_assert(i1 zeroext %c)
+  ret void
+}
+
+attributes #0 = { nounwind uwtable optnone noinline }
+attributes #1 = { nounwind }
+
+!llvm.module.flags = !{!0}
+!llvm.ident = !{!1}
+
+!0 = !{i32 1, !"wchar_size", i32 4}
+!1 = !{!"clang version 10.0.0-4ubuntu1 "}

--- a/test/run-pass/inst/insertelement/insert-ptr-vector.ll
+++ b/test/run-pass/inst/insertelement/insert-ptr-vector.ll
@@ -1,0 +1,27 @@
+source_filename = "manual test"
+target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128"
+target triple = "x86_64-pc-linux-gnu"
+
+declare dso_local void @caffeine_assume(i1 zeroext) local_unnamed_addr #1
+declare dso_local void @caffeine_assert(i1 zeroext) local_unnamed_addr #1
+
+@data = internal global i8 5, align 4
+
+define dso_local void @test() local_unnamed_addr #0 {
+  %z = insertelement <2 x i8*> zeroinitializer, i8* @data, i32 0
+  %a = extractelement <2 x i8*> %z, i32 0
+  %b = ptrtoint i8* %a to i64
+  %e = ptrtoint i8* @data to i64
+  %c = icmp eq i64 %b, %e
+  call void @caffeine_assert(i1 zeroext %c)
+  ret void
+}
+
+attributes #0 = { nounwind uwtable optnone noinline }
+attributes #1 = { nounwind }
+
+!llvm.module.flags = !{!0}
+!llvm.ident = !{!1}
+
+!0 = !{i32 1, !"wchar_size", i32 4}
+!1 = !{!"clang version 10.0.0-4ubuntu1 "}


### PR DESCRIPTION
Basically these instructions caused crashes when used on vectors of pointers. This was discovered when trying to write a test case for #432. I've also included a better assertion message for some assertions in `Operation.cpp`.

This includes test cases for both error cases.

Closes #433 