### PR TITLE
Remove llvm-support dependency from //tools/compdb

### DIFF
--- a/tools/compdb/BUILD
+++ b/tools/compdb/BUILD
@@ -9,6 +9,5 @@ cc_binary(
         "@boost//:algorithm",
         "@boost//:json",
         "@boost//:process",
-        "@llvm//llvm:Support",
     ],
 )

--- a/tools/compdb/main.cpp
+++ b/tools/compdb/main.cpp
@@ -7,7 +7,6 @@
 #include <boost/process.hpp>
 #include <filesystem>
 #include <iostream>
-#include <llvm/Support/InitLLVM.h>
 #include <optional>
 #include <sstream>
 #include <string>
@@ -32,9 +31,6 @@ std::string execution_root() {
 
 int main(int argc, char** argv) {
   // To get useful stacktraces in case of error.
-  int fake_argc = 1;
-  llvm::InitLLVM llvm(fake_argc, argv);
-
   auto cwd = execution_root();
   auto exec_dir = std::filesystem::current_path();
 


### PR DESCRIPTION
This caused first builds for this to be rather slow and it was only
needed for better stacktraces.