### PR TITLE
Add some utility classes and scripts for debugging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,7 @@ build/
 .vscode/
 .cache
 
-bazel-*
+bazel-*/**
 compile_commands.json
 local.bazelrc
 

--- a/bazel/bitcode.bzl
+++ b/bazel/bitcode.bzl
@@ -390,6 +390,8 @@ def caffeine_bitcode_test(should_fail = False, skip = False, **kwargs):
     args = [
         "$(location @//tools/caffeine)",
         "$(location {}#bitcode)".format(name),
+        "-t",
+        "1",
     ]
     if should_fail:
         args.append("--invert-exitcode")

--- a/include/caffeine/Solver/LoggingSolver.h
+++ b/include/caffeine/Solver/LoggingSolver.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include "caffeine/Solver/Solver.h"
+
+namespace caffeine {
+
+// Solver that logs it's incoming arguments when queried.
+class LoggingSolver : public Solver {
+private:
+  std::shared_ptr<Solver> solver;
+
+  bool should_filter(const AssertionList& assertions, const Assertion& extra);
+
+  void log_arguments(const AssertionList& assertions, const Assertion& extra);
+  void log_result(const SolverResult& result);
+
+public:
+  SolverResult check(AssertionList& assertions, const Assertion& extra);
+  SolverResult resolve(AssertionList& assertions, const Assertion& extra);
+
+  LoggingSolver(const std::shared_ptr<Solver>& solver);
+};
+
+} // namespace caffeine

--- a/scripts/output-path.sh
+++ b/scripts/output-path.sh
@@ -6,4 +6,10 @@ shift
 bazel cquery \
   --output=starlark \
   --starlark:expr="target.files.to_list()[0].path" \
-  "'$TARGET'" "$@"
+  "'$TARGET'" "$@" 2> bazel-out/query.log
+
+if [ $? -ne 0 ]; then
+  cat bazel-out/query.log 1>&2
+fi
+
+rm bazel-out/query.log

--- a/scripts/output-path.sh
+++ b/scripts/output-path.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+TARGET="$1"
+shift
+
+bazel cquery \
+  --output=starlark \
+  --starlark:expr="target.files.to_list()[0].path" \
+  "'$TARGET'" "$@"

--- a/src/Solver/LoggingSolver.cpp
+++ b/src/Solver/LoggingSolver.cpp
@@ -1,0 +1,63 @@
+#include "caffeine/Solver/LoggingSolver.h"
+#include "caffeine/Support/LLVMFmt.h"
+#include <fmt/format.h>
+#include <fmt/ostream.h>
+#include <iostream>
+#include <magic_enum.hpp>
+
+namespace caffeine {
+
+LoggingSolver::LoggingSolver(const std::shared_ptr<Solver>& solver)
+    : solver(solver) {}
+
+bool LoggingSolver::should_filter(const AssertionList& assertions,
+                                  const Assertion& extra) {
+  if (extra.is_constant_value(false))
+    return true;
+  if (assertions.empty() && extra.is_constant_value(true))
+    return true;
+  return false;
+}
+
+void LoggingSolver::log_arguments(const AssertionList& assertions,
+                                  const Assertion& extra) {
+  fmt::print(std::cout, "Call to solver with arguments:\n");
+
+  for (const auto& assertion : assertions)
+    fmt::print(std::cout, FMT_STRING(" - {}\n"), assertion);
+  if (!extra.is_constant_value(true))
+    fmt::print(std::cout, FMT_STRING(" - {}\n"), extra);
+}
+
+void LoggingSolver::log_result(const SolverResult& result) {
+  fmt::print(std::cout, FMT_STRING("Solver call exited with result {}\n"),
+             magic_enum::enum_name(result.kind()));
+}
+
+SolverResult LoggingSolver::check(AssertionList& assertions,
+                                  const Assertion& extra) {
+  bool filter = should_filter(assertions, extra);
+  if (!filter)
+    log_arguments(assertions, extra);
+
+  auto result = solver->check(assertions, extra);
+
+  if (!filter)
+    log_result(result);
+  return result;
+}
+
+SolverResult LoggingSolver::resolve(AssertionList& assertions,
+                                    const Assertion& extra) {
+  bool filter = should_filter(assertions, extra);
+  if (!filter)
+    log_arguments(assertions, extra);
+
+  auto result = solver->resolve(assertions, extra);
+
+  if (!filter)
+    log_result(result);
+  return result;
+}
+
+} // namespace caffeine

--- a/tools/caffeine/main.cpp
+++ b/tools/caffeine/main.cpp
@@ -161,7 +161,7 @@ int main(int argc, char** argv) {
 
   auto policy = caffeine::AlwaysAllowExecutionPolicy();
   auto builder = caffeine::SolverBuilder::with_default();
-  
+
   auto exec =
       caffeine::Executor(&policy, store.get(), &logger, &builder, options);
 

--- a/tools/caffeine/main.cpp
+++ b/tools/caffeine/main.cpp
@@ -161,7 +161,6 @@ int main(int argc, char** argv) {
 
   auto policy = caffeine::AlwaysAllowExecutionPolicy();
   auto builder = caffeine::SolverBuilder::with_default();
-  builder.with<LoggingSolver>();
   
   auto exec =
       caffeine::Executor(&policy, store.get(), &logger, &builder, options);

--- a/tools/caffeine/main.cpp
+++ b/tools/caffeine/main.cpp
@@ -4,6 +4,7 @@
 #include "caffeine/Interpreter/Policy.h"
 #include "caffeine/Interpreter/Store.h"
 #include "caffeine/Interpreter/ThreadQueueStore.h"
+#include "caffeine/Solver/LoggingSolver.h"
 #include "caffeine/Support/DiagnosticHandler.h"
 #include "caffeine/Support/Signal.h"
 #include "caffeine/Support/Tracing.h"
@@ -160,6 +161,8 @@ int main(int argc, char** argv) {
 
   auto policy = caffeine::AlwaysAllowExecutionPolicy();
   auto builder = caffeine::SolverBuilder::with_default();
+  builder.with<LoggingSolver>();
+  
   auto exec =
       caffeine::Executor(&policy, store.get(), &logger, &builder, options);
 


### PR DESCRIPTION
This PR adds some helpers that I found useful while attempting to debug the malloc-free issue. They aren't used anywhere but are useful to when you need logging output.

This PR includes:
- A script to print out the path to the output of a bazel targets. This is surprisingly annoying to get out of bazel so I've wrapped it in a script.
- A solver wrapper that logs all the assertions passed in along with the result output by the solver.
- A fix to the test harness so that it runs caffeine tests in single-threaded mode similar to how the cmake test setup does.