### PR TITLE
Add utilities for implementing forking operations in builtins

### DIFF
--- a/include/caffeine/Interpreter/Interpreter.h
+++ b/include/caffeine/Interpreter/Interpreter.h
@@ -125,6 +125,8 @@ private:
   ExecutionResult visitFree(llvm::CallInst& inst);
 
   ExecutionResult visitBuiltinResolve(llvm::CallInst& inst);
+
+  friend class TransformBuilder;
 };
 
 } // namespace caffeine

--- a/include/caffeine/Interpreter/TransformBuilder.h
+++ b/include/caffeine/Interpreter/TransformBuilder.h
@@ -1,0 +1,131 @@
+#pragma once
+
+#include "caffeine/Interpreter/Context.h"
+#include <array>
+#include <cstdlib>
+#include <llvm/ADT/FunctionExtras.h>
+#include <llvm/ADT/SmallVector.h>
+#include <variant>
+
+namespace llvm {
+class Value;
+class Type;
+} // namespace llvm
+
+namespace caffeine {
+class ExecutionResult;
+class Interpreter;
+
+/**
+ * Perform a sequence of operations while internally handling all forking.
+ *
+ * When writing a builtin it is often necessary to do operations that might
+ * cause the context to fork. Dealing with these results in a lot of boilerplate
+ * code that is tedious to write and easy to screw up. This class encapsulates
+ * that into a linear set of instructions with the forking handled behind the
+ * scenes. This avoids having to get all the nested loops correct when handling
+ * individual types.
+ *
+ * Implementation
+ * ==============
+ * At it's core, this class builds a list of operations that somehow transform
+ * and possibly fork the initial context. Each of these transforms is just a
+ * function object that takes a context+state and then returns any number of
+ * context+state instances to the run queue.
+ */
+class TransformBuilder {
+public:
+  struct Value {
+    size_t index;
+
+    Value(size_t index) : index(index) {}
+  };
+
+  using Argument = std::variant<Value, llvm::Value*>;
+
+  struct ContextState {
+  private:
+    size_t inst = 0;
+    immer::map<size_t, LLVMValue> values;
+
+  public:
+    Context ctx;
+    Interpreter* interpreter;
+
+  public:
+    LLVMValue lookup(const Argument& arg);
+    void insert(Value key, LLVMValue val);
+
+    ContextState fork(const Context& newctx) const;
+    ContextState fork(Context&& newctx) const;
+
+    // Return a value that points to the output of the current operation.
+    Value current() const;
+
+  private:
+    ContextState(Context&& ctx, Interpreter* interp);
+
+    friend class TransformBuilder;
+  };
+
+  // Function for inserting a context state back into the execution queue.
+  using InsertFn = llvm::unique_function<void(ContextState&&)>;
+  using TransformFn =
+      llvm::unique_function<void(ContextState&&, InsertFn&) const>;
+
+private:
+  struct Operation {
+    TransformFn func;
+
+    Operation(TransformFn&& func) : func(std::move(func)) {}
+  };
+
+private:
+  llvm::SmallVector<Operation, 16> operations;
+
+public:
+  TransformBuilder() = default;
+
+  // Resolve a pointer for a read/write of the provided type.
+  //
+  // This will fork the context for each allocation that the input pointer gets
+  // resolved to. By default, if the pointer could point outside of an
+  // allocation then it logs a failure and kills the current context. Usually,
+  // this is what you want. However, you can pass die_on_failure = false to
+  // disable this behaviour.
+  Value resolve(Argument pointer, llvm::Type* type, bool die_on_failure = true);
+
+  // Run the provided function against each context-state fork. The function is
+  // responsible for inserting all contexts that should continue executing by
+  // passing them to the provided InsertFn instance.
+  //
+  // All operations eventually boil down to this function.
+  Value transform_fork(TransformFn&& func);
+
+  // Run the provided function against each provided context-state fork.
+  //
+  // This is meant for transformations that will never create new forks or kill
+  // a context. If you need the ability to do those then use transform_fork.
+  template <typename F>
+  Value transform(F&& func) {
+    return transform_fork(
+        [mfunc = std::move(func)](ContextState&& state, InsertFn& insert_fn) {
+          mfunc(state);
+          insert_fn(std::move(state));
+        });
+  }
+
+  // Assign the provided temporary argument value in the top stack frame of the
+  // context.
+  void assign(llvm::Value* value, Argument arg);
+  void assign(llvm::Value* value, LLVMValue arg);
+  void assign(llvm::Value* value, LLVMScalar arg);
+
+  // Read a value from the provided pointer. The pointer must have been resolved
+  // (usually by a call to resolve).
+  Value read(Argument arg, llvm::Type* type);
+
+  ExecutionResult execute(Interpreter* interp) const;
+};
+
+} // namespace caffeine

--- a/include/caffeine/Memory/MemHeap.h
+++ b/include/caffeine/Memory/MemHeap.h
@@ -331,6 +331,14 @@ public:
   MemHeap& operator[](unsigned index);
   const MemHeap& operator[](unsigned index) const;
 
+  /**
+   * Get the allocation that this pointer corresponds to.
+   *
+   * If the pointer is not resolved then this will cause an assertion failure.
+   */
+  Allocation& ptr_allocation(const Pointer& ptr);
+  const Allocation& ptr_allocation(const Pointer& ptr) const;
+
   Assertion check_valid(const Pointer& value, uint32_t width);
   Assertion check_valid(const Pointer& value, const OpRef& width);
   Assertion check_starts_allocation(const Pointer& value);

--- a/src/Interpreter/TransformBuilder.cpp
+++ b/src/Interpreter/TransformBuilder.cpp
@@ -1,0 +1,146 @@
+#include "caffeine/Interpreter/TransformBuilder.h"
+#include "caffeine/Interpreter/Interpreter.h"
+#include <immer/map.hpp>
+#include <stack>
+
+namespace caffeine {
+
+TransformBuilder::ContextState::ContextState(Context&& ctx, Interpreter* interp)
+    : ctx(std::move(ctx)), interpreter(interp) {}
+
+LLVMValue TransformBuilder::ContextState::lookup(const Argument& arg) {
+  if (auto val = std::get_if<llvm::Value*>(&arg))
+    return ctx.lookup(*val);
+  return values.at(std::get<TransformBuilder::Value>(arg).index);
+}
+
+void TransformBuilder::ContextState::insert(Value key, LLVMValue val) {
+  values = std::move(values).insert({key.index, std::move(val)});
+}
+
+TransformBuilder::ContextState
+TransformBuilder::ContextState::fork(const Context& newctx) const {
+  return fork(Context(newctx));
+}
+TransformBuilder::ContextState
+TransformBuilder::ContextState::fork(Context&& newctx) const {
+  ContextState clone{std::move(newctx), interpreter};
+  clone.inst = inst;
+  clone.values = values;
+  return clone;
+}
+
+TransformBuilder::Value TransformBuilder::ContextState::current() const {
+  return Value(inst - 1);
+}
+
+ExecutionResult TransformBuilder::execute(Interpreter* interp) const {
+  std::stack<ContextState> stack;
+  stack.push(ContextState(interp->ctx->fork_once(), interp));
+
+  // We use an erased function here to avoid having to expose internal data
+  // structures to all downstream functions.
+  InsertFn insert_fn = [&](ContextState&& state) {
+    stack.push(std::move(state));
+  };
+
+  ExecutionResult::ContextVec output;
+  while (!stack.empty()) {
+    ContextState state = std::move(stack.top());
+    stack.pop();
+
+    if (state.inst >= operations.size()) {
+      output.push_back(std::move(state.ctx));
+      continue;
+    }
+
+    const Operation& op = operations[state.inst];
+    state.inst += 1;
+
+    // The operation function is responsible for putting states back onto the
+    // stack if they're supposed to continue being executed.
+    op.func(std::move(state), insert_fn);
+  }
+
+  if (output.size() == 1) {
+    *interp->ctx = std::move(output[0]);
+    return ExecutionResult::Continue;
+  } else {
+    return ExecutionResult(std::move(output));
+  }
+}
+
+TransformBuilder::Value TransformBuilder::resolve(Argument pointer,
+                                                  llvm::Type* type,
+                                                  bool die_on_failure) {
+  return transform_fork([=](ContextState&& state, InsertFn& insert_fn) {
+    Context& ctx = state.ctx;
+    auto solver = state.interpreter->solver;
+    const llvm::DataLayout& layout = ctx.mod->getDataLayout();
+
+    auto result_id = state.current();
+    auto unresolved = state.lookup(pointer).scalar().pointer();
+    auto assertion =
+        ctx.heaps.check_valid(unresolved, layout.getTypeStoreSize(type));
+    if (ctx.check(solver, !assertion) == SolverResult::SAT) {
+      state.interpreter->logFailure(ctx, !assertion,
+                                    "invalid pointer load/store");
+
+      if (die_on_failure) {
+        // If we're getting an out-of-bounds access then there's a pretty
+        // good chance that we'll find that we can overlap with just about
+        // any other allocation. This isn't likely to produce useful bugs so
+        // we'll kill the context here.
+        return;
+      }
+    }
+
+    auto resolved = ctx.heaps.resolve(solver, unresolved, ctx);
+    auto forks = ctx.fork(resolved.size());
+
+    for (auto [fork, ptr] : llvm::zip(forks, resolved)) {
+      Allocation& alloc = fork.heaps[ptr.heap()][ptr.alloc()];
+      fork.add(
+          alloc.check_inbounds(ptr.offset(), layout.getTypeStoreSize(type)));
+
+      if (!unresolved.is_resolved()) {
+        fork.backprop(unresolved, ptr);
+      }
+
+      ContextState newstate = state.fork(std::move(fork));
+      newstate.insert(result_id, LLVMValue(ptr));
+      insert_fn(std::move(newstate));
+    }
+  });
+}
+
+TransformBuilder::Value TransformBuilder::transform_fork(TransformFn&& func) {
+  operations.emplace_back(std::move(func));
+  return Value(operations.size() - 1);
+}
+
+void TransformBuilder::assign(llvm::Value* value, Argument arg) {
+  transform([=](ContextState& state) {
+    state.ctx.stack_top().insert(value, state.lookup(arg));
+  });
+}
+void TransformBuilder::assign(llvm::Value* value, LLVMValue arg) {
+  transform([value, marg = std::move(arg)](ContextState& state) {
+    state.ctx.stack_top().insert(value, marg);
+  });
+}
+void TransformBuilder::assign(llvm::Value* value, LLVMScalar arg) {
+  assign(value, LLVMValue(std::move(arg)));
+}
+
+TransformBuilder::Value TransformBuilder::read(Argument arg, llvm::Type* type) {
+  return transform([=](ContextState& state) {
+    const auto& layout = state.ctx.mod->getDataLayout();
+
+    auto ptr = state.lookup(arg).scalar().pointer();
+    Allocation& alloc = state.ctx.heaps.ptr_allocation(ptr);
+    state.insert(state.current(), alloc.read(ptr.offset(), type, layout));
+  });
+}
+
+} // namespace caffeine

--- a/src/Memory/MemHeap.cpp
+++ b/src/Memory/MemHeap.cpp
@@ -541,6 +541,17 @@ const MemHeap& MemHeapMgr::operator[](unsigned index) const {
   return it->getSecond();
 }
 
+Allocation& MemHeapMgr::ptr_allocation(const Pointer& ptr) {
+  CAFFEINE_ASSERT(ptr.is_resolved(),
+                  "cannot get allocation for an unresolved pointer");
+  return (*this)[ptr.heap()][ptr.alloc()];
+}
+const Allocation& MemHeapMgr::ptr_allocation(const Pointer& ptr) const {
+  CAFFEINE_ASSERT(ptr.is_resolved(),
+                  "cannot get allocation for an unresolved pointer");
+  return (*this)[ptr.heap()][ptr.alloc()];
+}
+
 Assertion MemHeapMgr::check_valid(const Pointer& ptr, uint32_t width) {
   return check_valid(ptr, ConstantInt::Create(llvm::APInt(
                               ptr.offset()->type().bitwidth(), width)));


### PR DESCRIPTION
A lot of operations involve first performing an operation that could fork and then doing other things on all the resulting contexts. This ends up being very tedious to write (e.g. resolving a pointer requires ~50 LOC every time we want to do it). This PR adds a utility that handles tracking all the forks and executing a series of operations on them.

So far I've only added the operations that were used in implementing `setjmp` and `longjmp`. As more operations are needed then they can be added. In the meantime, they will all be wrappers around the `transform_fork` function so there's no functionality that couldn't be implemented manually. 