### PR TITLE
Various optimizations to pointer resolution

### DIFF
--- a/src/Interpreter/Interpreter.cpp
+++ b/src/Interpreter/Interpreter.cpp
@@ -136,6 +136,10 @@ void Interpreter::execute() {
 
     if (!res.contexts().empty()) {
       auto& ctxs = res.contexts();
+      if (ctxs.size() == 1) {
+        *ctx = std::move(ctxs[0]);
+        continue;
+      }
 
       auto it =
           std::remove_if(ctxs.begin(), ctxs.end(), [&](const Context& ctx) {

--- a/src/Solver/Z3Solver.cpp
+++ b/src/Solver/Z3Solver.cpp
@@ -231,13 +231,18 @@ SolverResult Z3Solver::resolve(AssertionList& assertions,
   if (extra.is_constant_value(false))
     return SolverResult::UNSAT;
 
+  for (const Assertion& assertion : assertions) {
+    if (assertion.is_constant_value(false))
+      return SolverResult::UNSAT;
+  }
+
   auto block = CAFFEINE_TRACE_SPAN("Z3Solver::resolve");
 
   z3::solver solver = impl->tactic.mk_solver();
   Z3Model::ConstMap constMap;
 
   Z3OpVisitor visitor{&solver, constMap};
-  for (Assertion assertion : assertions) {
+  for (const Assertion& assertion : assertions) {
     if (assertion.is_empty()) {
       continue;
     }


### PR DESCRIPTION
From looking at traces, the most common callers of `Solver::check` turn out to be pointer resolution. However, when run with the concrete allocator we end up with two problems:
- Resolving a pointer (in store and load) always ends up forking the context, and
- We are making lots of solver calls that don't require instantiating the underlying solver since they contain terms which are just `false`.

This PR addresses both of those issues. The first by using transform builder, and the second by explicitly checking for `false` assertions within the input assertion list.