### PR TITLE
Implement `setjmp` and `longjmp`

### DIFF
--- a/include/caffeine/Interpreter/Interpreter.h
+++ b/include/caffeine/Interpreter/Interpreter.h
@@ -1,6 +1,7 @@
 #ifndef CAFFEINE_INTERP_INTERPRETER_H
 #define CAFFEINE_INTERP_INTERPRETER_H
 
+#include <iostream>
 #include <memory>
 
 #include "caffeine/IR/Assertion.h"
@@ -8,6 +9,7 @@
 #include "caffeine/Interpreter/FailureLogger.h"
 #include "caffeine/Interpreter/Options.h"
 #include "caffeine/Support/Assert.h"
+#include "caffeine/Support/Macros.h"
 
 #include <llvm/IR/InstVisitor.h>
 
@@ -15,6 +17,7 @@ namespace caffeine {
 
 class ExecutionPolicy;
 class ExecutionContextStore;
+class Interpreter;
 
 class ExecutionResult {
 public:
@@ -43,6 +46,8 @@ private:
   Status status_;
   ContextVec contexts_;
 };
+
+typedef ExecutionResult (*InterpreterFunction)(Interpreter&, llvm::CallInst&);
 
 class Interpreter : public llvm::InstVisitor<Interpreter, ExecutionResult> {
 private:
@@ -126,7 +131,14 @@ private:
 
   ExecutionResult visitBuiltinResolve(llvm::CallInst& inst);
 
+  ExecutionResult visitSetjmp(llvm::CallInst& inst);
+  ExecutionResult visitLongjmp(llvm::CallInst& inst);
+
   friend class TransformBuilder;
+
+public:
+  static std::unordered_map<std::string_view, InterpreterFunction>&
+  extern_functions();
 };
 
 } // namespace caffeine

--- a/include/caffeine/Interpreter/StackFrame.h
+++ b/include/caffeine/Interpreter/StackFrame.h
@@ -38,6 +38,9 @@ public:
   // Allocations within the current frame.
   std::vector<StackAllocation> allocations;
 
+  uint64_t frame_id;
+
+public:
   StackFrame(llvm::Function* function);
 
   /**
@@ -54,6 +57,9 @@ public:
    */
   void insert(llvm::Value* value, const OpRef& expr);
   void insert(llvm::Value* value, const LLVMValue& exprs);
+
+private:
+  static std::atomic<uint64_t> next_frame_id;
 };
 
 } // namespace caffeine

--- a/src/Interpreter/Builtins/setjmp-longjmp.cpp
+++ b/src/Interpreter/Builtins/setjmp-longjmp.cpp
@@ -1,0 +1,77 @@
+#include "caffeine/Interpreter/Interpreter.h"
+#include <fmt/format.h>
+
+namespace caffeine {
+namespace {
+  llvm::StructType* getJmpBufType(llvm::LLVMContext& ctx) {
+    return llvm::StructType::get(
+        llvm::Type::getInt64Ty(ctx),
+        llvm::Type::getIntNTy(ctx, sizeof(void*) * CHAR_BIT));
+  }
+
+  // TODO: This stores a interpreter pointer in the memory of the interpreted
+  //       program. This will not work when we want to make caffeine
+  //       distributed. However, I don't see another good way to write this for
+  //       now so I'm leaving it.
+  LLVMValue getJmpBuf(uint64_t stack_id, llvm::CallInst& inst) {
+    return LLVMValue(llvm::ArrayRef<LLVMValue>{
+        LLVMValue(ConstantInt::Create(llvm::APInt(64, stack_id))),
+        LLVMValue(ConstantInt::Create(llvm::APInt(
+            sizeof(void*) * CHAR_BIT, reinterpret_cast<uintptr_t>(&inst))))});
+  }
+} // namespace
+
+ExecutionResult Interpreter::visitSetjmp(llvm::CallInst& inst) {
+  CAFFEINE_ASSERT(inst.getNumArgOperands() == 1,
+                  "Invalid signature for _setjmp");
+
+  const auto& layout = inst.getModule()->getDataLayout();
+  auto& frame = ctx->stack_top();
+
+  auto pointer = ctx->lookup(inst.getArgOperand(0)).scalar().pointer();
+  auto jmpbuf = getJmpBuf(frame.frame_id, inst);
+  auto jmpbuf_ty = getJmpBufType(inst.getContext());
+
+  CAFFEINE_ASSERT(
+      layout.getTypeStoreSize(inst.getArgOperand(0)->getType()) <=
+          layout.getTypeStoreSize(jmpbuf_ty),
+      fmt::format("Platform jmp_buf is too small for caffeine to use: {} > {}",
+                  layout.getTypeStoreSize(inst.getArgOperand(0)->getType()),
+                  layout.getTypeStoreSize(jmpbuf_ty)));
+
+  auto assertion =
+      ctx->heaps.check_valid(pointer, layout.getTypeStoreSize(jmpbuf_ty));
+  if (ctx->check(solver, !assertion) == SolverResult::SAT) {
+    logFailure(*ctx, !assertion, "invalid pointer store");
+
+    // If we're getting an out-of-bounds access then there's a pretty good
+    // chance that we'll find that we can overlap with just about any other
+    // allocation. This isn't likely to produce useful bugs so we'll kill the
+    // context here.
+    return ExecutionResult::Dead;
+  }
+
+  frame.insert(&inst,
+               ConstantInt::CreateZero(inst.getType()->getIntegerBitWidth()));
+
+  auto resolved = ctx->heaps.resolve(solver, pointer, *ctx);
+  auto forks = ctx->fork(resolved.size());
+
+  for (auto [fork, ptr] : llvm::zip(forks, resolved)) {
+    Allocation& alloc = fork.heaps[ptr.heap()][ptr.alloc()];
+    fork.add(
+        alloc.check_inbounds(ptr.offset(), layout.getTypeStoreSize(jmpbuf_ty)));
+    alloc.write(ptr.offset(), jmpbuf_ty, jmpbuf, fork.heaps, layout);
+
+    if (!ptr.is_resolved()) {
+      fork.backprop(pointer, ptr);
+    }
+  }
+
+  return forks;
+}
+
+ExecutionResult Interpreter::visitLongjmp(llvm::CallInst& inst) {
+  CAFFEINE_UNIMPLEMENTED("test");
+}
+} // namespace caffeine

--- a/src/Interpreter/Builtins/setjmp-longjmp.cpp
+++ b/src/Interpreter/Builtins/setjmp-longjmp.cpp
@@ -1,8 +1,12 @@
 #include "caffeine/Interpreter/Interpreter.h"
+#include "caffeine/Interpreter/TransformBuilder.h"
 #include <fmt/format.h>
 
 namespace caffeine {
 namespace {
+  using ContextState = TransformBuilder::ContextState;
+  using InsertFn = TransformBuilder::InsertFn;
+
   llvm::StructType* getJmpBufType(llvm::LLVMContext& ctx) {
     return llvm::StructType::get(
         llvm::Type::getInt64Ty(ctx),
@@ -19,6 +23,48 @@ namespace {
         LLVMValue(ConstantInt::Create(llvm::APInt(
             sizeof(void*) * CHAR_BIT, reinterpret_cast<uintptr_t>(&inst))))});
   }
+
+  // Find the stack frame in which the jump target occurs.
+  //
+  // Returns the frame index only if a frame with the right frame id and the
+  // frame function contains the instruction in jmp_tgt. Furthermore, jmp_tgt
+  // must be a call instruction that calls _setjmp.
+  std::optional<size_t> findJumpTargetFrame(const Context& ctx,
+                                            uint64_t frame_id,
+                                            llvm::Instruction* jmp_tgt) {
+    llvm::Module* module = ctx.mod;
+    llvm::Function* setjmp_fn = module->getFunction("_setjmp");
+
+    if (setjmp_fn)
+      return std::nullopt;
+
+    for (size_t i = ctx.stack.size(); i != 0; --i) {
+      size_t idx = i - 1;
+      const StackFrame& frame = ctx.stack[idx];
+
+      if (frame.frame_id != frame_id)
+        continue;
+
+      llvm::Function* func = frame.current_block->getParent();
+      for (const llvm::BasicBlock& block : func->getBasicBlockList()) {
+        for (const llvm::Instruction& inst : block.instructionsWithoutDebug()) {
+          if (&inst != jmp_tgt)
+            continue;
+
+          llvm::CallInst* call = llvm::dyn_cast<llvm::CallInst>(jmp_tgt);
+          if (!call)
+            continue;
+
+          if (call->getCalledFunction() != setjmp_fn)
+            continue;
+
+          return idx;
+        }
+      }
+    }
+
+    return std::nullopt;
+  }
 } // namespace
 
 ExecutionResult Interpreter::visitSetjmp(llvm::CallInst& inst) {
@@ -28,7 +74,6 @@ ExecutionResult Interpreter::visitSetjmp(llvm::CallInst& inst) {
   const auto& layout = inst.getModule()->getDataLayout();
   auto& frame = ctx->stack_top();
 
-  auto pointer = ctx->lookup(inst.getArgOperand(0)).scalar().pointer();
   auto jmpbuf = getJmpBuf(frame.frame_id, inst);
   auto jmpbuf_ty = getJmpBufType(inst.getContext());
 
@@ -39,39 +84,108 @@ ExecutionResult Interpreter::visitSetjmp(llvm::CallInst& inst) {
                   layout.getTypeStoreSize(inst.getArgOperand(0)->getType()),
                   layout.getTypeStoreSize(jmpbuf_ty)));
 
-  auto assertion =
-      ctx->heaps.check_valid(pointer, layout.getTypeStoreSize(jmpbuf_ty));
-  if (ctx->check(solver, !assertion) == SolverResult::SAT) {
-    logFailure(*ctx, !assertion, "invalid pointer store");
+  auto ops = TransformBuilder();
 
-    // If we're getting an out-of-bounds access then there's a pretty good
-    // chance that we'll find that we can overlap with just about any other
-    // allocation. This isn't likely to produce useful bugs so we'll kill the
-    // context here.
-    return ExecutionResult::Dead;
-  }
+  auto resolved = ops.resolve(inst.getArgOperand(0), jmpbuf_ty);
+  ops.transform([&](TransformBuilder::ContextState& state) {
+    auto ptr = state.lookup(resolved).scalar().pointer();
 
-  frame.insert(&inst,
-               ConstantInt::CreateZero(inst.getType()->getIntegerBitWidth()));
+    Allocation& alloc = state.ctx.heaps[ptr.heap()][ptr.alloc()];
+    alloc.write(ptr.offset(), jmpbuf_ty, jmpbuf, state.ctx.heaps, layout);
+  });
+  ops.assign(&inst,
+             ConstantInt::CreateZero(inst.getType()->getIntegerBitWidth()));
 
-  auto resolved = ctx->heaps.resolve(solver, pointer, *ctx);
-  auto forks = ctx->fork(resolved.size());
-
-  for (auto [fork, ptr] : llvm::zip(forks, resolved)) {
-    Allocation& alloc = fork.heaps[ptr.heap()][ptr.alloc()];
-    fork.add(
-        alloc.check_inbounds(ptr.offset(), layout.getTypeStoreSize(jmpbuf_ty)));
-    alloc.write(ptr.offset(), jmpbuf_ty, jmpbuf, fork.heaps, layout);
-
-    if (!ptr.is_resolved()) {
-      fork.backprop(pointer, ptr);
-    }
-  }
-
-  return forks;
+  return ops.execute(this);
 }
 
 ExecutionResult Interpreter::visitLongjmp(llvm::CallInst& inst) {
-  CAFFEINE_UNIMPLEMENTED("test");
+  CAFFEINE_ASSERT(inst.getNumArgOperands() == 2,
+                  "Invalid signature for longjmp");
+  CAFFEINE_ASSERT(inst.getArgOperand(0)->getType()->isPointerTy(),
+                  "Invalid signature for longjmp");
+  CAFFEINE_ASSERT(inst.getArgOperand(1)->getType()->isIntegerTy(),
+                  "Invalid signature for longjmp");
+
+  const auto& layout = inst.getModule()->getDataLayout();
+  auto jmpbuf_ty = getJmpBufType(inst.getContext());
+
+  CAFFEINE_ASSERT(
+      layout.getTypeStoreSize(inst.getArgOperand(0)->getType()) <=
+          layout.getTypeStoreSize(jmpbuf_ty),
+      fmt::format("Platform jmp_buf is too small for caffeine to use: {} > {}",
+                  layout.getTypeStoreSize(inst.getArgOperand(0)->getType()),
+                  layout.getTypeStoreSize(jmpbuf_ty)));
+
+  auto ops = TransformBuilder();
+  auto resolved = ops.resolve(inst.getArgOperand(0), jmpbuf_ty);
+  auto read = ops.read(resolved, jmpbuf_ty);
+
+  // Fork the context for all possible concrete jump targets.
+  //
+  // TODO: Right now we just fail if the contents of the jump buffer are not
+  //       concrete. In the future we should resolve all possible concrete
+  //       values of the jump target buffer and fork for each of them.
+  auto concrete = ops.transform_fork([&](ContextState&& state,
+                                         InsertFn& insert_fn) -> void {
+    auto jmpbuf = state.lookup(read);
+
+    auto frame_id = jmpbuf.member(0).scalar().expr();
+    auto jmp_tgt = jmpbuf.member(1).scalar().expr();
+
+    if (!llvm::isa<ConstantInt>(frame_id.get())) {
+      logFailure(state.ctx, Assertion::constant(false),
+                 "symbolic longjmp targets are not supported.");
+      return;
+    }
+
+    if (!llvm::isa<ConstantInt>(jmp_tgt.get())) {
+      logFailure(state.ctx, Assertion::constant(false),
+                 "symbolic longjmp targets are not supported.");
+      return;
+    }
+
+    auto val_id = state.current();
+    state.insert(val_id, LLVMValue(std::vector<LLVMValue>{LLVMValue(frame_id),
+                                                          LLVMValue(jmp_tgt)}));
+    insert_fn(std::move(state));
+  });
+
+  ops.transform_fork([&](ContextState&& state, InsertFn& insert_fn) -> void {
+    auto input = state.lookup(concrete);
+
+    uint64_t frame_id =
+        llvm::cast<ConstantInt>(input.member(0).scalar().expr().get())
+            ->value()
+            .getLimitedValue();
+
+    // Note: jmp_tgt is not guaranteed to be valid in any way until we find it
+    //       in a function definition.
+    llvm::Instruction* jmp_tgt =
+        reinterpret_cast<llvm::Instruction*>(static_cast<uintptr_t>(
+            llvm::cast<ConstantInt>(input.member(1).scalar().expr().get())
+                ->value()
+                .getLimitedValue()));
+
+    // Search backwards through the call stack to see if we can find the frame
+    // in which the corresponding setjmp call was made.
+
+    std::optional<size_t> target_frame =
+        findJumpTargetFrame(state.ctx, frame_id, jmp_tgt);
+
+    if (!target_frame.has_value()) {
+      logFailure(state.ctx, Assertion::constant(false),
+                 "invalid longjmp target");
+      return;
+    }
+
+    state.ctx.stack.erase(state.ctx.stack.begin() + *target_frame,
+                          state.ctx.stack.end());
+    state.ctx.stack_top().insert(jmp_tgt, state.lookup(inst.getArgOperand(1)));
+
+    insert_fn(std::move(state));
+  });
+
+  return ops.execute(this);
 }
 } // namespace caffeine

--- a/src/Interpreter/Builtins/setjmp-longjmp.cpp
+++ b/src/Interpreter/Builtins/setjmp-longjmp.cpp
@@ -3,6 +3,42 @@
 #include <fmt/format.h>
 
 namespace caffeine {
+
+/**
+ * Implementing setjmp and longjmp
+ * ===============================
+ * To implement setjmp and longjmp on a normal architecture we need to somehow
+ * record the current location of the thread and then return to it at a later
+ * time (when longjmp is called). This is done by recording the registers at
+ * that and then restoring them (mostly) when longjmp is called which has the
+ * effect of returning to the call location.
+ *
+ * To implement these within caffeine we need to do much of the same thing.
+ * Caffeine doesn't have any registers so all we really need to do is restore
+ * the stack frame and the instruction pointer at the time setjmp was called.
+ * The way that this is currently done is by saving two bits of info within the
+ * jump buffer type:
+ *
+ * 1. The frame ID of the frame that first called setjmp. This is the frame we
+ *    need to return to when longjmp is called.
+ * 2. The llvm instruction pointer that corresponds to the call instruction to
+ *    setjmp. This is the instruction we'll need to return to when longjmp is
+ *    called.
+ *
+ * Then, when longjmp is called we search for the correct frame and instruction
+ * pointer that we read from the interpreted program's memory. If we find them
+ * then we drop all stack frames below the initial setjmp, reset the instruction
+ * pointer, and set up the return value.
+ *
+ * Downsides
+ * =========
+ * This implementation has the problem that we are storing host-specific
+ * pointers within the memory of the program being interpreted. At the moment,
+ * this does not cause any issues. However, as soon as we want to go distributed
+ * it's going to have to be changed to something that remains the same across
+ * hosts.
+ */
+
 namespace {
   using ContextState = TransformBuilder::ContextState;
   using InsertFn = TransformBuilder::InsertFn;
@@ -181,7 +217,16 @@ ExecutionResult Interpreter::visitLongjmp(llvm::CallInst& inst) {
 
     state.ctx.stack.erase(state.ctx.stack.begin() + *target_frame,
                           state.ctx.stack.end());
-    state.ctx.stack_top().insert(jmp_tgt, state.lookup(inst.getArgOperand(1)));
+    auto& frame = state.ctx.stack_top();
+    frame.insert(jmp_tgt, state.lookup(inst.getArgOperand(1)));
+    frame.jump_to(jmp_tgt->getParent());
+
+    while (&*frame.current != jmp_tgt) {
+      ++frame.current;
+      CAFFEINE_ASSERT(frame.current != frame.current_block->end());
+    }
+    // Don't want to execute _setjmp again
+    ++frame.current;
 
     insert_fn(std::move(state));
   });

--- a/src/Interpreter/StackFrame.cpp
+++ b/src/Interpreter/StackFrame.cpp
@@ -8,9 +8,11 @@
 
 namespace caffeine {
 
+std::atomic<uint64_t> StackFrame::next_frame_id{0};
+
 StackFrame::StackFrame(llvm::Function* function)
     : current_block(&function->getEntryBlock()), prev_block(nullptr),
-      current(current_block->begin()) {}
+      current(current_block->begin()), frame_id(next_frame_id++) {}
 
 void StackFrame::jump_to(llvm::BasicBlock* block) {
   prev_block = current_block;

--- a/test/run-pass/intrin/longjmp/setjmp-longjmp.c
+++ b/test/run-pass/intrin/longjmp/setjmp-longjmp.c
@@ -1,0 +1,21 @@
+#include "caffeine.h"
+
+#include <setjmp.h>
+
+__attribute__((noinline)) void inner_func(jmp_buf buf) {
+  longjmp(buf, 11);
+}
+
+void test() {
+  jmp_buf buf;
+  switch (setjmp(buf)) {
+  case 0:
+    inner_func(buf);
+  default:
+    caffeine_assert(false);
+    break;
+
+  case 11:
+    return;
+  }
+}

--- a/test/run-pass/intrin/setjmp/setjmp-no-longjmp.c
+++ b/test/run-pass/intrin/setjmp/setjmp-no-longjmp.c
@@ -1,0 +1,14 @@
+#include "caffeine.h"
+
+#include <setjmp.h>
+
+void test() {
+  jmp_buf buf;
+  switch (setjmp(buf)) {
+  case 0:
+    break;
+  default:
+    caffeine_assert(false);
+    break;
+  }
+}


### PR DESCRIPTION
As in title. See the comment within `setjmp-longjmp.cpp` for an explanation of how this all works.

## Details
- Add a global registry for builtin library functions. This is a step away from them all needing to be member functions of `Interpreter`.
- Add a frame ID to all stack frames so that we can search for them when doing a `longjmp`
- Implement `setjmp` and `longjmp`

/stack #456 