### PR TITLE
Refactor LLVMValue and LLVMScalar header into Model folder

### DIFF
--- a/include/caffeine/Interpreter/StackFrame.h
+++ b/include/caffeine/Interpreter/StackFrame.h
@@ -8,8 +8,8 @@
 #include <vector>
 
 #include "caffeine/IR/Operation.h"
-#include "caffeine/Interpreter/Value.h"
 #include "caffeine/Memory/MemHeap.h"
+#include "caffeine/Model/Value.h"
 
 namespace caffeine {
 

--- a/include/caffeine/Model/Value.h
+++ b/include/caffeine/Model/Value.h
@@ -123,6 +123,6 @@ std::ostream& operator<<(std::ostream& os, const LLVMValue& value);
 
 } // namespace caffeine
 
-#include "caffeine/Interpreter/Value.inl"
+#include "caffeine/Model/Value.inl"
 
 #endif

--- a/include/caffeine/Model/Value.inl
+++ b/include/caffeine/Model/Value.inl
@@ -1,7 +1,7 @@
 #ifndef CAFFEINE_INTERP_VALUE_INL
 #define CAFFEINE_INTERP_VALUE_INL
 
-#include "caffeine/Interpreter/Value.h"
+#include "caffeine/Model/Value.h"
 
 #include <tuple>
 

--- a/include/caffeine/Solver/Solver.h
+++ b/include/caffeine/Solver/Solver.h
@@ -9,7 +9,7 @@
 #include "caffeine/ADT/Ref.h"
 #include "caffeine/IR/Value.h"
 #include "caffeine/Interpreter/AssertionList.h"
-#include "caffeine/Interpreter/Value.h"
+#include "caffeine/Model/Value.h"
 
 namespace caffeine {
 

--- a/src/Interpreter/ExprEval.cpp
+++ b/src/Interpreter/ExprEval.cpp
@@ -1,8 +1,8 @@
 #include "caffeine/Interpreter/ExprEval.h"
 
 #include "caffeine/Interpreter/Context.h"
-#include "caffeine/Interpreter/Value.h"
 #include "caffeine/Memory/MemHeap.h"
+#include "caffeine/Model/Value.h"
 #include "caffeine/Support/LLVMFmt.h"
 #include "caffeine/Support/UnsupportedOperation.h"
 #include <fmt/format.h>

--- a/src/Interpreter/Interpreter.cpp
+++ b/src/Interpreter/Interpreter.cpp
@@ -4,7 +4,7 @@
 #include "caffeine/Interpreter/StackFrame.h"
 #include "caffeine/Interpreter/Store.h"
 #include "caffeine/Interpreter/TransformBuilder.h"
-#include "caffeine/Interpreter/Value.h"
+#include "caffeine/Model/Value.h"
 #include "caffeine/Support/Assert.h"
 #include "caffeine/Support/LLVMFmt.h"
 #include "caffeine/Support/Tracing.h"

--- a/src/Memory/MemHeap.cpp
+++ b/src/Memory/MemHeap.cpp
@@ -1,7 +1,7 @@
 #include "caffeine/Memory/MemHeap.h"
 #include "caffeine/IR/Assertion.h"
 #include "caffeine/Interpreter/Context.h"
-#include "caffeine/Interpreter/Value.h"
+#include "caffeine/Model/Value.h"
 #include "caffeine/Solver/Solver.h"
 #include "caffeine/Support/Assert.h"
 #include "caffeine/Support/UnsupportedOperation.h"

--- a/src/Model/Value.cpp
+++ b/src/Model/Value.cpp
@@ -1,4 +1,4 @@
-#include "caffeine/Interpreter/Value.h"
+#include "caffeine/Model/Value.h"
 #include "caffeine/IR/Operation.h"
 
 #include <type_traits>


### PR DESCRIPTION
I'd like to separate all the core data structures we use for caffeine out into a `Model` folder so that they don't get conflated with all the stuff around `Interpreter`. This change is the first step in doing that.