### PR TITLE
Avoid evaluating trace span names if tracing is disabled

### DIFF
--- a/src/Support/Tracing.cpp
+++ b/src/Support/Tracing.cpp
@@ -68,6 +68,10 @@ bool TraceContext::is_enabled() const {
   return !!impl;
 }
 
+bool TraceContext::tracing_enabled() {
+  return !!trace_sink;
+}
+
 struct AutoTraceBlock::Impl {
   capnp::MallocMessageBuilder message;
   llvm::SmallVector<
@@ -103,6 +107,7 @@ struct AutoTraceBlock::Impl {
   }
 };
 
+AutoTraceBlock::AutoTraceBlock() {}
 AutoTraceBlock::AutoTraceBlock(std::string_view name) {
   if (trace_sink) {
     impl = std::make_unique<Impl>();


### PR DESCRIPTION
This is just another small set of optimizations to avoid running code when tracing is disabled.