### PR TITLE
Relieve cache pressure by reducing the number of caches uploaded by PRs

### DIFF
--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -17,7 +17,21 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+
       - uses: actions/cache@v2
+        if: ${{ !github.ref.endsWith('merge') }}
+        with:
+          path: |
+            ~/.cache/bazel-disk-cache
+          key: bazel-build-${{ matrix.mode }}-${{ github.sha }}
+          # Prefer our own cache if possible but fall back to using
+          restore-keys: |
+            bazel-build-${{ matrix.mode }}-
+            bazel-format-${{ matrix.mode }}-
+      
+      # Use a fork of the cache action that doesn't save the cache if it got a cache hit
+      - uses: Phantomical/cache@44a67f2178cb7151430282b0650055385d637880
+        if: ${{ github.ref.endsWith('merge') }}
         with:
           path: |
             ~/.cache/bazel-disk-cache

--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - uses: actions/cache@v2
-        if: ${{ !github.ref.endsWith('merge') }}
+        if: ${{ !endsWith(github.ref, '/merge') }}
         with:
           path: |
             ~/.cache/bazel-disk-cache
@@ -31,7 +31,7 @@ jobs:
       
       # Use a fork of the cache action that doesn't save the cache if it got a cache hit
       - uses: Phantomical/cache@44a67f2178cb7151430282b0650055385d637880
-        if: ${{ github.ref.endsWith('merge') }}
+        if: ${{ endsWith(github.ref, '/merge') }}
         with:
           path: |
             ~/.cache/bazel-disk-cache


### PR DESCRIPTION
Currently every CI run by a PR uploads a new cache artifact. These are large and can push out the caches made by the master branch rather quickly. Instead, this new change only uploads a cache in a PR if it didn't get a cache hit.