### PR TITLE
Replace broken BuddyAllocator with BumpAllocator

### DIFF
--- a/include/caffeine/Interpreter/ExprEval.h
+++ b/include/caffeine/Interpreter/ExprEval.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "caffeine/IR/Operation.h"
+#include "caffeine/Support/UnsupportedOperation.h"
 #include <llvm/IR/InstVisitor.h>
 #include <optional>
 #include <stdexcept>
@@ -33,7 +34,7 @@ public:
     constexpr Options() noexcept {}
   };
 
-  class Unevaluatable : public std::exception {
+  class Unevaluatable : public UnsupportedOperationException {
   private:
     llvm::Value* expr_;
     const char* context_;
@@ -42,14 +43,11 @@ public:
   public:
     explicit Unevaluatable(llvm::Value* expr, const char* context = nullptr);
 
-    const char* what() const throw() override;
+    const char* what() const noexcept override;
     llvm::Value* expr() const;
   };
 
   explicit ExprEvaluator(Context* ctx, Options options = Options());
-
-private:
-  LLVMValue visit_internal(llvm::Value* val);
 
 public:
   LLVMValue visit(llvm::Value* val);

--- a/include/caffeine/Interpreter/ExprEval.h
+++ b/include/caffeine/Interpreter/ExprEval.h
@@ -48,6 +48,10 @@ public:
 
   explicit ExprEvaluator(Context* ctx, Options options = Options());
 
+private:
+  LLVMValue visit_internal(llvm::Value* val);
+
+public:
   LLVMValue visit(llvm::Value* val);
   LLVMValue visit(llvm::Value& val);
 

--- a/include/caffeine/Memory/BumpAllocator.h
+++ b/include/caffeine/Memory/BumpAllocator.h
@@ -1,0 +1,30 @@
+#pragma once
+
+#include <llvm/ADT/APInt.h>
+#include <llvm/ADT/Hashing.h>
+#include <optional>
+#include <unordered_set>
+
+namespace caffeine {
+class BumpAllocator {
+private:
+  struct llvm_hash {
+    size_t operator()(const llvm::APInt& v) const {
+      return (size_t)llvm::hash_value(v);
+    }
+  };
+
+  std::unordered_set<llvm::APInt, llvm_hash> allocations;
+  llvm::APInt current;
+
+  llvm::APInt base;
+  llvm::APInt size;
+
+public:
+  BumpAllocator(const llvm::APInt& base, const llvm::APInt& size);
+
+  std::optional<llvm::APInt> allocate(const llvm::APInt& size,
+                                      const llvm::APInt& align);
+  void deallocate(const llvm::APInt& addr);
+};
+} // namespace caffeine

--- a/include/caffeine/Memory/MemHeap.h
+++ b/include/caffeine/Memory/MemHeap.h
@@ -4,6 +4,7 @@
 #include "caffeine/ADT/SlotMap.h"
 #include "caffeine/IR/Operation.h"
 #include "caffeine/Memory/Allocator.h"
+#include "caffeine/Memory/BumpAllocator.h"
 #include <climits>
 #include <llvm/ADT/APInt.h>
 #include <llvm/ADT/DenseMap.h>
@@ -219,7 +220,7 @@ private:
 
   slot_map<Allocation> allocs_;
   unsigned index_;
-  std::variant<std::monostate, BuddyAllocator, std::monostate> allocator_;
+  std::variant<std::monostate, BumpAllocator, std::monostate> allocator_;
 
 public:
   MemHeap(unsigned index, bool concrete = true);

--- a/src/Interpreter/ExprEval.cpp
+++ b/src/Interpreter/ExprEval.cpp
@@ -20,7 +20,7 @@ namespace caffeine {
 
 ExprEvaluator::Unevaluatable::Unevaluatable(llvm::Value* expr,
                                             const char* context)
-    : expr_(expr), context_(context) {
+    : UnsupportedOperationException(""), expr_(expr), context_(context) {
   CAFFEINE_ASSERT(expr != nullptr);
 }
 
@@ -46,19 +46,13 @@ OpRef ExprEvaluator::scalarize(const LLVMScalar& scalar) const {
   return scalar.pointer().value(ctx->heaps);
 }
 
-LLVMValue ExprEvaluator::visit_internal(llvm::Value* val) {
+LLVMValue ExprEvaluator::visit(llvm::Value* val) {
   const auto& frame = ctx->stack_top();
   auto it = frame.variables.find(val);
   if (it != frame.variables.end())
     return it->second;
 
   return evaluate(val);
-}
-
-LLVMValue ExprEvaluator::visit(llvm::Value* val) {
-  try {
-    return visit_internal(val);
-  } catch (Unevaluatable& e) { CAFFEINE_UNSUPPORTED(e.what()); }
 }
 LLVMValue ExprEvaluator::visit(llvm::Value& val) {
   return visit(&val);
@@ -111,7 +105,7 @@ LLVMValue ExprEvaluator::evaluate(llvm::Value& val) {
 
 std::optional<LLVMValue> ExprEvaluator::try_visit(llvm::Value* val) {
   try {
-    return visit_internal(val);
+    return visit(val);
   } catch (Unevaluatable&) { return std::nullopt; }
 }
 

--- a/src/Memory/BumpAllocator.cpp
+++ b/src/Memory/BumpAllocator.cpp
@@ -1,0 +1,48 @@
+#include "caffeine/Memory/BumpAllocator.h"
+#include "caffeine/Support/Assert.h"
+#include "caffeine/Support/LLVMFmt.h"
+#include <fmt/format.h>
+
+namespace caffeine {
+
+BumpAllocator::BumpAllocator(const llvm::APInt& base, const llvm::APInt& size)
+    : current(base), base(base), size(size) {}
+
+std::optional<llvm::APInt> BumpAllocator::allocate(const llvm::APInt& size_,
+                                                   const llvm::APInt& align_) {
+  CAFFEINE_ASSERT(align_.isNullValue() || align_.isPowerOf2(),
+                  "cannot allocate with a non-power-of-2 alignment");
+
+  llvm::APInt align = align_;
+  if (align.getLimitedValue() < 8) {
+    align.clearAllBits();
+    align.setBit(3);
+  }
+
+  // Note: we allocate extra space after the allocation so that we catch out of
+  //       bounds accesses.
+  llvm::APInt size = size_ + 8;
+
+  current += align - 1;
+  current &= ~(align - 1);
+
+  if ((this->size - (current - base)).ult(size))
+    return std::nullopt;
+
+  llvm::APInt pos = current;
+  current += size;
+
+  allocations.insert(pos);
+
+  return pos;
+}
+
+void BumpAllocator::deallocate(const llvm::APInt& addr) {
+  CAFFEINE_ASSERT(
+      allocations.erase(addr),
+      fmt::format(
+          FMT_STRING("attempted to deallocate an invalid address: 0x{:x}"),
+          addr));
+}
+
+} // namespace caffeine


### PR DESCRIPTION
The `BuddyAllocator` we use is broken. However, I have not been able to figure out what is actually going wrong with it since it doesn't show up under simple test programs. As a stopgap measure this PR replaces the buddy allocator with a simpler one that is (more) obviously correct.

I've also included a change to make exceptions thrown by `ExprEvaluator` recoverable. This means that they only kill the current branch instead of all of caffeine.