### PR TITLE
Add `pthread_once`

### DIFF
--- a/libraries/builtins/threading.c
+++ b/libraries/builtins/threading.c
@@ -1,0 +1,21 @@
+#include <pthread.h>
+#include <errno.h>
+
+// TODO: Improve implementation if we ever support
+// analysis of multithreaded programs
+
+// Allegedly this can return EINVAL "If either once_control or init_routine is invalid."
+// ( https://linux.die.net/man/3/pthread_once ) Not sure exactly what "invalid" means here
+// though because the function marks `once_control` and `init_routine` as non-null.
+// I also looked at some implementations and it looks like they just return 0
+int pthread_once(pthread_once_t *once_control,
+    void (*init_routine)(void)) {
+
+  if (*once_control != PTHREAD_ONCE_INIT) {
+    return 0;
+  }
+
+  *once_control = !PTHREAD_ONCE_INIT;
+  init_routine();
+  return 0;
+}

--- a/test/run-pass/pthread/pthread_once.c
+++ b/test/run-pass/pthread/pthread_once.c
@@ -1,0 +1,16 @@
+#include "caffeine.h"
+
+#include <pthread.h>
+
+pthread_once_t lock = PTHREAD_ONCE_INIT;
+int global = 0;
+
+void increment() {
+  global++;
+}
+
+void test() {
+  pthread_once(&lock, increment);
+  pthread_once(&lock, increment);
+  caffeine_assert(global == 1);
+}


### PR DESCRIPTION
C++ exception support calls `pthread_once` at some point which means
that we need to support a bare bones implementation.