### PR TITLE
Use buildbuddy cache for CI builds

### DIFF
--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -57,7 +57,6 @@ jobs:
           echo build --bes_backend=grpcs://cloud.buildbuddy.io                >> local.bazelrc
           echo build --remote_cache=grpcs://cloud.buildbuddy.io               >> local.bazelrc
           echo build --remote_timeout=3600                                    >> local.bazelrc
-          echo ${{ github.event_name }}
 
       - name: Configure buildbuddy API token
         if: github.event_name != 'pull_request'


### PR DESCRIPTION
Currently our CI caching for bazel doesn't work very well. It's an all-or-nothing affair and is susceptible to getting lost when lots of builds occur. When this happens we need to wait ~3hrs for a full build before any cache artifacts get uploaded which can lead to a bunch of builds stacking up and hogging all the CI runners.

Buildbuddy lets us work around this by providing a remote cache. This allows it to be shared between all CI instances as they run which should help reduce some of the pile-up effect. In addition, it will most likely keep artifacts around for longer and should use less resources than trying to reuse the github actions cache.