### PR TITLE
Rework `Operation` cache to avoid blocking threads

### DIFF
--- a/cmake/CaffeineDependencies.cmake
+++ b/cmake/CaffeineDependencies.cmake
@@ -132,19 +132,12 @@ caffeine_dependency(
 )
 
 caffeine_dependency(
-  AFLplusplus    ""
-  GIT_REPOSITORY https://github.com/AFLplusplus/AFLplusplus
-  GIT_TAG        3.12c
-  GIT_SHALLOW    TRUE
-  GIT_SUBMODULES ""
+  AFLplusplus                ""
+  GIT_REPOSITORY             https://github.com/AFLplusplus/AFLplusplus
+  GIT_TAG                    3.12c
+  GIT_SHALLOW                TRUE
+  GIT_SUBMODULES             ""
   PATCH_COMMAND  "${CMAKE_COMMAND}"
     "${CMAKE_SOURCE_DIR}/cmake/AFLplusplus.patch"
     -P "${CMAKE_SOURCE_DIR}/cmake/CaffeinePatch.cmake"
-)
-
-caffeine_dependency(
-  tsl-hopscotch-map 2.3.0
-  GIT_REPOSITORY    https://github.com/Tessil/hopscotch-map
-  GIT_TAG           v2.3.0
-  GIT_SHALLOW       TRUE
 )

--- a/cmake/CaffeineDependencies.cmake
+++ b/cmake/CaffeineDependencies.cmake
@@ -141,3 +141,10 @@ caffeine_dependency(
     "${CMAKE_SOURCE_DIR}/cmake/AFLplusplus.patch"
     -P "${CMAKE_SOURCE_DIR}/cmake/CaffeinePatch.cmake"
 )
+
+caffeine_dependency(
+  tsl-hopscotch-map 2.3.0
+  GIT_REPOSITORY    https://github.com/Tessil/hopscotch-map
+  GIT_TAG           v2.3.0
+  GIT_SHALLOW       true
+)

--- a/cmake/CaffeineDependencies.cmake
+++ b/cmake/CaffeineDependencies.cmake
@@ -132,12 +132,19 @@ caffeine_dependency(
 )
 
 caffeine_dependency(
-  AFLplusplus                ""
-  GIT_REPOSITORY             https://github.com/AFLplusplus/AFLplusplus
-  GIT_TAG                    3.12c
-  GIT_SHALLOW                TRUE
-  GIT_SUBMODULES             ""
+  AFLplusplus    ""
+  GIT_REPOSITORY https://github.com/AFLplusplus/AFLplusplus
+  GIT_TAG        3.12c
+  GIT_SHALLOW    TRUE
+  GIT_SUBMODULES ""
   PATCH_COMMAND  "${CMAKE_COMMAND}"
     "${CMAKE_SOURCE_DIR}/cmake/AFLplusplus.patch"
     -P "${CMAKE_SOURCE_DIR}/cmake/CaffeinePatch.cmake"
+)
+
+caffeine_dependency(
+  tsl-hopscotch-map 2.3.0
+  GIT_REPOSITORY    https://github.com/Tessil/hopscotch-map
+  GIT_TAG           v2.3.0
+  GIT_SHALLOW       TRUE
 )

--- a/include/caffeine/IR/Operation.h
+++ b/include/caffeine/IR/Operation.h
@@ -302,7 +302,7 @@ public:
   Operation& operator=(Operation&& op) noexcept;
 
   // Need to force operation to have a vtable
-  virtual ~Operation();
+  virtual ~Operation() = default;
 
 protected:
   /**

--- a/include/caffeine/IR/OperationCache.h
+++ b/include/caffeine/IR/OperationCache.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include "caffeine/IR/Operation.h"
-#include <boost/thread/shared_mutex.hpp>
+#include <shared_mutex>
 #include <tsl/hopscotch_set.h>
 
 namespace caffeine {
@@ -15,21 +15,60 @@ private:
   };
 
   struct equal_to {
+    using is_transparent = void;
+
     bool operator()(const OpRef& a, const OpRef& b) const {
       return *a == *b;
     }
+
+    bool operator()(const OpRef& a, const Operation& b) const {
+      return *a == b;
+    }
+    bool operator()(const Operation& a, const OpRef& b) const {
+      return a == *b;
+    }
   };
 
-  boost::upgrade_mutex mutex;
-  tsl::hopscotch_set<OpRef, hasher, equal_to, std::allocator<OpRef>, 30, true>
-      cache;
+  using set_type = tsl::hopscotch_set<OpRef, hasher, equal_to>;
+
+  // Minimum threshold for a GC collection to run automatically.
+  static constexpr size_t min_threshold = 2048;
+
+  mutable std::shared_mutex mutex;
+  set_type set;
+  size_t threshold = min_threshold;
 
 public:
   OperationCache() = default;
 
+  // Get a pointer to the default global cache.
+  static OperationCache* default_cache();
+
+  size_t size() const;
+
+  // Remove all items from the cache.
+  void clear();
+
   // Look up an opertion in the cache, inserting it if it is not already
   // present.
+  //
+  // Note that this method does not cache any of the operands of op. If you want
+  // to cache recursively then use intern instead.
   OpRef cache(Operation&& op);
+  OpRef cache(const Operation& op);
+
+  // Cache op and all of its operands recursively until everything is cached.
+  OpRef intern(const OpRef& op);
+
+  // Remove all items in the map with no external references.
+  //
+  // Normally the cache will automatically perform garbage collection every so
+  // often but this method can be useful for forcing it.
+  void gc();
+
+private:
+  void gc_locked(std::unique_lock<std::shared_mutex>&);
+  OpRef intern_locked(const OpRef& op, std::unique_lock<std::shared_mutex>&);
 };
 
 } // namespace caffeine

--- a/include/caffeine/IR/OperationCache.h
+++ b/include/caffeine/IR/OperationCache.h
@@ -1,0 +1,35 @@
+#pragma once
+
+#include "caffeine/IR/Operation.h"
+#include <boost/thread/shared_mutex.hpp>
+#include <tsl/hopscotch_set.h>
+
+namespace caffeine {
+
+class OperationCache {
+private:
+  struct hasher {
+    size_t operator()(const OpRef& op) const {
+      return hash_value(*op);
+    }
+  };
+
+  struct equal_to {
+    bool operator()(const OpRef& a, const OpRef& b) const {
+      return *a == *b;
+    }
+  };
+
+  boost::upgrade_mutex mutex;
+  tsl::hopscotch_set<OpRef, hasher, equal_to, std::allocator<OpRef>, 30, true>
+      cache;
+
+public:
+  OperationCache() = default;
+
+  // Look up an opertion in the cache, inserting it if it is not already
+  // present.
+  OpRef cache(Operation&& op);
+};
+
+} // namespace caffeine

--- a/include/caffeine/IR/OperationCache.h
+++ b/include/caffeine/IR/OperationCache.h
@@ -6,6 +6,13 @@
 
 namespace caffeine {
 
+/**
+ * Global cache for operations.
+ *
+ * In order to allow for efficient comparisons of operations caffeine memoizes
+ * operation creation. This class is responsible for caching operations that are
+ * currently in use.
+ */
 class OperationCache {
 private:
   struct hasher {

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -62,7 +62,6 @@ target_link_libraries(caffeine PUBLIC
   magic_enum::magic_enum
   CapnProto::capnp-rpc
   Boost::thread
-  tsl::hopscotch_map
 )
 
 install(

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -62,6 +62,7 @@ target_link_libraries(caffeine PUBLIC
   magic_enum::magic_enum
   CapnProto::capnp-rpc
   Boost::thread
+  tsl::hopscotch_map
 )
 
 install(

--- a/src/IR/Operation.cpp
+++ b/src/IR/Operation.cpp
@@ -270,10 +270,10 @@ Constant::Constant(Type t, Symbol&& symbol)
                 ConstantData(std::move(symbol), nullptr)) {}
 
 OpRef Constant::Create(Type t, const Symbol& symbol) {
-  return OpRef(new Constant(t, symbol));
+  return Constant::Create(t, Symbol(symbol));
 }
 OpRef Constant::Create(Type t, Symbol&& symbol) {
-  return OpRef(new Constant(t, std::move(symbol)));
+  return constant_fold(Constant(t, std::move(symbol)));
 }
 
 Operation::Opcode Constant::op_for_symbol(const Symbol& symbol) {
@@ -296,13 +296,13 @@ Value ConstantInt::as_value() const {
 }
 
 OpRef ConstantInt::Create(const llvm::APInt& iconst) {
-  return OpRef(new ConstantInt(iconst));
+  return Create(llvm::APInt(iconst));
 }
 OpRef ConstantInt::Create(llvm::APInt&& iconst) {
-  return OpRef(new ConstantInt(iconst));
+  return constant_fold(ConstantInt(iconst));
 }
 OpRef ConstantInt::Create(bool value) {
-  return ConstantInt::Create(llvm::APInt(1, static_cast<uint64_t>(value)));
+  return Create(llvm::APInt(1, static_cast<uint64_t>(value)));
 }
 OpRef ConstantInt::Create(const Value& value) {
   return Create(value.apint());
@@ -322,13 +322,13 @@ ConstantFloat::ConstantFloat(llvm::APFloat&& fconst)
                 std::move(fconst)) {}
 
 OpRef ConstantFloat::Create(const llvm::APFloat& fconst) {
-  return OpRef(new ConstantFloat(fconst));
+  return Create(llvm::APFloat(fconst));
 }
 OpRef ConstantFloat::Create(llvm::APFloat&& fconst) {
-  return OpRef(new ConstantFloat(fconst));
+  return constant_fold(ConstantFloat(fconst));
 }
 OpRef ConstantFloat::Create(double value) {
-  return OpRef(new ConstantFloat(llvm::APFloat(value)));
+  return Create(llvm::APFloat(value));
 }
 
 /***************************************************
@@ -345,7 +345,7 @@ OpRef ConstantArray::Create(const Symbol& symbol, const OpRef& size) {
 OpRef ConstantArray::Create(Symbol&& symbol, const OpRef& size) {
   CAFFEINE_ASSERT(size->type().is_int());
 
-  return OpRef(new ConstantArray(std::move(symbol), size));
+  return constant_fold(ConstantArray(std::move(symbol), size));
 }
 
 OpRef ConstantArray::with_new_operands(llvm::ArrayRef<OpRef> operands) const {

--- a/src/IR/OperationCache.cpp
+++ b/src/IR/OperationCache.cpp
@@ -1,0 +1,5 @@
+#include "caffeine/IR/OperationCache.h"
+
+namespace caffeine {
+  
+}

--- a/src/IR/OperationCache.cpp
+++ b/src/IR/OperationCache.cpp
@@ -1,5 +1,116 @@
 #include "caffeine/IR/OperationCache.h"
+#include "caffeine/Support/Assert.h"
+
+#include <algorithm>
 
 namespace caffeine {
-  
+
+OperationCache* OperationCache::default_cache() {
+  static OperationCache cache;
+  return &cache;
 }
+
+size_t OperationCache::size() const {
+  auto lock = std::shared_lock(mutex);
+  return set.size();
+}
+
+void OperationCache::clear() {
+  auto lock = std::unique_lock(mutex);
+  set.clear();
+  threshold = min_threshold;
+}
+
+OpRef OperationCache::cache(const Operation& op) {
+  return cache(Operation(op));
+}
+OpRef OperationCache::cache(Operation&& op) {
+  auto hash = hash_value(op);
+
+  // Fast path - the item is already in the cache
+  auto lock = std::shared_lock(mutex);
+  auto it = set.find<Operation>(op, hash);
+  if (it != set.end())
+    return *it;
+
+  // Slow path - need to modify the map itself
+  lock.unlock();
+  auto ulock = std::unique_lock(mutex);
+  auto val = *set.insert(std::make_shared<Operation>(std::move(op))).first;
+
+  if (set.size() > threshold)
+    gc_locked(ulock);
+
+  return val;
+}
+
+OpRef OperationCache::intern(const OpRef& op) {
+  CAFFEINE_ASSERT(op);
+  auto hash = hasher()(op);
+
+  // Fast path - the item is already in the cache
+  auto lock = std::shared_lock(mutex);
+  auto it = set.find(op, hash);
+  if (it != set.end())
+    return *it;
+
+  // Slow path - need to recursively intern values
+  lock.unlock();
+  auto ulock = std::unique_lock(mutex);
+  auto interned = intern_locked(op, ulock);
+
+  if (set.size() > threshold)
+    gc_locked(ulock);
+
+  return interned;
+}
+
+OpRef OperationCache::intern_locked(const OpRef& op,
+                                    std::unique_lock<std::shared_mutex>& lock) {
+  auto it = set.find(op);
+  if (it != set.end())
+    return op;
+
+  bool any_cached = false;
+  size_t num_operands = op->num_operands();
+  llvm::SmallVector<OpRef, 3> operands;
+  operands.reserve(num_operands);
+
+  for (size_t i = 0; i < num_operands; ++i) {
+    const auto& uncached = op->operand_at(i);
+    auto cached = intern_locked(uncached, lock);
+
+    if (cached == uncached)
+      any_cached = true;
+
+    operands.push_back(std::move(cached));
+  }
+
+  if (!any_cached) {
+    set.insert(op);
+    return op;
+  }
+
+  auto cached = op->with_new_operands(operands);
+  set.insert(cached);
+  return cached;
+}
+
+void OperationCache::gc() {
+  auto lock = std::unique_lock(mutex);
+  gc_locked(lock);
+}
+
+void OperationCache::gc_locked(std::unique_lock<std::shared_mutex>&) {
+  for (auto it = set.begin(), end = set.end(); it != end;) {
+    if (it->use_count() == 1) {
+      it = set.erase(it);
+    } else {
+      ++it;
+    }
+  }
+
+  threshold = std::max(set.size() * 2, min_threshold);
+}
+
+} // namespace caffeine


### PR DESCRIPTION
This PR does a few things
1. Add a new dependency on https://github.com/Tessil/hopscotch-map which is a fast hashmap library.
2. Rework the existing operation cache to use a shared lock so that no threads get blocked if the operation is already in the cache.
3. Move the operation cache to its own public header.
4. Change the last few non-cached operation types to be fully cached now.

The one exception here is that `FixedArray` is still lazily cached (i.e. only cached when we need to build an operation that uses it directly). This is to avoid quadratic blowup when caching lots of temporary writes to an array.

This is part of a series of PRs cleaning up caffeine in preparation for focusing more on optimization.