### PR TITLE
Fix dependencies for test case build

### DIFF
--- a/cmake/CaffeineTestUtils.cmake
+++ b/cmake/CaffeineTestUtils.cmake
@@ -119,12 +119,16 @@ function(declare_test TEST_NAME_OUT test EXPECTED)
       -o <OUTPUT>
       "$<TARGET_PROPERTY:${test_target},OUTPUT>"
     COMMENT "Optimizing ${test_target}"
-    DEPENDS caffeine-opt-plugin "${test_target}"
+    DEPENDS 
+      caffeine-opt-plugin
+      "${test_target}"
+      "$<TARGET_PROPERTY:${test_target},OUTPUT>"
   )
 
   caffeine_custom_command(
     TARGET "gen-${test_target}" ALL
     OUTPUT "${DIS_OUT}"
+    DEPENDS "${OUT_DIR}/optimized.bc"
     MAIN_DEPENDENCY "${OUT_DIR}/optimized.bc"
     COMMAND "${LLVM_DIS}" ARGS
       "${OUT_DIR}/optimized.bc"

--- a/cmake/LLVMIRUtils.cmake
+++ b/cmake/LLVMIRUtils.cmake
@@ -227,7 +227,7 @@ function(llvm_library TARGET_NAME)
       -o "${library}" "${linked}"
     MAIN_DEPENDENCY "${linked}"
     DEPENDS "$<TARGET_FILE:caffeine-opt-plugin>"
-    COMMENT "Generating builtin methods for ${library}"
+    COMMENT "Generating builtin methods for ${library_rel}"
   )
 
   set_target_properties(


### PR DESCRIPTION
These were broken again 😦. This PR fixes the dependencies yet again.

Eventually I should create a cmake library that fixes this bs...