### PR TITLE
Improve logging message for invalid deallocations

### DIFF
--- a/include/caffeine/Support/LLVMFmt.h
+++ b/include/caffeine/Support/LLVMFmt.h
@@ -105,6 +105,11 @@ public:
     if (*it == 'i' || *it == 'u')
       signed_ = *it++ == 'i';
 
+    if (*it == 'x' || *it == 'X') {
+      radix_ = 16;
+      return ++it;
+    }
+
     unsigned radix = 0;
     while (it != end && *it != '}') {
       if (!('0' <= *it || *it <= '9'))

--- a/src/Memory/Allocator.cpp
+++ b/src/Memory/Allocator.cpp
@@ -1,5 +1,6 @@
 #include "caffeine/Memory/Allocator.h"
 #include "caffeine/Support/Assert.h"
+#include "caffeine/Support/LLVMFmt.h"
 #include <algorithm>
 #include <immer/flex_vector_transient.hpp>
 #include <llvm/ADT/Hashing.h>
@@ -81,7 +82,10 @@ std::optional<llvm::APInt> BuddyAllocator::allocate(const llvm::APInt& size_,
 
 void BuddyAllocator::deallocate(const llvm::APInt& addr) {
   auto it = allocated.find(addr);
-  CAFFEINE_ASSERT(it, "attempted to deallocate an invalid address");
+  CAFFEINE_ASSERT(
+      it, fmt::format(
+              FMT_STRING("attempted to deallocate an invalid address: 0x{:x}"),
+              addr));
 
   size_t index = *it;
   const auto& nodes = this->nodes.get();


### PR DESCRIPTION
As in title. I've also gone and added a hexadecimal format specifier for APInts.