### PR TITLE
Add `:compile-commands` as a bazel target

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -2,6 +2,7 @@ load("@bazel_skylib//rules:common_settings.bzl", "bool_flag", "string_flag")
 load("//bazel:configure.bzl", "configure_file")
 load("//bazel:warnings.bzl", "WARNING_FLAGS")
 load("//bazel:clang-format.bzl", "check_format", "do_format")
+load("//bazel:compile-commands.bzl", "compile_commands")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -121,4 +122,8 @@ check_format(
 do_format(
     name = "format",
     deps = CAFFEINE_TARGETS,
+)
+
+compile_commands(
+    name = "compile-commands",
 )

--- a/bazel/compile-commands.bzl
+++ b/bazel/compile-commands.bzl
@@ -1,0 +1,44 @@
+"""
+"""
+
+_SCRIPT = """
+WORKSPACE="$(dirname \"$(readlink WORKSPACE)\")"
+CWD="$(dirname \"${BASH_SOURCE[0]}\")"
+
+cd "$WORKSPACE"
+"$CWD/tools/compdb/compdb" 'deps(//...)' > compile_commands.json
+"""
+
+def _compile_commands(ctx):
+    script = ctx.actions.declare_file(ctx.label.name + ".sh")
+
+    ctx.actions.write(
+        output = script,
+        content = _SCRIPT,
+        is_executable = True,
+    )
+
+    runfiles = ctx.runfiles(
+        files = [
+            ctx.file._workspace,
+            ctx.executable._compdb,
+        ],
+    )
+
+    return [DefaultInfo(executable = script, runfiles = runfiles)]
+
+compile_commands = rule(
+    implementation = _compile_commands,
+    attrs = {
+        "_workspace": attr.label(
+            default = "@//:WORKSPACE",
+            allow_single_file = True,
+        ),
+        "_compdb": attr.label(
+            default = "@caffeine//tools/compdb",
+            executable = True,
+            cfg = "exec",
+        ),
+    },
+    executable = True,
+)


### PR DESCRIPTION
This allows for you to run `bazel run //:compile-commands` and it will generate a `compile_commands.json` database for use with editors. This does the same thing as `./scripts/gen-comp-commands.sh` except it is more convenient to use.