### PR TITLE
Avoid caching the format action if possible

### DIFF
--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -24,7 +24,8 @@ jobs:
           path: |
             ~/.cache/bazel-disk-cache
           key: bazel-build-${{ matrix.mode }}-${{ github.sha }}
-          # Prefer our own cache if possible but fall back to using
+          # Prefer our own cache if possible but fall back to using the format
+          # one otherwise.
           restore-keys: |
             bazel-build-${{ matrix.mode }}-
             bazel-format-${{ matrix.mode }}-
@@ -74,14 +75,17 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/cache@v2
+      
+      # Use a fork of the cache action that doesn't save the cache if it got a cache hit
+      - uses: Phantomical/cache@44a67f2178cb7151430282b0650055385d637880
         with:
           path: |
             ~/.cache/bazel-disk-cache
-          key: bazel-format${{ matrix.mode }}-${{ github.sha }}
+          key: bazel-format-${{ matrix.mode }}-${{ github.sha }}
+          # Prefer the build cache so that it keeps being used.
           restore-keys: |
-            bazel-format-${{ matrix.mode }}-
             bazel-build-${{ matrix.mode }}-
+            bazel-format-${{ matrix.mode }}-
       
       - name: Configure bazel flags
         shell: bash


### PR DESCRIPTION
The `format` job is still generating a large cache upload every time it is run. However, it can reuse the cache from the build job if at all possible. This change will prevent it from uploading a new cache artifact if it gets any cache hit and also makes it prefer the cache for the `build` job.