### PR TITLE
Add CI workflow that doesn't use the docker container

### DIFF
--- a/.github/scripts/update-alternatives-llvm.sh
+++ b/.github/scripts/update-alternatives-llvm.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env sh
+
+# Use update-alternatives to register all llvm utility versions
+
+version=$1
+priority=$2
+
+update-alternatives \
+    --verbose \
+    --install /usr/bin/llvm-config       llvm-config      /usr/bin/llvm-config-${version} ${priority} \
+    --slave   /usr/bin/llvm-ar           llvm-ar          /usr/bin/llvm-ar-${version} \
+    --slave   /usr/bin/llvm-as           llvm-as          /usr/bin/llvm-as-${version} \
+    --slave   /usr/bin/llvm-bcanalyzer   llvm-bcanalyzer  /usr/bin/llvm-bcanalyzer-${version} \
+    --slave   /usr/bin/llvm-cov          llvm-cov         /usr/bin/llvm-cov-${version} \
+    --slave   /usr/bin/llvm-diff         llvm-diff        /usr/bin/llvm-diff-${version} \
+    --slave   /usr/bin/llvm-dis          llvm-dis         /usr/bin/llvm-dis-${version} \
+    --slave   /usr/bin/llvm-dwarfdump    llvm-dwarfdump   /usr/bin/llvm-dwarfdump-${version} \
+    --slave   /usr/bin/llvm-extract      llvm-extract     /usr/bin/llvm-extract-${version} \
+    --slave   /usr/bin/llvm-link         llvm-link        /usr/bin/llvm-link-${version} \
+    --slave   /usr/bin/llvm-mc           llvm-mc          /usr/bin/llvm-mc-${version} \
+    --slave   /usr/bin/llvm-nm           llvm-nm          /usr/bin/llvm-nm-${version} \
+    --slave   /usr/bin/llvm-objdump      llvm-objdump     /usr/bin/llvm-objdump-${version} \
+    --slave   /usr/bin/llvm-ranlib       llvm-ranlib      /usr/bin/llvm-ranlib-${version} \
+    --slave   /usr/bin/llvm-readobj      llvm-readobj     /usr/bin/llvm-readobj-${version} \
+    --slave   /usr/bin/llvm-rtdyld       llvm-rtdyld      /usr/bin/llvm-rtdyld-${version} \
+    --slave   /usr/bin/llvm-size         llvm-size        /usr/bin/llvm-size-${version} \
+    --slave   /usr/bin/llvm-stress       llvm-stress      /usr/bin/llvm-stress-${version} \
+    --slave   /usr/bin/llvm-symbolizer   llvm-symbolizer  /usr/bin/llvm-symbolizer-${version} \
+    --slave   /usr/bin/llvm-tblgen       llvm-tblgen      /usr/bin/llvm-tblgen-${version} \
+    --slave   /usr/bin/llvm-objcopy      llvm-objcopy     /usr/bin/llvm-objcopy-${version} \
+    --slave   /usr/bin/llvm-strip        llvm-strip       /usr/bin/llvm-strip-${version}
+
+update-alternatives \
+    --verbose \
+    --install /usr/bin/clang             clang            /usr/bin/clang-${version} ${priority} \
+    --slave   /usr/bin/asan_symbolize    asan_symbolize   /usr/bin/asan_symbolize-${version} \
+    --slave   /usr/bin/clang-cpp         clang-cpp        /usr/bin/clang-cpp-${version} \
+    --slave   /usr/bin/ld.lld            ld.lld           /usr/bin/ld.lld-${version}
+
+update-alternatives \
+  --verbose \
+  --install   /usr/bin/clang++           clang++          /usr/bin/clang++-${version} ${priority}

--- a/.github/workflows/build-apt.yml
+++ b/.github/workflows/build-apt.yml
@@ -1,0 +1,73 @@
+name: build-apt
+
+on:
+  # Don't build CI for stackbot internal branches, they are already built for PRs
+  push:
+    branches-ignore:
+      - stackbot/**
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        compiler: [clang, gcc]
+      # We explicitly want to run all the compilers
+      fail-fast: false
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Install required dependencies
+        # ubuntu-latest already has many of the packages we want installed. See
+        # https://github.com/actions/virtual-environments/blob/main/images/linux/Ubuntu2004-README.md
+        run: |
+          sudo apt-get install -y \
+            ninja-build \
+            libgtest-dev \
+            libfmt-dev \
+            libboost-all-dev \
+            capnproto libcapnp-dev \
+            git-restore-mtime
+          sudo ./.github/scripts/update-alternatives-llvm.sh 11 20
+          go get github.com/SRI-CSL/gllvm/cmd/...
+
+      - name: Set up compiler env vars
+        run: |
+          ./.github/scripts/setup-env.sh --compiler ${{ matrix.compiler }}
+
+      # If we don't do this then all the files have newer timestamps then those
+      # in the cache and no reuse of anything within the build folder occurs.
+      # This script just sets the time of files according to their commit times.
+      - name: Restore time stamps according to commit times
+        run: git restore-mtime
+
+      - uses: actions/cache@v2
+        env:
+          cache-name: cache-build
+        with:
+          path: build
+          key: ${{ env.cache-name }}-os-${{ runner.os }}-compiler-${{ matrix.compiler }}
+
+      # Note: We set CMP0116 to OLD to silence warnings that don't apply since
+      #       we keep the policy as OLD anyway.
+      - name: Configure
+        run: |
+          mkdir -p build
+          cmake -B build -S . -G Ninja \
+            -DCMAKE_POLICY_WARNING_CMP0116=OLD \
+            -DCAFFEINE_CI=ON \
+            -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+            -DCAFFEINE_ENABLE_UBSAN=ON \
+            -DCAFFEINE_ENABLE_ASAN=ON \
+            -DCAFFEINE_ENABLE_LIBC=ON
+
+      - name: Build
+        run: cmake --build build
+
+      - name: Test
+        run: |
+          cd build
+          ctest . --output-on-failure -j$(nproc)


### PR DESCRIPTION
This PR adds an additional actions workflow that doesn't use the docker image. Instead it
- Takes advantage of the pre-installed libraries already on the ubuntu-latest github actions image
- Should (maybe) cache the build directory for faster follow-on rebuilds
- Uses ninja to build in CI (no more nonsensical percentage markers)
- Should be at least 30s faster due to not having to download an entire OS
- Also caches the output build directory for (hopefully) faster rebuilds.

The combination of caching + apt dependencies looks like it is able to bring the build time down to 1-2 minutes for a cached build.