### PR TITLE
Fix search for `longjmp` target

### DIFF
--- a/src/Interpreter/Builtins/setjmp-longjmp.cpp
+++ b/src/Interpreter/Builtins/setjmp-longjmp.cpp
@@ -71,7 +71,7 @@ namespace {
     llvm::Module* module = ctx.mod;
     llvm::Function* setjmp_fn = module->getFunction("_setjmp");
 
-    if (setjmp_fn)
+    if (!setjmp_fn)
       return std::nullopt;
 
     for (size_t i = ctx.stack.size(); i != 0; --i) {

--- a/test/run-fail/intrin/call-longjmp.ll
+++ b/test/run-fail/intrin/call-longjmp.ll
@@ -1,4 +1,3 @@
-; SKIP TEST
 target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128"
 target triple = "x86_64-pc-linux-gnu"
 

--- a/test/run-fail/intrin/invoke-longjmp.ll
+++ b/test/run-fail/intrin/invoke-longjmp.ll
@@ -1,4 +1,3 @@
-; SKIP TEST
 target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128"
 target triple = "x86_64-pc-linux-gnu"
 

--- a/test/run-pass/intrin/longjmp/invoke-longjmp.ll
+++ b/test/run-pass/intrin/longjmp/invoke-longjmp.ll
@@ -1,4 +1,3 @@
-; SKIP TEST
 target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128"
 target triple = "x86_64-pc-linux-gnu"
 


### PR DESCRIPTION
The issue here was pretty simple. All this PR does is do the 1-line fix and re-enable the test cases.

Closes #485 