### PR TITLE
Convert `Interpreter` to use `InterpreterContext` in easy cases

### DIFF
--- a/include/caffeine/Interpreter/InterpreterContext.h
+++ b/include/caffeine/Interpreter/InterpreterContext.h
@@ -94,6 +94,15 @@ public:
    */
   void jump_to(llvm::BasicBlock* block);
 
+  /**
+   * Return from the current stack frame with an optional return value. If this
+   * causes the stack to be empty then the context will also be killed.
+   *
+   * This will cause an assertion failure if the current function's return type
+   * is inconsistent with the presence (or lack thereof) of a return value.
+   */
+  void function_return(std::optional<LLVMValue> retval = std::nullopt);
+
   // Assertion/Solver-related methods
 
   /**

--- a/include/caffeine/Interpreter/InterpreterContext.h
+++ b/include/caffeine/Interpreter/InterpreterContext.h
@@ -85,6 +85,15 @@ public:
   void store(llvm::Value* ident, const LLVMValue& value);
   void store(llvm::Value* ident, LLVMValue&& value);
 
+  /**
+   * Set the instruction pointer of the current stack frame to the first
+   * instruction within the provided basic block.
+   *
+   * The basic block must belong to the same function as that for the current
+   * stack frame and current stack frame must not be an external stack frame.
+   */
+  void jump_to(llvm::BasicBlock* block);
+
   // Assertion/Solver-related methods
 
   /**

--- a/src/Interpreter/Interpreter.cpp
+++ b/src/Interpreter/Interpreter.cpp
@@ -302,20 +302,13 @@ ExecutionResult Interpreter::visitBranchInst(llvm::BranchInst& inst) {
   return ExecutionResult::Migrated;
 }
 ExecutionResult Interpreter::visitReturnInst(llvm::ReturnInst& inst) {
-  std::optional<LLVMValue> result = std::nullopt;
-  if (inst.getNumOperands() != 0)
-    result = ctx->lookup(inst.getOperand(0));
+  if (inst.getNumOperands() != 0) {
+    interp->function_return(interp->load(inst.getOperand(0)));
+  } else {
+    interp->function_return();
+  }
 
-  ctx->pop();
-
-  if (ctx->empty())
-    return ExecutionResult::Stop;
-
-  auto& parent = ctx->stack_top();
-
-  parent.set_result(result, std::nullopt);
-
-  return ExecutionResult::Continue;
+  return ExecutionResult::Migrated;
 }
 ExecutionResult Interpreter::visitSwitchInst(llvm::SwitchInst& inst) {
   auto cond = ctx->lookup(inst.getCondition()).scalar().expr();

--- a/src/Interpreter/Interpreter.cpp
+++ b/src/Interpreter/Interpreter.cpp
@@ -194,10 +194,8 @@ ExecutionResult Interpreter::visitUDiv(llvm::BinaryOperator& op) {
   return ExecutionResult::Migrated;
 }
 ExecutionResult Interpreter::visitSDiv(llvm::BinaryOperator& op) {
-  auto& frame = ctx->stack_top().get_regular();
-
-  auto lhs = ctx->lookup(op.getOperand(0));
-  auto rhs = ctx->lookup(op.getOperand(1));
+  auto lhs = interp->load(op.getOperand(0));
+  auto rhs = interp->load(op.getOperand(1));
 
   auto result = transform_exprs(
       [&](const auto& lhs, const auto& rhs) {
@@ -207,20 +205,18 @@ ExecutionResult Interpreter::visitSDiv(llvm::BinaryOperator& op) {
                      llvm::APInt::getSignedMinValue(lhs->type().bitwidth())));
         auto cmp3 = ICmpOp::CreateICmpEQ(rhs, -1);
 
-        // lhs == 0 || (lhs == INT_MIN && rhs == -1)
-        Assertion assertion =
-            BinaryOp::CreateOr(cmp1, BinaryOp::CreateAnd(cmp2, cmp3));
-        if (ctx->check(solver, assertion) == SolverResult::SAT)
-          logFailure(*ctx, assertion, "sdiv fault (div by 0 or overflow)");
-        ctx->add(!assertion);
+        // assert lhs == 0 || (lhs == INT_MIN && rhs == -1)
+        interp->assert_or_fail(!Assertion(BinaryOp::CreateOr(
+                                   cmp1, BinaryOp::CreateAnd(cmp2, cmp3))),
+                               "sdiv fault (div by 0 or overflow)");
 
         return BinaryOp::CreateSDiv(lhs, rhs);
       },
       lhs, rhs);
 
-  frame.insert(&op, std::move(result));
+  interp->store(&op, std::move(result));
 
-  return ExecutionResult::Continue;
+  return ExecutionResult::Migrated;
 }
 ExecutionResult Interpreter::visitSRem(llvm::BinaryOperator& op) {
   auto& frame = ctx->stack_top().get_regular();

--- a/src/Interpreter/Interpreter.cpp
+++ b/src/Interpreter/Interpreter.cpp
@@ -261,13 +261,13 @@ ExecutionResult Interpreter::visitURem(llvm::BinaryOperator& op) {
 }
 
 ExecutionResult Interpreter::visitPHINode(llvm::PHINode& node) {
-  auto& frame = ctx->stack_top().get_regular();
+  auto& frame = interp->context().stack_top().get_regular();
 
   // PHI nodes in the entry block is invalid.
   CAFFEINE_ASSERT(frame.prev_block != nullptr);
 
-  auto value = ctx->lookup(node.getIncomingValueForBlock(frame.prev_block));
-  frame.insert(&node, value);
+  auto value = interp->load(node.getIncomingValueForBlock(frame.prev_block));
+  interp->store(&node, value);
 
   return ExecutionResult::Continue;
 }

--- a/src/Interpreter/InterpreterContext.cpp
+++ b/src/Interpreter/InterpreterContext.cpp
@@ -95,6 +95,24 @@ void InterpreterContext::jump_to(llvm::BasicBlock* block) {
   context().stack_top().get_regular().jump_to(block);
 }
 
+void InterpreterContext::function_return(std::optional<LLVMValue> retval) {
+  if (getCurrentFunction()->getReturnType()->isVoidTy()) {
+    CAFFEINE_ASSERT(!retval.has_value());
+  } else {
+    CAFFEINE_ASSERT(retval.has_value());
+  }
+
+  auto& ctx = context();
+  ctx.pop();
+
+  if (ctx.stack.empty()) {
+    kill();
+    return;
+  }
+
+  ctx.stack_top().set_result(retval, std::nullopt);
+}
+
 const std::shared_ptr<Solver>& InterpreterContext::solver() const {
   return solver_;
 }

--- a/src/Interpreter/InterpreterContext.cpp
+++ b/src/Interpreter/InterpreterContext.cpp
@@ -85,6 +85,16 @@ void InterpreterContext::store(llvm::Value* ident, LLVMValue&& value) {
   regular.insert(ident, std::move(value));
 }
 
+void InterpreterContext::jump_to(llvm::BasicBlock* block) {
+  CAFFEINE_ASSERT(!context().stack.empty());
+  CAFFEINE_ASSERT(
+      block->getParent() == getCurrentFunction(),
+      "attempted to jump to basic block not within the current function");
+  CAFFEINE_ASSERT(context().stack_top().is_regular());
+
+  context().stack_top().get_regular().jump_to(block);
+}
+
 const std::shared_ptr<Solver>& InterpreterContext::solver() const {
   return solver_;
 }


### PR DESCRIPTION
This PR converts all the easy cases within `Interpreter` to use `InterpreterContext` instead of directly mucking about within `Context`. It also adds new utility methods to `InterpreterContext` to provide functionality that wasn't already there.

As the next part of this PR stack I'll look into fixing some of the harder parts.