### PR TITLE
Add optimization passes to caffeine

### DIFF
--- a/include/caffeine/Interpreter/Executor.h
+++ b/include/caffeine/Interpreter/Executor.h
@@ -7,6 +7,8 @@
 #include "caffeine/Interpreter/FailureLogger.h"
 #include "caffeine/Interpreter/Store.h"
 
+#include <llvm/IR/PassManager.h>
+
 namespace caffeine {
 
 class ExecutionPolicy;
@@ -14,8 +16,10 @@ class ExecutionContextStore;
 
 struct ExecutorOptions {
   uint32_t num_threads = 2;
+  std::shared_ptr<llvm::PassManager<llvm::Module>> pass_manager;
+  std::shared_ptr<llvm::Module> mod;
 
-  constexpr ExecutorOptions() = default;
+  ExecutorOptions(std::shared_ptr<llvm::Module> module);
 };
 
 class Executor {
@@ -29,10 +33,11 @@ private:
 public:
   Executor(ExecutionPolicy* policy, ExecutionContextStore* store,
            FailureLogger* logger, const SolverBuilder* builder,
-           const ExecutorOptions& options = {});
+           const ExecutorOptions& options);
 
   /**
-   * Runs the contexts in its possesion until there are none left
+   * Runs optimization passes on the LLVM module and then runs the contexts in
+   * its possesion until there are none left
    */
   void run();
 

--- a/tools/caffeine/main.cpp
+++ b/tools/caffeine/main.cpp
@@ -108,7 +108,8 @@ int main(int argc, char** argv) {
     }
   }
 
-  auto module = loadFile(argv[0], input_filename.getValue(), ctx);
+  std::shared_ptr<llvm::Module> module =
+      loadFile(argv[0], input_filename.getValue(), ctx);
   if (!module) {
     errs() << argv[0] << ": ";
     WithColor::error() << " loading file '" << input_filename.getValue()
@@ -125,7 +126,7 @@ int main(int argc, char** argv) {
 
   auto logger = CountingFailureLogger{std::cout, function};
 
-  caffeine::ExecutorOptions options;
+  caffeine::ExecutorOptions options(module);
   options.num_threads =
       threads != 0 ? threads : std::thread::hardware_concurrency();
 

--- a/tools/guided-fuzzing/include/CaffeineMutator.h
+++ b/tools/guided-fuzzing/include/CaffeineMutator.h
@@ -24,7 +24,7 @@ public:
   afl_state_t* afl;
 
 private:
-  std::unique_ptr<llvm::Module> module;
+  std::shared_ptr<llvm::Module> module;
   std::unique_ptr<llvm::LLVMContext> llvm_context;
   llvm::Function* fuzz_target;
   std::mutex termination_mutex;

--- a/tools/guided-fuzzing/src/CaffeineMutator.cpp
+++ b/tools/guided-fuzzing/src/CaffeineMutator.cpp
@@ -31,7 +31,7 @@ class NullFailureLogger : public caffeine::FailureLogger {
 };
 
 llvm::Function*
-getTargetFunction(std::unique_ptr<llvm::Module>& module,
+getTargetFunction(std::shared_ptr<llvm::Module>& module,
                   std::unique_ptr<llvm::LLVMContext>& llvm_context) {
   llvm::Function* fuzz_target = module->getFunction(CAFFEINE_FUZZ_START);
   auto bitwidth = module->getDataLayout().getPointerSizeInBits();
@@ -110,7 +110,7 @@ size_t CaffeineMutator::mutate(caffeine::Span<char> data) {
     return 0;
   }
 
-  caffeine::ExecutorOptions options;
+  caffeine::ExecutorOptions options(module);
   options.num_threads = 1;
 
   auto bitwidth = this->module->getDataLayout().getPointerSizeInBits();


### PR DESCRIPTION
We will need optimization passes in order to generate exception
information for c++. In order to implement this I added more options to
the `ExecutorOptions` struct. This leads to a minor interface change
because I want some of these optimization passes to be mandatory so that
the interpreter can depend on the data generated by these passes.