### PR TITLE
Add simplifications to optimize away load-store cycles

### DIFF
--- a/include/caffeine/IR/Operation.h
+++ b/include/caffeine/IR/Operation.h
@@ -318,6 +318,7 @@ public:
 };
 
 std::ostream& operator<<(std::ostream& os, const Operation& op);
+std::ostream& operator<<(std::ostream& os, Operation::Opcode opcode);
 
 /**
  * Base class for all array-typed operations.

--- a/src/IR/Operation.cpp
+++ b/src/IR/Operation.cpp
@@ -236,6 +236,17 @@ std::ostream& operator<<(std::ostream& os, const Operation& op) {
   }
   return os << ')';
 }
+std::ostream& operator<<(std::ostream& os, Operation::Opcode opcode) {
+  switch (opcode) {
+#define HANDLE_OP(opcode, opname, opclass)                                     \
+  case Operation::opcode:                                                      \
+    return os << #opcode;
+#include "caffeine/IR/Operation.def"
+
+  default:
+    return os << "Unknown(" << (uint16_t)opcode << ")";
+  }
+}
 
 /***************************************************
  * OperationCache                                  *

--- a/src/IR/Operation.h
+++ b/src/IR/Operation.h
@@ -113,6 +113,9 @@ public:
 
 template <bool move_out = false>
 class ConstantFolder : public ConstOpVisitor<ConstantFolder<move_out>, OpRef> {
+private:
+  using BaseType = ConstOpVisitor<ConstantFolder<move_out>, OpRef>;
+
 public:
 #define TRY_CONST_INT(expr)                                                    \
   do {                                                                         \
@@ -445,6 +448,17 @@ public:
       return ConstantInt::Create(val->value().sext(op.type().bitwidth()));
 
     return this->visitUnaryOp(op);
+  }
+  OpRef visitBitcast(const UnaryOp& op) {
+    {
+      OpRef value;
+      if (matches(op.operand(), matching::Bitcast(value)) &&
+          value->type() == op.type()) {
+        return value;
+      }
+    }
+
+    return BaseType::visitBitcast(op);
   }
 
   OpRef visitSelectOp(const SelectOp& op) {

--- a/test/unit/IR/Operation.cpp
+++ b/test/unit/IR/Operation.cpp
@@ -149,3 +149,20 @@ TEST(OperationTests, int_load_store_simplify_to_noop) {
   ASSERT_EQ((Operation::Opcode)read->opcode(), Operation::ConstantNumbered);
   ASSERT_EQ(value, read) << read;
 }
+
+TEST(OperationTests, float_load_store_simplify_to_noop) {
+  auto layout = llvm::DataLayout(X86_64_LINUX);
+  auto value = Constant::Create(Type::type_of<float>(), 0);
+  auto alloc = Allocation(
+      ConstantInt::CreateZero(64), ConstantInt::Create(llvm::APInt(64, 4)),
+      AllocOp::Create(ConstantInt::Create(llvm::APInt(64, 4)),
+                      ConstantInt::CreateZero(8)),
+      AllocationKind::Alloca, AllocationPermissions::ReadWrite);
+
+  alloc.write(ConstantInt::CreateZero(64), value, layout);
+  auto read =
+      alloc.read(ConstantInt::CreateZero(64), Type::type_of<float>(), layout);
+
+  ASSERT_EQ((Operation::Opcode)read->opcode(), Operation::ConstantNumbered);
+  ASSERT_EQ(value, read) << read;
+}


### PR DESCRIPTION
When we store a value to memory we first have to break it down into bytes. When we load it back again we then need to rebuild the value from the original bytes. This produces a large expression to effectively just go in a circle. This PR adds a number of simplifications that completely eliminate this type of expression.

This should hopefully simplify symbolic expressions by quite a bit when they have to go through memory.