### PR TITLE
Fix cmake error message if `clang-tidy` is not found

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -100,9 +100,9 @@ find_program(CLANG_TIDY clang-tidy)
 if (CLANG_TIDY STREQUAL "CLANG_TIDY-NOTFOUND")
   message(
     ${CAFFEINE_WARNING}
-    "Unable to find clang-format. "
-    "Formatting target will not be configured. "
-    "Specify CLANG_FORMAT to re-enable formatting."
+    "Unable to find clang-tidy. "
+    "Linting target will not be configured. "
+    "Specify CLANG_TIDY to re-enable formatting."
   )
 else()
   include(CaffeineLinting)


### PR DESCRIPTION
Previously this would say that `clang-format` was not found which is wrong and confusing. This fixes the error message to actually say to install clang-tidy.