### PR TITLE
Progress output bar

### DIFF
--- a/include/caffeine/Interpreter/ContextEvent.h
+++ b/include/caffeine/Interpreter/ContextEvent.h
@@ -45,7 +45,7 @@ protected:
   void update() override;
 
 public:
-  ContextEventLogger(std::ostream& o) : ContextEventObserver(), os(&o){};
+  ContextEventLogger(std::ostream& o);
 };
 
 } // namespace caffeine

--- a/include/caffeine/Interpreter/ContextEvent.h
+++ b/include/caffeine/Interpreter/ContextEvent.h
@@ -1,14 +1,12 @@
 #pragma once
 
-#include <vector>
 #include <ostream>
-//#include <memory>
+#include <vector>
 
 namespace caffeine {
 
 class ContextEventNotifier;
 class ContextEventObserver;
-
 
 class ContextEventNotifier {
 
@@ -18,7 +16,7 @@ public:
   ContextEventNotifier() = default;
   virtual ~ContextEventNotifier() = default;
 
-  void add_observer(ContextEventObserver * o);
+  void add_observer(ContextEventObserver* o);
 
   void notify_context_added(size_t added = 1);
   void notify_context_finished(size_t finished = 1);
@@ -29,12 +27,11 @@ class ContextEventObserver {
   virtual void update() = 0;
 
 protected:
-
   size_t total_contexts;
   size_t completed_contexts;
 
 public:
-  ContextEventObserver() : total_contexts(0), completed_contexts(0) {};
+  ContextEventObserver() : total_contexts(0), completed_contexts(0){};
   virtual ~ContextEventObserver() = default;
 
   virtual void update_added_contexts(size_t added);
@@ -42,14 +39,13 @@ public:
 };
 
 class ContextEventLogger : public ContextEventObserver {
-  std::ostream * os;
+  std::ostream* os;
 
 protected:
   void update() override;
 
 public:
-  ContextEventLogger(std::ostream& o) : ContextEventObserver(), os(&o) {};
-
+  ContextEventLogger(std::ostream& o) : ContextEventObserver(), os(&o){};
 };
 
 } // namespace caffeine

--- a/include/caffeine/Interpreter/ContextEvent.h
+++ b/include/caffeine/Interpreter/ContextEvent.h
@@ -1,0 +1,55 @@
+#pragma once
+
+#include <vector>
+#include <ostream>
+//#include <memory>
+
+namespace caffeine {
+
+class ContextEventNotifier;
+class ContextEventObserver;
+
+
+class ContextEventNotifier {
+
+  std::vector<ContextEventObserver*> observers;
+
+public:
+  ContextEventNotifier() = default;
+  virtual ~ContextEventNotifier() = default;
+
+  void add_observer(ContextEventObserver * o);
+
+  void notify_context_added(size_t added = 1);
+  void notify_context_finished(size_t finished = 1);
+};
+
+class ContextEventObserver {
+
+  virtual void update() = 0;
+
+protected:
+
+  size_t total_contexts;
+  size_t completed_contexts;
+
+public:
+  ContextEventObserver() : total_contexts(0), completed_contexts(0) {};
+  virtual ~ContextEventObserver() = default;
+
+  virtual void update_added_contexts(size_t added);
+  virtual void update_finished_contexts(size_t finished);
+};
+
+class ContextEventLogger : public ContextEventObserver {
+  std::ostream * os;
+
+protected:
+  void update() override;
+
+public:
+  ContextEventLogger(std::ostream& o) : ContextEventObserver(), os(&o) {};
+
+};
+
+} // namespace caffeine

--- a/include/caffeine/Interpreter/Policy.h
+++ b/include/caffeine/Interpreter/Policy.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "caffeine/IR/Assertion.h"
+#include "caffeine/Interpreter/ContextEvent.h"
 
 namespace caffeine {
 
@@ -14,7 +15,7 @@ class Context;
  * If you don't care about controlling queuing behaviour you may want to derive
  * from AlwaysAllowExecutionPolicy instead of the base ExecutionPolicy class.
  */
-class ExecutionPolicy {
+class ExecutionPolicy : public ContextEventNotifier {
 public:
   enum ExitStatus {
     // The context returned from the top-level function.

--- a/include/caffeine/Interpreter/Store.h
+++ b/include/caffeine/Interpreter/Store.h
@@ -3,6 +3,7 @@
 #include "caffeine/ADT/Span.h"
 #include "caffeine/ADT/ThreadMap.h"
 #include "caffeine/Interpreter/Context.h"
+#include "caffeine/Interpreter/ContextEvent.h"
 #include <condition_variable>
 #include <mutex>
 #include <optional>
@@ -16,7 +17,7 @@ namespace caffeine {
  * Note that when executing in a multithreaded fashion this may be accessed
  * concurrently from multiple threads.
  */
-class ExecutionContextStore {
+class ExecutionContextStore : public ContextEventNotifier {
 public:
   ExecutionContextStore() = default;
   virtual ~ExecutionContextStore() = default;

--- a/s-outputq:q
+++ b/s-outputq:q
@@ -1,0 +1,7 @@
+  SharedArray-tests[m
+  build-instructions-quick-fix[m
+* [32mlocking-ostream[m
+  master[m
+  progress-output[m
+  test-serializer[m
+  test-serializer-old[m

--- a/src/Interpreter/ContextEvent.cpp
+++ b/src/Interpreter/ContextEvent.cpp
@@ -5,48 +5,39 @@
 namespace caffeine {
 
 //// ContextEventNotifier Member functions
-void ContextEventNotifier::add_observer(ContextEventObserver* o)
-{
-    observers.push_back(o);
+void ContextEventNotifier::add_observer(ContextEventObserver* o) {
+  observers.push_back(o);
 }
 
-void ContextEventNotifier::notify_context_added(size_t added)
-{
-    for (ContextEventObserver * o : observers) {
-        o->update_added_contexts(added);
-    }
+void ContextEventNotifier::notify_context_added(size_t added) {
+  for (ContextEventObserver* o : observers) {
+    o->update_added_contexts(added);
+  }
 }
 
-void ContextEventNotifier::notify_context_finished(size_t finished)
-{
-    for (ContextEventObserver * o : observers) {
-        o->update_finished_contexts(finished);
-    }
+void ContextEventNotifier::notify_context_finished(size_t finished) {
+  for (ContextEventObserver* o : observers) {
+    o->update_finished_contexts(finished);
+  }
 }
 
 //// ContextEventObserver Member Functions
-void ContextEventObserver::update_added_contexts(size_t added)
-{
-    total_contexts += added;
-    update();
+void ContextEventObserver::update_added_contexts(size_t added) {
+  total_contexts += added;
+  update();
 }
 
-void ContextEventObserver::update_finished_contexts(size_t finished)
-{
-    completed_contexts += finished;
-    update();
+void ContextEventObserver::update_finished_contexts(size_t finished) {
+  completed_contexts += finished;
+  update();
 }
 
+void ContextEventLogger::update() {
+  std::stringstream ss;
+  ss << "Currently processed " << completed_contexts << " / " << total_contexts
+     << " total contexts.\n";
 
-void ContextEventLogger::update()
-{
-    std::stringstream ss;
-    ss << "Currently processed " << completed_contexts << " / " << total_contexts << " total contexts.\n";
-
-    // Not thread safe....
-    *os << ss.str() << std::flush;
+  *os << ss.str() << std::flush;
 }
-
-
 
 } // namespace caffeine

--- a/src/Interpreter/ContextEvent.cpp
+++ b/src/Interpreter/ContextEvent.cpp
@@ -1,0 +1,52 @@
+#include "caffeine/Interpreter/ContextEvent.h"
+
+#include <sstream>
+
+namespace caffeine {
+
+//// ContextEventNotifier Member functions
+void ContextEventNotifier::add_observer(ContextEventObserver* o)
+{
+    observers.push_back(o);
+}
+
+void ContextEventNotifier::notify_context_added(size_t added)
+{
+    for (ContextEventObserver * o : observers) {
+        o->update_added_contexts(added);
+    }
+}
+
+void ContextEventNotifier::notify_context_finished(size_t finished)
+{
+    for (ContextEventObserver * o : observers) {
+        o->update_finished_contexts(finished);
+    }
+}
+
+//// ContextEventObserver Member Functions
+void ContextEventObserver::update_added_contexts(size_t added)
+{
+    total_contexts += added;
+    update();
+}
+
+void ContextEventObserver::update_finished_contexts(size_t finished)
+{
+    completed_contexts += finished;
+    update();
+}
+
+
+void ContextEventLogger::update()
+{
+    std::stringstream ss;
+    ss << "Currently processed " << completed_contexts << " / " << total_contexts << " total contexts.\n";
+
+    // Not thread safe....
+    *os << ss.str() << std::flush;
+}
+
+
+
+} // namespace caffeine

--- a/src/Interpreter/Policy.cpp
+++ b/src/Interpreter/Policy.cpp
@@ -6,7 +6,9 @@ namespace caffeine {
 void ExecutionPolicy::on_path_forked(Context&) {}
 void ExecutionPolicy::on_path_dequeued(Context&) {}
 void ExecutionPolicy::on_path_complete(const Context&, ExitStatus,
-                                       const Assertion&) {}
+                                       const Assertion&) {
+  notify_context_finished();
+}
 
 bool AlwaysAllowExecutionPolicy::should_queue_path(const Context&) {
   return true;

--- a/src/Interpreter/ThreadQueueStore.cpp
+++ b/src/Interpreter/ThreadQueueStore.cpp
@@ -143,6 +143,7 @@ void ThreadQueueContextStore::add_context(Context&& ctx) {
 
   size.fetch_add(1);
   tqueue->queue.push_back(ctx);
+  notify_context_added();
 }
 
 void ThreadQueueContextStore::add_context_multi(Span<Context> ctxs) {
@@ -151,6 +152,7 @@ void ThreadQueueContextStore::add_context_multi(Span<Context> ctxs) {
   auto queue_lock = std::unique_lock(tqueue->mutex);
 
   size.fetch_add(ctxs.size());
+  notify_context_added(ctxs.size());
   for (auto&& ctx : ctxs) {
     tqueue->queue.push_back(std::move(ctx));
   }

--- a/tools/caffeine/main.cpp
+++ b/tools/caffeine/main.cpp
@@ -143,6 +143,9 @@ int main(int argc, char** argv) {
   }
 
   auto logger = CountingFailureLogger{std::cout, function};
+  // TODO: REMOVE: // std::unique_ptr<ContextEventObserver> ctx_logger = std::make_unique<ContextEventLogger>(std::cout);
+  ContextEventLogger ctx_logger(std::cout);
+  ContextEventObserver * ctx_observer = &ctx_logger;
 
   caffeine::ExecutorOptions options;
   options.num_threads =
@@ -157,11 +160,15 @@ int main(int argc, char** argv) {
     WithColor::error() << " unknown store type '" << store_type << "'\n";
     return 2;
   }
+  std::cout << store_type << std::endl;
 
   auto policy = caffeine::AlwaysAllowExecutionPolicy();
   auto builder = caffeine::SolverBuilder::with_default();
   auto exec =
       caffeine::Executor(&policy, store.get(), &logger, &builder, options);
+
+  policy.add_observer(ctx_observer);
+  store->add_observer(ctx_observer);
 
   auto context = Context(function);
   context.heaps.set_concrete(!force_symbolic_allocator);

--- a/tools/caffeine/main.cpp
+++ b/tools/caffeine/main.cpp
@@ -143,9 +143,8 @@ int main(int argc, char** argv) {
   }
 
   auto logger = CountingFailureLogger{std::cout, function};
-  // TODO: REMOVE: // std::unique_ptr<ContextEventObserver> ctx_logger = std::make_unique<ContextEventLogger>(std::cout);
   ContextEventLogger ctx_logger(std::cout);
-  ContextEventObserver * ctx_observer = &ctx_logger;
+  ContextEventObserver* ctx_observer = &ctx_logger;
 
   caffeine::ExecutorOptions options;
   options.num_threads =
@@ -160,7 +159,6 @@ int main(int argc, char** argv) {
     WithColor::error() << " unknown store type '" << store_type << "'\n";
     return 2;
   }
-  std::cout << store_type << std::endl;
 
   auto policy = caffeine::AlwaysAllowExecutionPolicy();
   auto builder = caffeine::SolverBuilder::with_default();

--- a/tools/guided-fuzzing/src/GuidedExecutionPolicy.cpp
+++ b/tools/guided-fuzzing/src/GuidedExecutionPolicy.cpp
@@ -55,6 +55,7 @@ void GuidedExecutionPolicy::on_path_complete(const Context& ctx, ExitStatus,
                                              const Assertion& assertion) {
   auto assertions = ctx.assertions;
   auto result = mutator->solver->resolve(assertions, assertion);
+  notify_context_finished();
 
   if (result != SolverResult::SAT)
     return;


### PR DESCRIPTION
This is tested with some of the example tests, and it just prints text that says the number of completed contexts / the number of total contexts every time either number is updated.

I believe there's an issue with thread safety here when using cout for both this progress output and the (printing) failure logger.