### PR TITLE
Add install targets for caffeine

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -76,50 +76,6 @@ mark_as_advanced(CAFFEINE_FMTONLY)
 # Disable messages for targets on makefile generators
 set_property(GLOBAL PROPERTY TARGET_MESSAGES OFF)
 
-if (CAFFEINE_ENABLE_BUILD)
-
-  # LLVM Requires an exact version specification so we need to do one
-  # find_package call for each LLVM version we want to support
-  find_package(LLVM 11.1 QUIET)
-  if (NOT LLVM_FOUND)
-    find_package(LLVM 11.0 REQUIRED)
-  endif()
-
-  # TODO: We should have an option to download and build these locally if needed.
-  find_package(GTest REQUIRED)
-  find_package(Z3 4.8.7 REQUIRED)
-  find_package(Boost REQUIRED)
-  find_package(fmt REQUIRED)
-  find_package(CapnProto REQUIRED)
-
-  include(CaffeineDependencies)
-
-  set(IR_USE_BITCODE ${CAFFEINE_BUILD_BITCODE})
-
-  include(CaffeineCoverage)
-  include(CaffeineSanitizers)
-  include(CaffeineWarnings)
-  include(CaffeineLinking)
-  include(CaffeineFlags)
-  include(LLVMIRUtils)
-
-  make_directory("${CMAKE_BINARY_DIR}/gen/caffeine")
-  configure_file(Config.h.in "${CMAKE_BINARY_DIR}/gen/caffeine/Config.h")
-
-  if (CAFFEINE_ENABLE_TESTS)
-    enable_testing()
-  endif()
-
-  add_subdirectory(src)
-  add_subdirectory(libraries)
-  add_subdirectory(tools)
-  add_subdirectory(bench)
-
-  if (CAFFEINE_ENABLE_TESTS)
-    add_subdirectory(test)
-  endif()
-endif()
-
 find_program(CLANG_FORMAT clang-format)
 if (CLANG_FORMAT STREQUAL "CLANG_FORMAT-NOTFOUND")
   message(
@@ -130,6 +86,51 @@ if (CLANG_FORMAT STREQUAL "CLANG_FORMAT-NOTFOUND")
   )
 else()
   include(CaffeineFormatting)
+endif()
+
+if (NOT CAFFEINE_ENABLE_BUILD)
+  return()
+endif()
+
+# LLVM Requires an exact version specification so we need to do one
+# find_package call for each LLVM version we want to support
+find_package(LLVM 11.1 QUIET)
+if (NOT LLVM_FOUND)
+  find_package(LLVM 11.0 REQUIRED)
+endif()
+
+# TODO: We should have an option to download and build these locally if needed.
+find_package(GTest REQUIRED)
+find_package(Z3 4.8.7 REQUIRED)
+find_package(Boost REQUIRED)
+find_package(fmt REQUIRED)
+find_package(CapnProto REQUIRED)
+
+include(CaffeineDependencies)
+
+set(IR_USE_BITCODE ${CAFFEINE_BUILD_BITCODE})
+
+include(CaffeineCoverage)
+include(CaffeineSanitizers)
+include(CaffeineWarnings)
+include(CaffeineLinking)
+include(CaffeineFlags)
+include(LLVMIRUtils)
+
+make_directory("${CMAKE_BINARY_DIR}/gen/caffeine")
+configure_file(Config.h.in "${CMAKE_BINARY_DIR}/gen/caffeine/Config.h")
+
+if (CAFFEINE_ENABLE_TESTS)
+  enable_testing()
+endif()
+
+add_subdirectory(src)
+add_subdirectory(libraries)
+add_subdirectory(tools)
+add_subdirectory(bench)
+
+if (CAFFEINE_ENABLE_TESTS)
+  add_subdirectory(test)
 endif()
 
 # This is only supported for cmake >= 3.17

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -192,6 +192,12 @@ install(
 )
 
 install(
+  DIRECTORY
+    scripts/vcpkg
+  DESTINATION "${CMAKE_INSTALL_DATAROOTDIR}/caffeine"
+)
+
+install(
   DIRECTORY interface
   DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/caffeine"
 )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@ if (CMAKE_VERSION VERSION_GREATER_EQUAL "3.20")
   cmake_policy(SET CMP0116 OLD)
 endif()
 
-project(caffeine LANGUAGES C CXX)
+project(caffeine LANGUAGES C CXX VERSION 0.0.0)
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake")
 
@@ -44,6 +44,8 @@ mark_as_advanced(CAFFEINE_ENABLE_BUILD BUILD_SHARED_LIBS)
 ###########################################################
 #            Non-option cmake configuration               #
 ###########################################################
+set(CAFFEINE_VERSION ${PROJECT_VERSION})
+
 set(CMAKE_EXPORT_COMPILE_COMMANDS TRUE)
 
 # C++17 has a bunch of nice stuff, seems like a good level to target.
@@ -140,3 +142,56 @@ if("${CMAKE_VERSION}" VERSION_GREATER_EQUAL "3.17")
     list(APPEND CMAKE_CTEST_ARGUMENTS "-j${NUM_PROCESSORS}")
   endif()
 endif()
+
+###########################################################
+#               Installation Configuration                #
+###########################################################
+include(GNUInstallDirs)
+
+set(INCLUDE_INSTALL_DIR include)
+set(IR_INSTALL_DIR      lib/caffeine)
+
+install(
+  TARGETS caffeine caffeine-bin caffeine-opt-plugin EXPORT CaffeineTargets
+  RUNTIME       DESTINATION "${CMAKE_INSTALL_BINDIR}"
+  LIBRARY       DESTINATION "${CMAKE_INSTALL_LIBDIR}"
+  ARCHIVE       DESTINATION "${CMAKE_INSTALL_LIBDIR}"
+  PUBLIC_HEADER DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}"
+)
+
+include(CMakePackageConfigHelpers)
+write_basic_package_version_file(
+  "${CMAKE_CURRENT_BINARY_DIR}/CaffeineConfigVersion.cmake"
+  COMPATIBILITY ExactVersion # Keep until 1.0
+)
+configure_package_config_file(
+  cmake/CaffeineConfig.cmake.in "${CMAKE_BINARY_DIR}/caffeine-config.cmake"
+  INSTALL_DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/caffeine"
+  PATH_VARS
+    INCLUDE_INSTALL_DIR
+    IR_INSTALL_DIR
+)
+
+install(EXPORT CaffeineTargets
+  FILE CaffeineTargets.cmake
+  DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/caffeine"
+  NAMESPACE caffeine::
+)
+install(
+  FILES
+    "${CMAKE_BINARY_DIR}/caffeine-config.cmake"
+    "${CMAKE_BINARY_DIR}/CaffeineConfigVersion.cmake"
+  DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/caffeine"
+)
+install(
+  FILES
+    "$<TARGET_PROPERTY:caffeine-builtins,OUTPUT>"
+    "$<$<BOOL:${CAFFEINE_ENABLE_LIBC}>:$<TARGET_PROPERTY:libc,OUTPUT>>"
+  DESTINATION "${CMAKE_INSTALL_LIBDIR}/caffeine"
+)
+
+install(
+  DIRECTORY interface
+  DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/caffeine"
+)
+

--- a/Config.h.in
+++ b/Config.h.in
@@ -1,6 +1,8 @@
 #ifndef CAFFEINE_CONFIG_H
 #define CAFFEINE_CONFIG_H
 
+#cmakedefine CAFFEINE_VERSION
+
 #cmakedefine01 CAFFEINE_ENABLE_TRACING
 
 #endif

--- a/cmake/CaffeineConfig.cmake.in
+++ b/cmake/CaffeineConfig.cmake.in
@@ -1,0 +1,25 @@
+set(CAFFEINE_VERSION @CAFFEINE_VERSION@)
+
+@PACKAGE_INIT@
+
+include("${CMAKE_CURRENT_LIST_DIR}/CaffeineTargets.cmake")
+
+set_and_check(CAFFEINE_INCLUDE_DIRS  "@PACKAGE_INCLUDE_INSTALL_DIR@")
+set_and_check(CAFFEINE_IR_LIBS_DIR   "@PACKAGE_IR_INSTALL_DIR@")
+set_and_check(CAFFEINE_BUILTINS      "@PACKAGE_IR_INSTALL_DIR@/caffeine-builtins.ll")
+set(CAFFEINE_LIBRARIES     caffeine::caffeine)
+
+add_library(caffeine             ALIAS caffeine::caffeine)
+add_library(caffeine::opt-plugin ALIAS caffeine::caffeine-opt-plugin)
+
+if (EXISTS "@PACKAGE_IR_INSTALL_DIR@/libc.ll")
+  set_and_check(CAFFEINE_LIBC "@PACKAGE_IR_INSTALL_DIR@/libc.ll")
+endif()
+
+add_library(caffeine::interface INTERFACE IMPORTED)
+set_target_properties(
+  caffeine::interface PROPERTIES
+  INTERFACE_INCLUDE_DIRECTORIES "${CAFFEINE_INCLUDE_DIRS}/caffeine/interface"
+)
+
+check_required_components(caffeine)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -33,18 +33,20 @@ list(APPEND sources ${CAPNP_SRCS})
 
 add_library(caffeine ${sources} ${headers})
 
-target_include_directories(caffeine PUBLIC "${CMAKE_BINARY_DIR}/gen/")
+target_include_directories(caffeine PUBLIC "$<BUILD_INTERFACE:${CMAKE_BINARY_DIR}/gen>")
 
 target_include_directories(caffeine
-  PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}"
-  PUBLIC "${CMAKE_SOURCE_DIR}/include"
+  PRIVATE  "${CMAKE_CURRENT_SOURCE_DIR}"
+  PUBLIC # Needs to be different between install and build configs
+    "$<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/include>"
+    $<INSTALL_INTERFACE:include/caffeine>
+  PUBLIC
 )
 
 # The SYSTEM should silence warnings within these headers
 target_include_directories(caffeine SYSTEM
   PUBLIC "${LLVM_INCLUDE_DIRS}"
   PUBLIC "${Z3_INCLUDE_DIRS}"
-  PUBLIC "${FMT_INCLUDE_DIRS}"
   PUBLIC "${Boost_INCLUDE_DIRS}"
 )
 
@@ -56,4 +58,20 @@ target_link_libraries(caffeine PUBLIC
   immer
   magic_enum::magic_enum
   CapnProto::capnp-rpc
+)
+
+install(
+  DIRECTORY "${CMAKE_SOURCE_DIR}/include/caffeine"
+  TYPE INCLUDE
+  FILES_MATCHING PATTERN "*.h"
+                 PATTERN "*.hpp"
+                 PATTERN "*.inl"
+)
+
+install(
+  DIRECTORY "${CMAKE_BINARY_DIR}/gen/caffeine"
+  TYPE INCLUDE
+  FILES_MATCHING PATTERN "*.h"
+                 PATTERN "*.hpp"
+                 PATTERN "*.inl"
 )


### PR DESCRIPTION
As in title. This allows us to run `make install` to install caffeine and then other projects can use `find_package(caffeine)` to make use of caffeine. The current targets that are included are
- `caffeine`
- `caffeine-opt-plugin`
- `caffeine-bin`
- All public headers (ones in `include` and generated ones)
- The builtins and libc bitcode libraries
- vcpkg triplet files

I haven't included the afl mutator since it doesn't match the naming conventions (it should be named caffeine-... so that it doesn't conflict with other libraries under `lib`)

I'm still not quite sure how to expose bitcode libraries. For the moment I've elected to just put them under `lib/caffeine` and add some variables that have the file names.