### PR TITLE
Fix test build configuration to always run all tests

### DIFF
--- a/test/unit/BUILD
+++ b/test/unit/BUILD
@@ -14,6 +14,7 @@ cc_library(
         "//:caffeine",
         "//third_party:gtest",
     ],
+    alwayslink = 1,
 )
 
 cc_test(


### PR DESCRIPTION
Turns out bazel wasn't linking all the tests in. This change fixes that so that all of our unit tests are actually being run by bazel test.