### PR TITLE
[bazel] Run most integration tests in CI

### DIFF
--- a/bazel/bitcode.bzl
+++ b/bazel/bitcode.bzl
@@ -384,9 +384,6 @@ def caffeine_bitcode_test(should_fail = False, skip = False, **kwargs):
     )
 
     tags = ["no-sandbox"]
-    if skip:
-        tags.append("manual")
-
     args = [
         "$(location @//tools/caffeine)",
         "$(location {}#bitcode)".format(name),
@@ -396,18 +393,26 @@ def caffeine_bitcode_test(should_fail = False, skip = False, **kwargs):
     if should_fail:
         args.append("--invert-exitcode")
 
-    native.sh_test(
-        name = name,
-        srcs = ["@//bazel:run_command.sh"],
-        tags = tags,
-        args = args,
-        data = [
-            ":{}#bitcode".format(name),
-            "@llvm//llvm:llvm-symbolizer",
-            "@//tools/caffeine",
-        ],
-        env = {
-            "LLVM_SYMBOLIZER_PATH": "$(location @llvm//llvm:llvm-symbolizer)",
-        },
-        **test_args
-    )
+    if skip:
+        native.sh_test(
+            name = name,
+            srcs = ["@caffeine//test:skip-test-bazel.sh"],
+            args = [native.package_name(), name],
+            data = [":{}#bitcode".format(name)],
+        )
+    else:
+        native.sh_test(
+            name = name,
+            srcs = ["@//bazel:run_command.sh"],
+            tags = tags,
+            args = args,
+            data = [
+                ":{}#bitcode".format(name),
+                "@llvm//llvm:llvm-symbolizer",
+                "@//tools/caffeine",
+            ],
+            env = {
+                "LLVM_SYMBOLIZER_PATH": "$(location @llvm//llvm:llvm-symbolizer)",
+            },
+            **test_args
+        )

--- a/test/BUILD
+++ b/test/BUILD
@@ -1,3 +1,5 @@
+exports_files(["skip-test-bazel.sh"])
+
 cc_binary(
     name = "skip-test",
     srcs = ["skip-test.cpp"],

--- a/test/run-fail/intrin/BUILD
+++ b/test/run-fail/intrin/BUILD
@@ -3,4 +3,8 @@ load("//test:tests.bzl", "generate_tests")
 generate_tests(
     exclude = [],
     should_fail = True,
+    skip_files = [
+        "call-longjmp.ll",
+        "invoke-longjmp.ll",
+    ],
 )

--- a/test/run-fail/mem/BUILD
+++ b/test/run-fail/mem/BUILD
@@ -3,4 +3,5 @@ load("//test:tests.bzl", "generate_tests")
 generate_tests(
     exclude = [],
     should_fail = True,
+    skip_files = ["alloca-escaped.c"],
 )

--- a/test/run-pass/intrin/longjmp/BUILD
+++ b/test/run-pass/intrin/longjmp/BUILD
@@ -1,3 +1,3 @@
 load("//test:tests.bzl", "generate_tests")
 
-generate_tests(skip_files = [])
+generate_tests(skip_files = ["invoke-longjmp.ll"])

--- a/test/run-pass/mem/BUILD
+++ b/test/run-pass/mem/BUILD
@@ -1,3 +1,3 @@
 load("//test:tests.bzl", "generate_tests")
 
-generate_tests(skip_files = [])
+generate_tests(skip_files = ["malloc-free.c"])

--- a/test/skip-test-bazel.sh
+++ b/test/skip-test-bazel.sh
@@ -1,0 +1,17 @@
+#!/bin/env bash
+
+SUITE="$1"
+TEST="$2"
+
+XML=<<EOF
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites>
+  <testsuite name="$SUITE">
+    <testcase name="$TEST">
+      <skipped/>
+    </testcase>
+  </testsuite>
+</testsuites>
+EOF
+
+echo "$XML" > "$XML_OUTPUT_FILE"


### PR DESCRIPTION
This change makes the bazel CI run all currently passing tests and any newly introduced ones. In order to make CI pass I've explicitly marked the currently failing tests as skipped within the BUILD files.

I'll remove these tests from the skipped lists as they get fixed.