### PR TITLE
Fix some `clang-tidy` lint warnings

### DIFF
--- a/src/IR/Operation.cpp
+++ b/src/IR/Operation.cpp
@@ -42,20 +42,20 @@ Operation::Operation(Opcode op, Type t, const OpRef* operands)
   // It'll mess up constructors and destructors.
   CAFFEINE_ASSERT(op != Invalid);
   // No opcodes have > 3 operands
-  CAFFEINE_ASSERT(num_operands() <= 3, "Invalid opcode");
+  CAFFEINE_ASSERT(detail::opcode_nargs(opcode_) <= 3, "Invalid opcode");
 }
 
 Operation::Operation(Opcode op, Type t, const OpRef& op0)
     : opcode_(static_cast<uint16_t>(op)), type_(t), inner_(OpVec{op0}) {
   CAFFEINE_ASSERT(detail::opcode_base(opcode_) != 1,
                   "Tried to create a constant with operands");
-  CAFFEINE_ASSERT(num_operands() == 1);
+  CAFFEINE_ASSERT(detail::opcode_nargs(opcode_) == 1);
 }
 Operation::Operation(Opcode op, Type t, const OpRef& op0, const OpRef& op1)
     : opcode_(static_cast<uint16_t>(op)), type_(t), inner_(OpVec{op0, op1}) {
   CAFFEINE_ASSERT(detail::opcode_base(opcode_) != 1,
                   "Tried to create a constant with operands");
-  CAFFEINE_ASSERT(num_operands() == 2);
+  CAFFEINE_ASSERT(detail::opcode_nargs(opcode_) == 2);
 }
 Operation::Operation(Opcode op, Type t, const OpRef& op0, const OpRef& op1,
                      const OpRef& op2)
@@ -63,7 +63,7 @@ Operation::Operation(Opcode op, Type t, const OpRef& op0, const OpRef& op1,
       inner_(OpVec{op0, op1, op2}) {
   CAFFEINE_ASSERT(detail::opcode_base(opcode_) != 1,
                   "Tried to create a constant with operands");
-  CAFFEINE_ASSERT(num_operands() == 3);
+  CAFFEINE_ASSERT(detail::opcode_nargs(opcode_) == 3);
 }
 
 Operation::Operation(const Operation& op)

--- a/src/Support/UnsupportedOperation.cpp
+++ b/src/Support/UnsupportedOperation.cpp
@@ -1,6 +1,5 @@
 #include "caffeine/Support/UnsupportedOperation.h"
 #include "caffeine/Interpreter/Context.h"
-#include <boost/core/demangle.hpp>
 #include <fmt/format.h>
 #include <fmt/ostream.h>
 #include <llvm/Support/Signals.h>
@@ -15,8 +14,6 @@ std::atomic<bool> UnsupportedOperation::RecoverFailures{true};
 void UnsupportedOperation::Abort(const char* condition, const char* function,
                                  unsigned int line, const char* file,
                                  std::string_view message) {
-  auto demangled = boost::core::demangle(function);
-
   std::stringstream output;
   fmt::print(output,
              "Unsupported operation: {}\n"


### PR DESCRIPTION
This fixes two of the clang-tidy lint warnings. I haven't understood what the root problem is with the other warnings so I haven't fixed them here.