### PR TITLE
Fix assertion when loading a boolean from memory

### DIFF
--- a/src/IR/Operation.cpp
+++ b/src/IR/Operation.cpp
@@ -648,21 +648,30 @@ DECL_UNOP_CREATE(FIsNaN, ASSERT_FP, Type::int_ty(1));
 OpRef UnaryOp::CreateTrunc(Type tgt, const OpRef& operand) {
   CAFFEINE_ASSERT(tgt.is_int());
   CAFFEINE_ASSERT(operand->type().is_int());
-  CAFFEINE_ASSERT(tgt.bitwidth() < operand->type().bitwidth());
+  CAFFEINE_ASSERT(tgt.bitwidth() <= operand->type().bitwidth());
+
+  if (tgt == operand->type())
+    return operand;
 
   return Create(Opcode::Trunc, operand, tgt);
 }
 OpRef UnaryOp::CreateZExt(Type tgt, const OpRef& operand) {
   CAFFEINE_ASSERT(tgt.is_int());
   CAFFEINE_ASSERT(operand->type().is_int());
-  CAFFEINE_ASSERT(tgt.bitwidth() > operand->type().bitwidth());
+  CAFFEINE_ASSERT(tgt.bitwidth() >= operand->type().bitwidth());
+
+  if (tgt == operand->type())
+    return operand;
 
   return Create(Opcode::ZExt, operand, tgt);
 }
 OpRef UnaryOp::CreateSExt(Type tgt, const OpRef& operand) {
   CAFFEINE_ASSERT(tgt.is_int());
   CAFFEINE_ASSERT(operand->type().is_int());
-  CAFFEINE_ASSERT(tgt.bitwidth() > operand->type().bitwidth());
+  CAFFEINE_ASSERT(tgt.bitwidth() >= operand->type().bitwidth());
+
+  if (tgt == operand->type())
+    return operand;
 
   return Create(Opcode::SExt, operand, tgt);
 }

--- a/src/IR/Operation.cpp
+++ b/src/IR/Operation.cpp
@@ -650,9 +650,6 @@ OpRef UnaryOp::CreateTrunc(Type tgt, const OpRef& operand) {
   CAFFEINE_ASSERT(operand->type().is_int());
   CAFFEINE_ASSERT(tgt.bitwidth() <= operand->type().bitwidth());
 
-  if (tgt == operand->type())
-    return operand;
-
   return Create(Opcode::Trunc, operand, tgt);
 }
 OpRef UnaryOp::CreateZExt(Type tgt, const OpRef& operand) {
@@ -660,18 +657,12 @@ OpRef UnaryOp::CreateZExt(Type tgt, const OpRef& operand) {
   CAFFEINE_ASSERT(operand->type().is_int());
   CAFFEINE_ASSERT(tgt.bitwidth() >= operand->type().bitwidth());
 
-  if (tgt == operand->type())
-    return operand;
-
   return Create(Opcode::ZExt, operand, tgt);
 }
 OpRef UnaryOp::CreateSExt(Type tgt, const OpRef& operand) {
   CAFFEINE_ASSERT(tgt.is_int());
   CAFFEINE_ASSERT(operand->type().is_int());
   CAFFEINE_ASSERT(tgt.bitwidth() >= operand->type().bitwidth());
-
-  if (tgt == operand->type())
-    return operand;
 
   return Create(Opcode::SExt, operand, tgt);
 }

--- a/src/IR/Operation.h
+++ b/src/IR/Operation.h
@@ -419,6 +419,9 @@ public:
     if (const auto* val = llvm::dyn_cast<ConstantInt>(op.operand().get()))
       return ConstantInt::Create(val->value().trunc(op.type().bitwidth()));
 
+    if (op.type() == op.operand()->type())
+      return op.operand();
+
     return this->visitUnaryOp(op);
   }
   OpRef visitZExt(const UnaryOp& op) {
@@ -426,6 +429,9 @@ public:
 
     if (const auto* val = llvm::dyn_cast<ConstantInt>(op.operand().get()))
       return ConstantInt::Create(val->value().zext(op.type().bitwidth()));
+
+    if (op.type() == op.operand()->type())
+      return op.operand();
 
     OpRef inner;
     // (zext.ixx (trunc.iyy v)) -> (and v (ixx (2^yy - 1)))
@@ -446,6 +452,9 @@ public:
   OpRef visitSExt(const UnaryOp& op) {
     if (const auto* val = llvm::dyn_cast<ConstantInt>(op.operand().get()))
       return ConstantInt::Create(val->value().sext(op.type().bitwidth()));
+
+    if (op.type() == op.operand()->type())
+      return op.operand();
 
     return this->visitUnaryOp(op);
   }

--- a/src/Memory/MemHeap.cpp
+++ b/src/Memory/MemHeap.cpp
@@ -82,8 +82,10 @@ OpRef Allocation::read(const OpRef& offset, const Type& t,
     bytes.push_back(LoadOp::Create(data(), BinaryOp::CreateAdd(offset, i)));
   }
 
-  if (width == 1)
+  if (t.is_int() && t.bitwidth() == 8) {
+    CAFFEINE_ASSERT(bytes.size() == 1);
     return std::move(bytes[0]);
+  }
 
   uint32_t bitwidth = width * 8;
   auto bitresult = UnaryOp::CreateZExt(Type::int_ty(bitwidth), bytes[0]);

--- a/test/regression/issue-362.pass.load-bool-from-memory.c
+++ b/test/regression/issue-362.pass.load-bool-from-memory.c
@@ -1,0 +1,11 @@
+#include "caffeine.h"
+#include <stdbool.h>
+#include <stdint.h>
+
+void test(bool x, bool y) {
+  caffeine_assume(x == y);
+
+  if (x) {
+    caffeine_assert(y);
+  }
+}


### PR DESCRIPTION
The issue was that if we are loading a type that takes up 1 byte in memory then we'd just directly forward the byte even if it was not valid to forward the byte. (e.g. if we're loading an i1 from memory then we'd just return an i8). This caused assertions later on when things were not as expected.

The fix is to only directly return the memory byte when the expected type is actually an i8, otherwise we need to go through the whole truncation/extension process.

Closes #362 