### PR TITLE
Investigating longjmp behaviour

### DIFF
--- a/include/caffeine/Interpreter/Interpreter.h
+++ b/include/caffeine/Interpreter/Interpreter.h
@@ -25,7 +25,7 @@ public:
   using ContextVec = llvm::SmallVector<Context, 2>;
 
   ExecutionResult(Status status);
-  ExecutionResult(ContextVec&& contexts);
+  ExecutionResult(ContextVec&& contexts, Status status=Dead);
 
   Status status() const {
     return status_;

--- a/include/caffeine/Interpreter/Interpreter.h
+++ b/include/caffeine/Interpreter/Interpreter.h
@@ -25,7 +25,7 @@ public:
   using ContextVec = llvm::SmallVector<Context, 2>;
 
   ExecutionResult(Status status);
-  ExecutionResult(ContextVec&& contexts, Status status=Dead);
+  ExecutionResult(ContextVec&& contexts, Status status = Dead);
 
   Status status() const {
     return status_;

--- a/src/Interpreter/Interpreter.cpp
+++ b/src/Interpreter/Interpreter.cpp
@@ -63,7 +63,8 @@ Interpreter::extern_functions() {
 }
 
 ExecutionResult::ExecutionResult(Status status) : status_(status) {}
-ExecutionResult::ExecutionResult(llvm::SmallVector<Context, 2>&& contexts, Status status)
+ExecutionResult::ExecutionResult(llvm::SmallVector<Context, 2>&& contexts,
+                                 Status status)
     : status_(status), contexts_(std::move(contexts)) {}
 
 Interpreter::Interpreter(Context* ctx, ExecutionPolicy* policy,

--- a/src/Interpreter/Interpreter.cpp
+++ b/src/Interpreter/Interpreter.cpp
@@ -63,8 +63,8 @@ Interpreter::extern_functions() {
 }
 
 ExecutionResult::ExecutionResult(Status status) : status_(status) {}
-ExecutionResult::ExecutionResult(llvm::SmallVector<Context, 2>&& contexts)
-    : status_(Dead), contexts_(std::move(contexts)) {}
+ExecutionResult::ExecutionResult(llvm::SmallVector<Context, 2>&& contexts, Status status)
+    : status_(status), contexts_(std::move(contexts)) {}
 
 Interpreter::Interpreter(Context* ctx, ExecutionPolicy* policy,
                          ExecutionContextStore* store, FailureLogger* logger,

--- a/src/Interpreter/TransformBuilder.cpp
+++ b/src/Interpreter/TransformBuilder.cpp
@@ -66,7 +66,8 @@ ExecutionResult TransformBuilder::execute(Interpreter* interp) const {
     *interp->ctx = std::move(output[0]);
     return ExecutionResult::Continue;
   } else {
-    return ExecutionResult(std::move(output), ExecutionResult::Status::Continue);
+    return ExecutionResult(std::move(output),
+                           ExecutionResult::Status::Continue);
   }
 }
 

--- a/src/Interpreter/TransformBuilder.cpp
+++ b/src/Interpreter/TransformBuilder.cpp
@@ -66,7 +66,7 @@ ExecutionResult TransformBuilder::execute(Interpreter* interp) const {
     *interp->ctx = std::move(output[0]);
     return ExecutionResult::Continue;
   } else {
-    return ExecutionResult(std::move(output));
+    return ExecutionResult(std::move(output), ExecutionResult::Status::Continue);
   }
 }
 


### PR DESCRIPTION
It seems that after making `ExecutionResult` continue in the `TransformBuilder`, `longjmp` started failing