### PR TITLE
Revert CI back to using github actions cache

### DIFF
--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -17,27 +17,39 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+      - uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cache/bazel-disk-cache
+          key: bazel-build-${{ matrix.mode }}-${{ github.sha }}
+          # Prefer our own cache if possible but fall back to using
+          restore-keys: |
+            bazel-build-${{ matrix.mode }}-
+            bazel-format-${{ matrix.mode }}-
       
       - name: Configure bazel flags
         shell: bash
         run: |
-          echo build --compilation_mode=${{ matrix.mode }}                    >> local.bazelrc
-          echo build --bes_results_url=https://app.buildbuddy.io/invocation/  >> local.bazelrc
-          echo build --bes_backend=grpcs://cloud.buildbuddy.io                >> local.bazelrc
-          echo build --remote_cache=grpcs://cloud.buildbuddy.io               >> local.bazelrc
-          echo build --remote_timeout=3600                                    >> local.bazelrc
-
-      - name: Configure buildbuddy API token
-        if: github.event_name != 'pull_request'
+          echo build --compilation_mode=${{ matrix.mode }} >> local.bazelrc
+      
+      - name: Reset accessed time of files within the cache
         shell: bash
         run: |
-          echo build --remote_header=x-buildbuddy-api-key=$BUILDBUDDY_API_KEY >> local.bazelrc
+          mkdir -p ~/.cache/bazel-disk-cache
+          find ~/.cache/bazel-disk-cache -type f -exec touch -a -d "10 years ago" {} \;
       
       - name: Build all caffeine targets
         run: bazel build -- //... -//third_party/... //third_party/divine/...
 
       - name: Run all tests
         run: bazel test -- //test/unit
+
+      - name: Prune unused build cache files
+        shell: bash
+        run: |
+          NFILES=$(find ~/.cache/bazel-disk-cache -type f -atime +100 | wc -l)
+          echo "Deleting $NFILES files"
+          find ~/.cache/bazel-disk-cache -type f -atime +100 | xargs -r -- rm -f
 
   format:
     runs-on: ubuntu-latest
@@ -48,22 +60,33 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-
+      - uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cache/bazel-disk-cache
+          key: bazel-format${{ matrix.mode }}-${{ github.sha }}
+          restore-keys: |
+            bazel-format-${{ matrix.mode }}-
+            bazel-build-${{ matrix.mode }}-
+      
       - name: Configure bazel flags
         shell: bash
         run: |
-          echo build --compilation_mode=${{ matrix.mode }}                    >> local.bazelrc
-          echo build --bes_results_url=https://app.buildbuddy.io/invocation/  >> local.bazelrc
-          echo build --bes_backend=grpcs://cloud.buildbuddy.io                >> local.bazelrc
-          echo build --remote_cache=grpcs://cloud.buildbuddy.io               >> local.bazelrc
-          echo build --remote_timeout=3600                                    >> local.bazelrc
-
-      - name: Configure buildbuddy API token
-        if: github.event_name != 'pull_request'
+          echo build --compilation_mode=${{ matrix.mode }} >> local.bazelrc
+      
+      - name: Reset accessed time of files within the cache
         shell: bash
         run: |
-          echo build --remote_header=x-buildbuddy-api-key=$BUILDBUDDY_API_KEY >> local.bazelrc
+          mkdir -p ~/.cache/bazel-disk-cache
+          find ~/.cache/bazel-disk-cache -type f -exec touch -a -d "10 years ago" {} \;
       
       - name: Check formatting of all targets
         run: bazel run -- //:check-format
+
+      - name: Prune unused build cache files
+        shell: bash
+        run: |
+          NFILES=$(find ~/.cache/bazel-disk-cache -type f -atime +100 | wc -l)
+          echo "Deleting $NFILES files"
+          find ~/.cache/bazel-disk-cache -type f -atime +100 | xargs -r -- rm -f
 


### PR DESCRIPTION
Turns out that the buildbuddy cache is way too slow when compared with using the disk cache. This PR just goes and fixes the issues that lead to the cache being broken in the first place.

In the future I'll look into avoiding the LLVM build altogether but for now I think using the github actions cache is the best approach. I've also set up the builds to use the related artifacts where applicable.