### PR TITLE
Mark slow tests as manual tests within bazel

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,6 +1,6 @@
 
-common --action_env=BAZEL_CXXOPTS=-std=c++17
-common --disk_cache=~/.cache/bazel-disk-cache
+build --disk_cache=~/.cache/bazel-disk-cache
+build --action_env=BAZEL_CXXOPTS=-std=c++17
 build --cxxopt='-std=c++17'
 
 # Avoid warning messages in other workspaces since they are not helpful

--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -54,10 +54,12 @@ jobs:
           find ~/.cache/bazel-disk-cache -type f -exec touch -a -d "10 years ago" {} \;
       
       - name: Build all caffeine targets
-        run: bazel build -- //... -//third_party/... //third_party/divine/...
+        run: bazel build -- //...
 
       - name: Run all tests
-        run: bazel test -- //test/unit
+        run: |
+          bazel test -- //... \
+            $(bazel query 'kind(".*_test", //...) intersect attr("tags", "manual", //...)')
 
       - name: Prune unused build cache files
         shell: bash

--- a/bazel/bitcode.bzl
+++ b/bazel/bitcode.bzl
@@ -390,6 +390,10 @@ def caffeine_bitcode_test(should_fail = False, skip = False, **kwargs):
         "-t",
         "1",
     ]
+
+    if "tags" in kwargs:
+        tags += kwargs["tags"]
+
     if should_fail:
         args.append("--invert-exitcode")
 

--- a/test/run-fail/BUILD
+++ b/test/run-fail/BUILD
@@ -1,6 +1,24 @@
 load("//test:tests.bzl", "generate_tests")
+load("//bazel:bitcode.bzl", "caffeine_bitcode_test")
 
 generate_tests(
-    exclude = [],
+    exclude = [
+        "collatz.c",
+        "murmurhash3.c"
+    ],
     should_fail = True,
+)
+
+caffeine_bitcode_test(
+    name = "collatz",
+    srcs = ["collatz.c"],
+    should_fail = True,
+    tags = ["manual"]
+)
+
+caffeine_bitcode_test(
+    name = "murmurhash3",
+    srcs = ["murmurhash3.c"],
+    should_fail = True,
+    tags = ["manual"]
 )


### PR DESCRIPTION
Both `collatz` and `murmurhash3` take > 30s to run. They are still useful to have but it's probably not necessary to run them every time we want to run unit tests locally.

This change marks them as manual and changes CI to still run manual tests. This way they are still continuously tested but they don't slow down the edit loop when working locally.