### PR TITLE
Add trace spans for individual instructions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,7 @@ project(caffeine LANGUAGES C CXX)
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake")
 
+include(CMakeDependentOption)
 
 option(CAFFEINE_ENABLE_TESTS    "Enable test targets" ON)
 option(CAFFEINE_ENABLE_FORMAT   "Enable formatting targets" ON)
@@ -19,6 +20,11 @@ option(CAFFEINE_BUILD_BITCODE   "If true compile tests and libraries down to bit
 option(CAFFEINE_ENABLE_IR_TESTS "Enable tests which involve handwritten LLVM IR" ON)
 option(CAFFEINE_ENABLE_LIBC     "Build a bitcode libc for use in tests" OFF)
 option(CAFFEINE_ENABLE_TRACING  "Enable tracing support within caffeine" OFF)
+
+cmake_dependent_option(
+  CAFFEINE_TRACING_EXPENSIVE_ANNOTATIONS "Enable expensive tracing annotations" OFF
+  "CAFFEINE_ENABLE_TRACING" OFF
+)
 
 # Optimization settings
 set(CAFFEINE_ENABLE_LTO OFF CACHE STRING "Enable link-time-optimizations. Valid values: ON, OFF, FULL, THIN")

--- a/Config.h.in
+++ b/Config.h.in
@@ -3,4 +3,7 @@
 
 #cmakedefine01 CAFFEINE_ENABLE_TRACING
 
+// Whether to generate expensive tracing annotations
+#cmakedefine01 CAFFEINE_TRACING_EXPENSIVE_ANNOTATIONS
+
 #endif

--- a/src/Interpreter/ExprEval.cpp
+++ b/src/Interpreter/ExprEval.cpp
@@ -404,7 +404,7 @@ LLVMValue ExprEvaluator::visitConstantExpr(llvm::ConstantExpr& expr) {
  *********************************************/
 
 LLVMValue ExprEvaluator::visitInstruction(llvm::Instruction& inst) {
-  CAFFEINE_ABORT(
+  CAFFEINE_UNSUPPORTED(
       fmt::format("Instruction '{}' not implemented! Full expression: {}",
                   inst.getOpcodeName(), inst));
 }

--- a/src/Interpreter/Interpreter.cpp
+++ b/src/Interpreter/Interpreter.cpp
@@ -68,7 +68,7 @@ Interpreter Interpreter::cloneWith(Context* ctx) {
 void Interpreter::execute() {
   auto frameblock = CAFFEINE_TRACE_SPAN("Interpreter::execute");
   (void)frameblock;
-  
+
   while (true) {
     StackFrame& frame = ctx->stack_top();
 


### PR DESCRIPTION
This adds tracing that tracks each individual executed instruction. It also adds an `CAFFEINE_TRACING_EXPENSIVE_ANNOTATIONS` config option which is used to enable/disable printing the resulting expression from instructions when they have one.