### PR TITLE
Change caffeine-assert library to an object library

### DIFF
--- a/src/Support/CMakeLists.txt
+++ b/src/Support/CMakeLists.txt
@@ -1,5 +1,5 @@
 
-add_library(caffeine-assert
+add_library(caffeine-assert OBJECT
   Assert.cpp
   "${CMAKE_SOURCE_DIR}/include/caffeine/Support/Assert.h"
 )


### PR DESCRIPTION
I was running into cmake issues due to it not being part of the set of installed libraries. Changing it to an object library seems to have fixed them.

We aren't interested in using the library as a static library anyway so this doesn't change anything else.