### PR TITLE
Implement Z3 expr -> `Operation` conversions

### DIFF
--- a/include/caffeine/IR/Operation.h
+++ b/include/caffeine/IR/Operation.h
@@ -467,6 +467,9 @@ public:
   static OpRef CreateShl(const OpRef& lhs, const OpRef& rhs);
   static OpRef CreateLShr(const OpRef& lhs, const OpRef& rhs);
   static OpRef CreateAShr(const OpRef& lhs, const OpRef& rhs);
+  static OpRef CreateNand(const OpRef& lhs, const OpRef& rhs);
+  static OpRef CreateNor(const OpRef& lhs, const OpRef& rhs);
+  static OpRef CreateXnor(const OpRef& lhs, const OpRef& rhs);
 
   static OpRef CreateFAdd(const OpRef& lhs, const OpRef& rhs);
   static OpRef CreateFSub(const OpRef& lhs, const OpRef& rhs);
@@ -501,6 +504,9 @@ public:
   CAFFEINE_DECL_BINOP_INT_CONST(Shl);
   CAFFEINE_DECL_BINOP_INT_CONST(LShr);
   CAFFEINE_DECL_BINOP_INT_CONST(AShr);
+  CAFFEINE_DECL_BINOP_INT_CONST(Nand);
+  CAFFEINE_DECL_BINOP_INT_CONST(Nor);
+  CAFFEINE_DECL_BINOP_INT_CONST(Xnor);
 
 #undef CAFFEINE_DECL_BINOP_INT_CONST
 
@@ -522,6 +528,7 @@ public:
   static OpRef Create(Opcode op, const OpRef& operand);
   static OpRef Create(Opcode op, const OpRef& operand, Type returnType);
   static OpRef CreateNot(const OpRef& operand);
+  static OpRef CreateNeg(const OpRef& operand);
   static OpRef CreateFNeg(const OpRef& operand);
   static OpRef CreateFIsNaN(const OpRef& operand);
 

--- a/include/caffeine/Solver/Z3/Convert.h
+++ b/include/caffeine/Solver/Z3/Convert.h
@@ -52,4 +52,21 @@ public:
   }
 };
 
+class Z3ExprConverter {
+  tsl::hopscotch_map<unsigned, OpRef> cached;
+
+  class UnsupportedConversion {};
+
+public:
+  Z3ExprConverter() = default;
+
+  std::optional<OpRef> convert(const z3::expr& expr);
+
+private:
+  OpRef visit(const z3::expr& expr);
+  OpRef visit_detail(const z3::expr& expr);
+
+  OpRef visit_app(const z3::expr& expr);
+};
+
 } // namespace caffeine

--- a/include/caffeine/Solver/Z3/Convert.h
+++ b/include/caffeine/Solver/Z3/Convert.h
@@ -55,7 +55,21 @@ public:
 class Z3ExprConverter {
   tsl::hopscotch_map<unsigned, OpRef> cached;
 
-  class UnsupportedConversion {};
+  class UnsupportedConversion : std::exception {
+  private:
+    std::string msg;
+
+  public:
+    explicit UnsupportedConversion(
+        std::string&& msg = "unable to convert expression")
+        : msg(std::move(msg)) {}
+    explicit UnsupportedConversion(const std::string& msg)
+        : UnsupportedConversion(std::string(msg)) {}
+
+    const char* what() const throw() override {
+      return msg.c_str();
+    }
+  };
 
 public:
   Z3ExprConverter() = default;
@@ -67,6 +81,7 @@ private:
   OpRef visit_detail(const z3::expr& expr);
 
   OpRef visit_app(const z3::expr& expr);
+  OpRef visit_numeral(const z3::expr& expr);
 };
 
 } // namespace caffeine

--- a/src/IR/Operation.cpp
+++ b/src/IR/Operation.cpp
@@ -432,6 +432,17 @@ DECL_BINOP_CREATE(FRem, ASSERT_FP);
   }                                                                            \
   static_assert(true)
 
+OpRef BinaryOp::CreateNand(const OpRef& lhs, const OpRef& rhs) {
+  return UnaryOp::CreateNot(BinaryOp::CreateAnd(lhs, rhs));
+}
+OpRef BinaryOp::CreateNor(const OpRef& lhs, const OpRef& rhs) {
+  return UnaryOp::CreateNot(BinaryOp::CreateOr(lhs, rhs));
+}
+OpRef BinaryOp::CreateXnor(const OpRef& lhs, const OpRef& rhs) {
+  return BinaryOp::CreateOr(BinaryOp::CreateAnd(lhs, rhs),
+                            BinaryOp::CreateNor(lhs, rhs));
+}
+
 OpRef BinaryOp::CreateUMulOverflow(const OpRef& a, const OpRef& b) {
   CAFFEINE_ASSERT(
       a->type() == b->type(),
@@ -541,6 +552,9 @@ DEF_INT_BINOP_CONST_CREATE(Xor);
 DEF_INT_BINOP_CONST_CREATE(Shl);
 DEF_INT_BINOP_CONST_CREATE(LShr);
 DEF_INT_BINOP_CONST_CREATE(AShr);
+DEF_INT_BINOP_CONST_CREATE(Nand);
+DEF_INT_BINOP_CONST_CREATE(Nor);
+DEF_INT_BINOP_CONST_CREATE(Xnor);
 
 #undef DEF_INT_BINOP_CONST_CREATE
 #undef DEF_INT_BINOP_CONST_CREATE_DETAIL
@@ -573,6 +587,10 @@ OpRef UnaryOp::Create(Opcode op, const OpRef& operand, Type returnType) {
 DECL_UNOP_CREATE(Not, ASSERT_INT, operand->type());
 DECL_UNOP_CREATE(FNeg, ASSERT_FP, operand->type());
 DECL_UNOP_CREATE(FIsNaN, ASSERT_FP, Type::int_ty(1));
+
+OpRef UnaryOp::CreateNeg(const OpRef& operand) {
+  return BinaryOp::CreateSub(0, operand);
+}
 
 OpRef UnaryOp::CreateTrunc(Type tgt, const OpRef& operand) {
   CAFFEINE_ASSERT(tgt.is_int());

--- a/test/unit/Solver/Z3/Convert.cpp
+++ b/test/unit/Solver/Z3/Convert.cpp
@@ -1,0 +1,13 @@
+#include "caffeine/Solver/Z3/Convert.h"
+#include <gtest/gtest.h>
+
+using namespace caffeine;
+
+TEST(Z3TestONE, a) {
+  z3::context ctx;
+
+  auto val = ctx.bv_const("test", 33);
+  
+  ASSERT_EQ(val.kind(), Z3_APP_AST);
+  ASSERT_EQ(val.decl().decl_kind(), Z3_OP_UNINTERPRETED);
+}


### PR DESCRIPTION
This PR implements backwards conversions from Z3 expressions to `Operations`. This will be needed for the unsat core work.