### PR TITLE
Implement better multithreaded context store

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -108,7 +108,7 @@ endif()
 # TODO: We should have an option to download and build these locally if needed.
 find_package(GTest REQUIRED)
 find_package(Z3 4.8.7 REQUIRED)
-find_package(Boost REQUIRED)
+find_package(Boost COMPONENTS thread REQUIRED)
 find_package(fmt REQUIRED)
 find_package(CapnProto REQUIRED)
 

--- a/include/caffeine/ADT/ThreadMap.h
+++ b/include/caffeine/ADT/ThreadMap.h
@@ -16,7 +16,7 @@ public:
     auto lock = std::shared_lock(mutex);
 
     auto it = map.find(id);
-    return it == map.end() ? nullptr : &it->second;
+    return it == map.end() ? nullptr : it->second.get();
   }
   T* get() {
     return const_cast<T*>(const_cast<const ThreadMap<T>*>(this)->get());
@@ -26,18 +26,25 @@ public:
     return get_or_insert();
   }
 
-  T& get_or_insert() {
+  template <typename... Args>
+  T& get_or_insert(Args&&... args) {
     if (auto* ptr = get())
       return *ptr;
 
     auto id = std::this_thread::get_id();
     auto lock = std::unique_lock(mutex);
-    return map[id];
+    auto it = map.find(id);
+    if (it == map.end()) {
+      it = map.emplace(id, std::make_unique<T>(std::forward<Args>(args)...))
+               .first;
+    }
+
+    return *it->second;
   }
 
 private:
   mutable std::shared_mutex mutex;
-  std::unordered_map<std::thread::id, T> map;
+  std::unordered_map<std::thread::id, std::unique_ptr<T>> map;
 };
 
 } // namespace caffeine

--- a/include/caffeine/Interpreter/Store.h
+++ b/include/caffeine/Interpreter/Store.h
@@ -75,23 +75,4 @@ private:
   std::queue<Context> queue;
 };
 
-class ThreadQueuedContextStore : public QueueingContextStore {
-public:
-  static constexpr size_t local_cache_size = 8;
-
-public:
-  explicit ThreadQueuedContextStore(size_t num_readers,
-                                    size_t cache_size = local_cache_size);
-  ~ThreadQueuedContextStore() = default;
-
-  std::optional<Context> next_context() override;
-
-  void add_context(Context&& ctx) override;
-  void add_context_multi(Span<Context> contexts) override;
-
-private:
-  ThreadMap<std::deque<Context>> locals;
-  size_t cache_size;
-};
-
 } // namespace caffeine

--- a/include/caffeine/Interpreter/ThreadQueueStore.h
+++ b/include/caffeine/Interpreter/ThreadQueueStore.h
@@ -1,0 +1,61 @@
+#pragma once
+
+#include "caffeine/ADT/ThreadMap.h"
+#include "caffeine/Interpreter/Store.h"
+#include <boost/thread/shared_mutex.hpp>
+#include <deque>
+#include <random>
+#include <thread>
+#include <unordered_map>
+
+namespace caffeine {
+
+class ThreadQueueContextStore : public ExecutionContextStore {
+private:
+  struct ThreadQueue {
+    std::mutex mutex;
+    std::deque<Context> queue;
+
+    std::optional<Context> steal();
+    std::optional<Context> dequeue();
+  };
+
+  using QueueMap =
+      std::unordered_map<std::thread::id, std::unique_ptr<ThreadQueue>>;
+
+  std::condition_variable_any condvar;
+  boost::upgrade_mutex mutex;
+  QueueMap queues;
+  // Store RNGs separately so that we don't create empty queues if not
+  // necessary.
+  ThreadMap<std::minstd_rand> rngs;
+
+  bool done = false;
+  bool explicit_shutdown = false;
+  std::atomic_size_t free{0};
+  std::atomic_size_t size{0};
+
+public:
+  ThreadQueueContextStore(unsigned numthreads);
+  ~ThreadQueueContextStore();
+
+  std::optional<Context> next_context() override;
+
+  void add_context(Context&& ctx) override;
+  void add_context_multi(Span<Context> ctxs) override;
+
+  void shutdown();
+
+private:
+  // Lock the store, doesn't ever create a new queue
+  std::pair<std::shared_lock<boost::upgrade_mutex>, ThreadQueue*>
+  try_get_thread_queue();
+
+  // Lock the store and create the overall queue if required.
+  std::pair<std::shared_lock<boost::upgrade_mutex>, ThreadQueue*>
+  get_thread_queue();
+
+  std::minstd_rand& get_rng();
+};
+
+} // namespace caffeine

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -61,6 +61,7 @@ target_link_libraries(caffeine PUBLIC
   immer
   magic_enum::magic_enum
   CapnProto::capnp-rpc
+  Boost::thread
 )
 
 install(

--- a/src/Interpreter/ThreadQueueStore.cpp
+++ b/src/Interpreter/ThreadQueueStore.cpp
@@ -1,9 +1,9 @@
 #include "caffeine/Interpreter/ThreadQueueStore.h"
 #include "caffeine/Support/Tracing.h"
 #include <chrono>
+#include <fmt/format.h>
 #include <iostream>
 #include <iterator>
-#include <fmt/format.h>
 
 namespace caffeine {
 
@@ -137,7 +137,7 @@ std::optional<Context> ThreadQueueContextStore::next_context() {
 }
 
 void ThreadQueueContextStore::add_context(Context&& ctx) {
-  auto block = CAFFEINE_TRACE_SPAN("TQCS::add_context");
+  [[maybe_unused]] auto block = CAFFEINE_TRACE_SPAN("TQCS::add_context");
   auto [lock, tqueue] = get_thread_queue();
   auto queue_lock = std::unique_lock(tqueue->mutex);
 
@@ -146,7 +146,7 @@ void ThreadQueueContextStore::add_context(Context&& ctx) {
 }
 
 void ThreadQueueContextStore::add_context_multi(Span<Context> ctxs) {
-  auto block = CAFFEINE_TRACE_SPAN("TQCS::add_context_multi");
+  [[maybe_unused]] auto block = CAFFEINE_TRACE_SPAN("TQCS::add_context_multi");
   auto [lock, tqueue] = get_thread_queue();
   auto queue_lock = std::unique_lock(tqueue->mutex);
 

--- a/src/Interpreter/ThreadQueueStore.cpp
+++ b/src/Interpreter/ThreadQueueStore.cpp
@@ -1,0 +1,204 @@
+#include "caffeine/Interpreter/ThreadQueueStore.h"
+#include "caffeine/Support/Tracing.h"
+#include <chrono>
+#include <iostream>
+#include <iterator>
+#include <fmt/format.h>
+
+namespace caffeine {
+
+namespace {
+  // Unique lock that can be downgraded down to a shared lock.
+  struct downgrade_lock {
+  private:
+    boost::upgrade_mutex* mutex;
+
+  public:
+    downgrade_lock(boost::upgrade_mutex& mutex) : mutex(&mutex) {
+      mutex.lock();
+    }
+    ~downgrade_lock() {
+      if (mutex)
+        mutex->unlock();
+    }
+
+    // Not copy anythingable
+    downgrade_lock(const downgrade_lock&) = delete;
+    downgrade_lock& operator=(const downgrade_lock&) = delete;
+
+    downgrade_lock(downgrade_lock&& lock) noexcept : mutex(lock.mutex) {
+      lock.mutex = nullptr;
+    }
+    downgrade_lock& operator=(downgrade_lock&& lock) {
+      if (mutex)
+        mutex->unlock();
+
+      mutex = lock.mutex;
+      lock.mutex = nullptr;
+      return *this;
+    }
+
+    // Atomically convert this lock from a unique lock to a shared lock.
+    std::shared_lock<boost::upgrade_mutex> downgrade() {
+      auto guard = make_guard([&] { this->mutex = nullptr; });
+      mutex->unlock_and_lock_shared();
+      return std::shared_lock<boost::upgrade_mutex>(*mutex, std::adopt_lock);
+    }
+  };
+} // namespace
+
+std::optional<Context> ThreadQueueContextStore::ThreadQueue::steal() {
+  auto lock = std::unique_lock(mutex);
+
+  if (queue.empty())
+    return std::nullopt;
+
+  auto guard = make_guard([&] { queue.pop_front(); });
+  return std::move(queue.front());
+}
+
+std::optional<Context> ThreadQueueContextStore::ThreadQueue::dequeue() {
+  auto lock = std::unique_lock(mutex);
+
+  if (queue.empty())
+    return std::nullopt;
+
+  auto guard = make_guard([&] { queue.pop_back(); });
+  return std::move(queue.back());
+}
+
+ThreadQueueContextStore::ThreadQueueContextStore(unsigned numthreads)
+    : free(numthreads) {}
+ThreadQueueContextStore::~ThreadQueueContextStore() {
+  if (explicit_shutdown)
+    return;
+
+  for (auto& [id, tqueue] : queues) {
+    auto& queue = tqueue->queue;
+    CAFFEINE_ASSERT(
+        queue.empty(),
+        "ThreadQueueContextStore shut down with elments still in queues.");
+  }
+}
+
+std::optional<Context> ThreadQueueContextStore::next_context() {
+  auto block = CAFFEINE_TRACE_SPAN("TQCS::next_context");
+  auto [lock, tqueue] = try_get_thread_queue();
+
+  if (tqueue) {
+    if (auto result = tqueue->dequeue()) {
+      size -= 1;
+
+      return result;
+    }
+  }
+
+  auto guard = make_guard([&] { free += 1; });
+  size_t cfree = --free;
+  size_t csize = size.load();
+
+  if (cfree == 0 && csize == 0) {
+    // Every thread is currently blocked and we have nothing in our queue. This
+    // means that it is time to shut down and so we need to unblock everything
+    // and terminate the program.
+
+    // Safe since all other threads are blocked
+    done = true;
+
+    // This synchronizes with condvar::wait so all threads will be able to see
+    // our assignment to done.
+    condvar.notify_all();
+
+    return std::nullopt;
+  }
+
+  block.annotate("blocking", "true");
+  auto& engine = get_rng();
+
+  // If our queue is empty then we try to pull a context off the back of a
+  // random queue. We repeat this until we find a non-empty queue.
+  while (!done) {
+    std::uniform_int_distribution<size_t> dist(0, queues.size() - 1);
+    size_t index = dist(engine);
+
+    auto it = queues.begin();
+    std::advance(it, index);
+    if (auto result = it->second->steal()) {
+      block.annotate("stolen-from", fmt::format("{}", index));
+      block.annotate("num-queues", fmt::format("{}", queues.size()));
+      size -= 1;
+      return result;
+    }
+
+    condvar.wait_for(lock, std::chrono::milliseconds(100));
+  }
+
+  return std::nullopt;
+}
+
+void ThreadQueueContextStore::add_context(Context&& ctx) {
+  auto block = CAFFEINE_TRACE_SPAN("TQCS::add_context");
+  auto [lock, tqueue] = get_thread_queue();
+  auto queue_lock = std::unique_lock(tqueue->mutex);
+
+  size.fetch_add(1);
+  tqueue->queue.push_back(ctx);
+}
+
+void ThreadQueueContextStore::add_context_multi(Span<Context> ctxs) {
+  auto block = CAFFEINE_TRACE_SPAN("TQCS::add_context_multi");
+  auto [lock, tqueue] = get_thread_queue();
+  auto queue_lock = std::unique_lock(tqueue->mutex);
+
+  size.fetch_add(ctxs.size());
+  for (auto&& ctx : ctxs) {
+    tqueue->queue.push_back(std::move(ctx));
+  }
+}
+
+void ThreadQueueContextStore::shutdown() {
+  auto lock = std::shared_lock(mutex);
+  done = true;
+  explicit_shutdown = true;
+}
+
+std::pair<std::shared_lock<boost::upgrade_mutex>,
+          ThreadQueueContextStore::ThreadQueue*>
+ThreadQueueContextStore::try_get_thread_queue() {
+  auto id = std::this_thread::get_id();
+  auto lock = std::shared_lock(mutex);
+  auto it = queues.find(id);
+  ThreadQueue* queue = nullptr;
+
+  if (it != queues.end()) {
+    queue = it->second.get();
+  }
+
+  return {std::move(lock), queue};
+}
+
+std::pair<std::shared_lock<boost::upgrade_mutex>,
+          ThreadQueueContextStore::ThreadQueue*>
+ThreadQueueContextStore::get_thread_queue() {
+  auto id = std::this_thread::get_id();
+  auto lock = std::shared_lock(mutex);
+  auto it = queues.find(id);
+
+  if (it == queues.end()) {
+    lock.unlock();
+    auto unique = downgrade_lock(mutex);
+    it = queues.emplace(id, std::make_unique<ThreadQueue>()).first;
+    lock = unique.downgrade();
+  }
+
+  return {std::move(lock), it->second.get()};
+}
+
+std::minstd_rand& ThreadQueueContextStore::get_rng() {
+  if (auto* rng = rngs.get())
+    return *rng;
+
+  return rngs.get_or_insert(std::random_device()());
+}
+
+} // namespace caffeine

--- a/src/Support/Tracing.cpp
+++ b/src/Support/Tracing.cpp
@@ -14,11 +14,9 @@
 
 namespace caffeine::tracing {
 
-namespace detail {
-  void annotate_tid(AutoTraceBlock& block) {
-    block.annotate("tid", fmt::format("{}", std::this_thread::get_id()));
-  }
-} // namespace detail
+void AutoTraceBlock::annotate_tid(AutoTraceBlock& block) {
+  block.annotate("tid", fmt::format("{}", std::this_thread::get_id()));
+}
 
 #if CAFFEINE_ENABLE_TRACING
 

--- a/tools/caffeine/main.cpp
+++ b/tools/caffeine/main.cpp
@@ -3,6 +3,7 @@
 #include "caffeine/Interpreter/Interpreter.h"
 #include "caffeine/Interpreter/Policy.h"
 #include "caffeine/Interpreter/Store.h"
+#include "caffeine/Interpreter/ThreadQueueStore.h"
 #include "caffeine/Support/DiagnosticHandler.h"
 #include "caffeine/Support/Signal.h"
 #include "caffeine/Support/Tracing.h"
@@ -132,7 +133,7 @@ int main(int argc, char** argv) {
   if (store_type == "queue")
     store = std::make_unique<QueueingContextStore>(options.num_threads);
   else if (store_type == "thread-queue")
-    store = std::make_unique<ThreadQueuedContextStore>(options.num_threads, 2);
+    store = std::make_unique<ThreadQueueContextStore>(options.num_threads);
   else {
     WithColor::error() << " unknown store type '" << store_type << "'\n";
     return 2;


### PR DESCRIPTION
Currently we use `QueueingContextStore` (or a variant thereof that caches the last value). However, this has a problem that if there isn't enough work to saturate all the worker threads then the unused threads will spend a bunch of their time bouncing through locks when new values are inserted into the queue. This results in caffeine using far more CPU than is useful. Furthermore, when new values are inserted generally a different thread will win the race to pull the context out of the store. This means that there is little cache locality when dealing with these contexts.

This PR introduces a new context store called `ThreadQueueContextStore` that keeps a separate deque for each thread. When a thread needs to get a new context it'll pull the most recent one off of it's own queue. If it has no work items then it will pull the oldest element of the queue of a random thread. If unable to find an element in the queue then it will sleep for a period before trying again. This ensures that inactive threads use little CPU while also ensuring that they find work in a reasonable amount of time.

This PR also includes a change to `ThreadMap` so that it can be used with non-default-initializable types as well as some small cleanups within the `Tracing.h`. Furthermore, I've deleted the old `ThreadQueuedExecutor` since it is worse in every single use case compared to the new one.

Closes #459 