### PR TITLE
Refactor `StackFrame` in order to simplify returning results

### DIFF
--- a/include/caffeine/Interpreter/Interpreter.h
+++ b/include/caffeine/Interpreter/Interpreter.h
@@ -120,12 +120,6 @@ private:
   void queueContext(Context&& ctx);
   Interpreter cloneWith(Context* ctx);
 
-  // Used to branch to the appropriate normal return path for functions that
-  // are returning and need to do different things based on whether they were
-  // called or invoked. Only works if the top of the stack frames contains the
-  // invoke instruction
-  static void performInvokeReturn(Context& ctx, llvm::Instruction& invoke);
-
 private:
   ExecutionResult visitExternFunc(llvm::CallBase& inst);
 

--- a/include/caffeine/Interpreter/StackFrame.h
+++ b/include/caffeine/Interpreter/StackFrame.h
@@ -58,6 +58,27 @@ public:
   void insert(llvm::Value* value, const OpRef& expr);
   void insert(llvm::Value* value, const LLVMValue& exprs);
 
+  /**
+   * Set the result of the current instruction in the stack frame.
+   * Used by functions in order to set their return value and whether
+   * the function resumed or not.
+   *
+   * If `resume_value` is std::nullopt, then the stack frame current pointer
+   * jumps to the normal execution path if the previous instruction was an
+   * Invoke.
+   *
+   * If `resume_value` has a value, then the stack frame current pointer jumps
+   * to the exceptional execution path that is determined by the resume value
+   * provided (currently unimplemented).
+   *
+   * This function can be called multiple times, and as a result, if `result` is
+   * std::nullopt, it will not override the previously set result.
+   */
+  virtual void set_result(std::optional<LLVMValue> result,
+                          std::optional<LLVMValue> resume_value);
+
+  virtual ~StackFrame() = default;
+
 private:
   static std::atomic<uint64_t> next_frame_id;
 };

--- a/src/Interpreter/Builtins/setjmp-longjmp.cpp
+++ b/src/Interpreter/Builtins/setjmp-longjmp.cpp
@@ -228,14 +228,9 @@ ExecutionResult Interpreter::visitLongjmp(llvm::CallBase& inst) {
 
     // Now we need to check if the caller is an invoke instruction and
     // go to the default return flow
-    llvm::InvokeInst* invoke =
-        llvm::dyn_cast<llvm::InvokeInst>(&*frame.current);
-    if (invoke) {
-      performInvokeReturn(state.ctx, *frame.current);
-    } else {
-      // Don't want to execute _setjmp again
-      ++frame.current;
-    }
+
+    ++frame.current;
+    frame.set_result(std::nullopt, std::nullopt);
 
     insert_fn(std::move(state));
   });


### PR DESCRIPTION
Because currently external functions cannot return values, or call other
functions, I needed to refactor how return values are passed to previous
stack frames.