### PR TITLE
Add external stackframe

### DIFF
--- a/include/caffeine/Interpreter/Interpreter.h
+++ b/include/caffeine/Interpreter/Interpreter.h
@@ -1,6 +1,7 @@
 #ifndef CAFFEINE_INTERP_INTERPRETER_H
 #define CAFFEINE_INTERP_INTERPRETER_H
 
+#include <functional>
 #include <iostream>
 #include <memory>
 
@@ -135,6 +136,18 @@ private:
 
   ExecutionResult visitSetjmp(llvm::CallBase& inst);
   ExecutionResult visitLongjmp(llvm::CallBase& inst);
+
+  // `callExternFunc` will set up the context's stack frame before
+  // performing a function call and then tear it down if that's necessary after
+  // the function returns. It will also preserve the return value
+  template <typename F, typename... Ts>
+  ExecutionResult callExternFunc(Context*, F func, Ts&&... args) {
+    // TODO: Create extern stack frame
+    ExecutionResult res = func(std::forward<Ts>(args)...);
+    // TODO: Pop temp stack frame
+
+    return res;
+  }
 
   friend class TransformBuilder;
 

--- a/src/Interpreter/Interpreter.cpp
+++ b/src/Interpreter/Interpreter.cpp
@@ -409,9 +409,12 @@ ExecutionResult Interpreter::visitCallBase(llvm::CallBase& callBase) {
     auto* prev_inst = &*ctx->stack_top().current;
     auto invoke = llvm::dyn_cast<llvm::InvokeInst>(&callBase);
 
-    // TODO: Create extern stack frame
-    auto res = visitExternFunc(callBase);
-    // TODO: Pop temp stack frame
+    std::function<ExecutionResult(llvm::CallBase&)> func =
+        [&](llvm::CallBase& callBase_) {
+          return this->visitExternFunc(callBase_);
+        };
+
+    auto res = callExternFunc(ctx, func, callBase);
 
     if (!invoke)
       return res;

--- a/src/Interpreter/StackFrame.cpp
+++ b/src/Interpreter/StackFrame.cpp
@@ -32,6 +32,8 @@ void StackFrame::insert(llvm::Value* value, const LLVMValue& exprs) {
 
 void StackFrame::set_result(std::optional<LLVMValue> result,
                             std::optional<LLVMValue> resume_value) {
+  CAFFEINE_ASSERT(!result.has_value() || !resume_value.has_value());
+
   auto& caller = *std::prev(current);
 
   if (result.has_value())
@@ -52,7 +54,9 @@ StackFrame::StackFrame() : frame_id(next_frame_id++) {}
 void ExternalStackFrame::set_result(std::optional<LLVMValue> result,
                                     std::optional<LLVMValue> resume_value) {
   // It would be pretty weird if both of these were set at the same
-  // time, but who am I to judge
+  // time
+  CAFFEINE_ASSERT(!result.has_value() || !resume_value.has_value());
+
   if (result.has_value())
     result_ = result;
 

--- a/src/Interpreter/StackFrame.cpp
+++ b/src/Interpreter/StackFrame.cpp
@@ -47,4 +47,17 @@ void StackFrame::set_result(std::optional<LLVMValue> result,
   }
 }
 
+StackFrame::StackFrame() : frame_id(next_frame_id++) {}
+
+void ExternalStackFrame::set_result(std::optional<LLVMValue> result,
+                                    std::optional<LLVMValue> resume_value) {
+  // It would be pretty weird if both of these were set at the same
+  // time, but who am I to judge
+  if (result.has_value())
+    result_ = result;
+
+  if (resume_value.has_value())
+    resume_value_ = resume_value;
+};
+
 } // namespace caffeine


### PR DESCRIPTION
This PR adds external stack frames which will be used to track return and resume values for functions called by external functions. It also adds a utility method to setup and tear down external stack frames before / after a function is called from an external method.

I didn't tie this all together yet because in the `Context` we have a vector of `StackFrame`s. However, since `ExternalStackFrame` subclasses from `StackFrame` we cannot store it in the same vector. I think the solution will be to use smartpointers in the `Context` but didn't want to add such a big change in one PR.