### PR TITLE
Convert visitIndirectCall to use InterpreterContext

### DIFF
--- a/include/caffeine/Interpreter/Interpreter.h
+++ b/include/caffeine/Interpreter/Interpreter.h
@@ -123,6 +123,7 @@ private:
                   std::string_view message = "");
   void queueContext(Context&& ctx);
   Interpreter cloneWith(Context* ctx);
+  Interpreter cloneWith(InterpreterContext* interp);
 
 private:
   ExecutionResult visitExternFunc(llvm::CallBase& inst);

--- a/include/caffeine/Interpreter/Interpreter.h
+++ b/include/caffeine/Interpreter/Interpreter.h
@@ -122,7 +122,6 @@ private:
   void logFailure(Context& ctx, const Assertion& assertion,
                   std::string_view message = "");
   void queueContext(Context&& ctx);
-  Interpreter cloneWith(Context* ctx);
   Interpreter cloneWith(InterpreterContext* interp);
 
 private:

--- a/include/caffeine/Interpreter/InterpreterContext.h
+++ b/include/caffeine/Interpreter/InterpreterContext.h
@@ -1,12 +1,12 @@
 #pragma once
 
 #include "caffeine/Interpreter/Context.h"
+#include "caffeine/Interpreter/Policy.h"
 #include "caffeine/Solver/Solver.h"
 
 namespace caffeine {
 
 class FailureLogger;
-class ExecutionPolicy;
 
 /**
  * Wrapper around the current execution context.
@@ -150,6 +150,19 @@ public:
    */
   void assert_or_fail(const Assertion& assertion, std::string_view message);
 
+  // Methods for working with pointers
+
+  /**
+   * Assert that it is valid to access the memory at [ptr, ptr+width).
+   *
+   * If this assertion fails then it will kill the current context and emit a
+   * test failure with the provided message as an explanatory string.
+   */
+  void assert_ptr_valid(const Pointer& ptr, uint32_t width,
+                        std::string_view message);
+  void assert_ptr_valid(const Pointer& ptr, const OpRef& width,
+                        std::string_view message);
+
   // Methods managing forks and context queuing
 
   /**
@@ -206,6 +219,11 @@ public:
    */
   void emit_failure(std::string_view message, const Model* model,
                     const Assertion& assertion);
+
+private:
+  // Set the current context as dead and emit the appropriate notifications.
+  void set_dead(ExecutionPolicy::ExitStatus status,
+                const Assertion& assertion = Assertion::constant(true));
 
 public:
   // Interfaces used by the scheduler to interact with InterpreterContext

--- a/include/caffeine/Interpreter/InterpreterContext.h
+++ b/include/caffeine/Interpreter/InterpreterContext.h
@@ -163,6 +163,30 @@ public:
   void assert_ptr_valid(const Pointer& ptr, const OpRef& width,
                         std::string_view message);
 
+  /**
+   * Check whether a pointer is valid and, if so, resolve which concrete
+   * allocations it could point to.
+   *
+   * In more detail:
+   *
+   * - Check to see whether it is possible to point outside of any existing
+   *   allocation. If so, fail the current context and don't do any pointer
+   *   resolution.
+   *
+   *   This is done since if the pointer could be pointing outside of an
+   *   allocation then it's likely that it could possibly be pointing to any
+   *   other allocation and failures found from those branches would not be
+   *   useful.
+   *
+   * - Determine which allocations the pointer could point within and return all
+   *   of them. If the pointer is already known to point to a specific
+   *   allocation then this is efficient.
+   */
+  llvm::SmallVector<Pointer, 1> resolve_ptr(const Pointer& ptr, uint32_t width,
+                                            std::string_view message);
+  llvm::SmallVector<Pointer, 1>
+  resolve_ptr(const Pointer& ptr, const OpRef& width, std::string_view message);
+
   // Methods managing forks and context queuing
 
   /**
@@ -171,8 +195,8 @@ public:
    *
    * This will also set up the new context to be queued up transparently.
    *
-   * Note that if the current context is dead then the forked context will _not_
-   * be dead.
+   * Note that if the current context is dead then the forked context will
+   * _not_ be dead.
    */
   InterpreterContext fork() const;
 

--- a/src/Interpreter/Interpreter.cpp
+++ b/src/Interpreter/Interpreter.cpp
@@ -95,13 +95,6 @@ void Interpreter::queueContext(Context&& ctx) {
   }
 }
 
-Interpreter Interpreter::cloneWith(Context* ctx) {
-  CAFFEINE_ASSERT(ctx);
-
-  Interpreter cloned = *this;
-  cloned.ctx = ctx;
-  return cloned;
-}
 Interpreter Interpreter::cloneWith(InterpreterContext* interp) {
   CAFFEINE_ASSERT(interp);
 

--- a/src/Interpreter/Interpreter.cpp
+++ b/src/Interpreter/Interpreter.cpp
@@ -102,6 +102,14 @@ Interpreter Interpreter::cloneWith(Context* ctx) {
   cloned.ctx = ctx;
   return cloned;
 }
+Interpreter Interpreter::cloneWith(InterpreterContext* interp) {
+  CAFFEINE_ASSERT(interp);
+
+  Interpreter cloned = *this;
+  cloned.interp = interp;
+  cloned.ctx = &interp->context();
+  return cloned;
+}
 
 void Interpreter::execute() {
   auto& frame = ctx->stack_top().get_regular();
@@ -422,49 +430,47 @@ ExecutionResult Interpreter::visitIndirectCall(llvm::CallBase& call) {
       call.isIndirectCall() || !call.getCalledFunction(),
       "visitIndirectCall called with a non-indirect call instruction");
 
-  auto pointer = ctx->lookup(call.getCalledOperand()).scalar().pointer();
+  auto pointer = interp->load(call.getCalledOperand()).scalar().pointer();
   CAFFEINE_ASSERT(
       pointer.heap() == MemHeapMgr::FUNCTION_INDEX,
       "Indirect call instruction called with pointer of wrong type");
 
-  auto assertion = ctx->heaps.check_valid(pointer, 1);
-  if (ctx->check(solver, !assertion) == SolverResult::SAT) {
-    logFailure(*ctx, !assertion, "invalid function pointer");
-
-    // If we get an invalid function pointer then there's a pretty good chance
-    // that we'll potentially be calling all the function pointers. This isn't
-    // likely to yield useful bugs so just kill the context.
-    return ExecutionResult::Dead;
-  }
-
-  auto resolved = ctx->heaps.resolve(solver, pointer, *ctx);
-  auto resolved_forks = ctx->fork(resolved.size());
+  auto resolved = interp->resolve_ptr(pointer, 1, "invalid function pointer");
+  interp->kill();
 
   auto newcall = llvm::cast<llvm::CallBase>(call.clone());
   auto _guard = llvm::unique_value(newcall);
 
-  llvm::SmallVector<Context, 2> forks;
+  for (auto& ptr : resolved) {
+    auto fork = interp->fork();
+    Allocation& alloc = fork.context().heaps.ptr_allocation(ptr);
+    fork.add_assertion(ICmpOp::CreateICmpEQ(
+        alloc.address(), pointer.value(fork.context().heaps)));
 
-  for (auto [fork, ptr] : llvm::zip(resolved_forks, resolved)) {
-    Allocation& alloc = fork.heaps[ptr.heap()][ptr.alloc()];
-    fork.add(ICmpOp::CreateICmp(ICmpOpcode::EQ, alloc.address(),
-                                pointer.value(fork.heaps)));
     newcall->setCalledFunction(
         llvm::cast<FunctionObject>(*alloc.data()).function());
 
     Interpreter interp = cloneWith(&fork);
     auto result = interp.visitCallBase(*newcall);
 
-    if (!result.empty()) {
-      auto& contexts = result.contexts();
-      forks.append(std::move_iterator(contexts.begin()),
-                   std::move_iterator(contexts.end()));
-    } else if (result.status() == ExecutionResult::Continue) {
-      forks.push_back(std::move(fork));
+    switch (result.status()) {
+    case ExecutionResult::Migrated:
+    case ExecutionResult::Continue:
+      break;
+    default:
+      fork.kill();
+
+      for (Context& ctx : result.contexts()) {
+        if (policy->should_queue_path(ctx)) {
+          fork.fork_existing(std::move(ctx));
+        } else {
+          policy->on_path_complete(ctx, ExecutionPolicy::Removed);
+        }
+      }
     }
   }
 
-  return forks;
+  return ExecutionResult::Migrated;
 }
 
 ExecutionResult Interpreter::visitLoadInst(llvm::LoadInst& inst) {

--- a/src/Interpreter/InterpreterContext.cpp
+++ b/src/Interpreter/InterpreterContext.cpp
@@ -169,6 +169,25 @@ void InterpreterContext::assert_ptr_valid(const Pointer& ptr, uint32_t width,
       message);
 }
 
+llvm::SmallVector<Pointer, 1>
+InterpreterContext::resolve_ptr(const Pointer& ptr, uint32_t width,
+                                std::string_view message) {
+  return resolve_ptr(
+      ptr,
+      ConstantInt::Create(llvm::APInt(ptr.offset()->type().bitwidth(), width)),
+      message);
+}
+llvm::SmallVector<Pointer, 1>
+InterpreterContext::resolve_ptr(const Pointer& ptr, const OpRef& width,
+                                std::string_view message) {
+  assert_ptr_valid(ptr, width, message);
+
+  if (is_dead())
+    return {};
+
+  return context().heaps.resolve(solver(), ptr, context());
+}
+
 InterpreterContext InterpreterContext::fork() const {
   auto entry = std::make_unique<ContextQueueEntry>(context().fork_once());
   auto index = queue_->size();


### PR DESCRIPTION
As in title. It turns out that the main issue was that `visitIndirectCall` was creating a copy of the interpreter without also updating the `InterpreterContext` pointer. This fixes that and also puts the same shim used within `execute` in `visitIndirectCall`.

This should now be enough for us to convert function calls to use `InterpreterContext` in a peicemeal fashion.