### PR TITLE
Rework function pointers

### DIFF
--- a/include/caffeine/Memory/MemHeap.h
+++ b/include/caffeine/Memory/MemHeap.h
@@ -333,6 +333,13 @@ public:
   const MemHeap& operator[](unsigned index) const;
 
   /**
+   * Shortcut function for accessing the function heap. This is equivalent to
+   * heaps[MemHeapMgr::FUNCTION_INDEX].
+   */
+  MemHeap& function_heap();
+  const MemHeap& function_heap() const;
+
+  /**
    * Get the allocation that this pointer corresponds to.
    *
    * If the pointer is not resolved then this will cause an assertion failure.

--- a/src/Memory/MemHeap.cpp
+++ b/src/Memory/MemHeap.cpp
@@ -542,6 +542,13 @@ const MemHeap& MemHeapMgr::operator[](unsigned index) const {
   return it->getSecond();
 }
 
+MemHeap& MemHeapMgr::function_heap() {
+  return (*this)[MemHeapMgr::FUNCTION_INDEX];
+}
+const MemHeap& MemHeapMgr::function_heap() const {
+  return (*this)[MemHeapMgr::FUNCTION_INDEX];
+}
+
 Allocation& MemHeapMgr::ptr_allocation(const Pointer& ptr) {
   CAFFEINE_ASSERT(ptr.is_resolved(),
                   "cannot get allocation for an unresolved pointer");


### PR DESCRIPTION
This PR changes the size of the allocations used by function pointers to be the number of instructions within the function. This is a pretty small change that doesn't affect much but it'll allow me to refer to jump targets in a uniform way (the pointer to an instruction is now just function ptr + index of instruction). This will be used when trying to fix #485.