### PR TITLE
Hide stderr output from tests that throw UnsupportedOperation exceptions

### DIFF
--- a/test/unit/BUILD
+++ b/test/unit/BUILD
@@ -6,9 +6,11 @@ cc_library(
         ["**/*.cpp"],
         exclude = ["main.cpp"],
     ),
+    hdrs = glob(["**/*.h"]),
     copts = WARNING_FLAGS,
     data = ["Interpreter/ir-with-global.ll"],
     local_defines = ["CAFFEINE_BAZEL"],
+    strip_include_prefix = "/test/unit",
     visibility = ["//:__pkg__"],
     deps = [
         "//:caffeine",

--- a/test/unit/Interpreter/ExprEval.cpp
+++ b/test/unit/Interpreter/ExprEval.cpp
@@ -1,4 +1,5 @@
 #include "caffeine/Interpreter/ExprEval.h"
+#include "Util/CaptureOutput.h"
 #include "caffeine/Interpreter/Context.h"
 #include "caffeine/Solver/Solver.h"
 #include "caffeine/Solver/Z3Solver.h"
@@ -29,6 +30,11 @@ public:
     ASSERT_NE(module_with_global, nullptr);
   }
 
+  void TearDown() override {
+    if (HasFailure())
+      capture.emit();
+  }
+
 private:
   std::unique_ptr<llvm::Module> loadFile(const char* filename) {
     llvm::SMDiagnostic error;
@@ -39,6 +45,9 @@ private:
 
     return module;
   }
+
+private:
+  CaptureStderr capture;
 };
 
 TEST_F(ExprEvaluatorTests, does_not_create_allocation) {

--- a/test/unit/Support/UnsupportedOperation.cpp
+++ b/test/unit/Support/UnsupportedOperation.cpp
@@ -1,14 +1,26 @@
 #include "caffeine/Support/UnsupportedOperation.h"
+#include "Util/CaptureOutput.h"
 #include <gtest/gtest.h>
 
 using namespace caffeine;
 
-TEST(UnsupportedOperationTests, throws_correct_exception) {
+class UnsupportedOperationTests : public ::testing::Test {
+private:
+  CaptureStderr capture;
+
+public:
+  void TearDown() override {
+    if (HasFailure())
+      capture.emit();
+  }
+};
+
+TEST_F(UnsupportedOperationTests, throws_correct_exception) {
   ASSERT_THROW(CAFFEINE_UNSUPPORTED("Test Throw"),
                caffeine::UnsupportedOperationException);
 }
 
-TEST(UnsupportedOperationTests, throws_with_message) {
+TEST_F(UnsupportedOperationTests, throws_with_message) {
   try {
     CAFFEINE_UNSUPPORTED("Test Throw");
     FAIL();

--- a/test/unit/Util/CaptureOutput.cpp
+++ b/test/unit/Util/CaptureOutput.cpp
@@ -16,7 +16,7 @@ CaptureStderr::CaptureStderr() : old_stderr(STDERR) {
 #ifndef __linux__
   int newfd = memfd_create("test-log-output", 0);
 #else
-  int newfd = open("test-log-output", O_CREAT | O_RDWR | O_EXCL);
+  int newfd = open("test-log-output", O_CREAT | O_RDWR | O_EXCL, S_IRWXU);
   unlink("test-log-output");
 #endif
 

--- a/test/unit/Util/CaptureOutput.cpp
+++ b/test/unit/Util/CaptureOutput.cpp
@@ -1,0 +1,65 @@
+#include "Util/CaptureOutput.h"
+
+#if defined(__linux__) || defined(__APPLE__)
+#include <errno.h>
+#include <fcntl.h>
+#include <sys/mman.h>
+#include <unistd.h>
+
+#define STDERR 2
+#endif
+
+namespace caffeine {
+
+#if defined(__linux__) || defined(__APPLE__)
+CaptureStderr::CaptureStderr() : old_stderr(STDERR) {
+#ifndef __linux__
+  int newfd = memfd_create("test-log-output", 0);
+#else
+  int newfd = open("test-log-output", O_CREAT | O_RDWR | O_EXCL);
+  unlink("test-log-output");
+#endif
+
+  if (newfd < 0)
+    return;
+
+  old_stderr = dup(STDERR);
+  dup2(newfd, STDERR);
+  close(newfd);
+}
+CaptureStderr::~CaptureStderr() {
+  dup2(old_stderr, STDERR);
+  if (old_stderr != STDERR)
+    close(old_stderr);
+}
+
+void CaptureStderr::emit() {
+  if (old_stderr == STDERR)
+    return;
+
+  char buffer[1024];
+
+  lseek(STDERR, 0, SEEK_SET);
+
+  while (true) {
+    ssize_t result = read(STDERR, buffer, sizeof(buffer));
+    if (result <= 0) {
+      if (result < 0 && errno == -EINTR)
+        continue;
+      break;
+    }
+
+    while (write(old_stderr, buffer, result) < 0 && errno == -EINTR) {}
+  }
+
+  while (ftruncate(STDERR, 0) < 0 && errno == -EINTR) {}
+}
+
+#else
+CaptureStderr::CaptureStderr() {}
+CaptureStderr::~CaptureStderr() {}
+
+void CaptureStderr::emit() {}
+#endif
+
+} // namespace caffeine

--- a/test/unit/Util/CaptureOutput.h
+++ b/test/unit/Util/CaptureOutput.h
@@ -1,0 +1,32 @@
+#pragma once
+
+namespace caffeine {
+
+class CaptureStderr {
+private:
+#ifdef __linux__
+  int redirect_fd;
+  int old_stderr;
+#else
+
+#endif
+
+public:
+  CaptureStderr();
+  ~CaptureStderr();
+
+#ifdef __linux__
+  CaptureStderr(CaptureStderr&&);
+  CaptureStderr& operator=(CaptureStderr&&);
+#else
+  CaptureStderr(CaptureStderr&&) = default;
+  CaptureStderr& operator=(CaptureStderr&&) = default;
+#endif
+
+  CaptureStderr(const CaptureStderr&) = delete;
+  CaptureStderr& operator=(const CaptureStderr&) = delete;
+
+  void emit();
+};
+
+} // namespace caffeine


### PR DESCRIPTION
Throwing UnsupportedOperation always writes directly to stderr. GoogleTest does not automatically catch this in the case where the test passes. Since the output is rather noisy then this makes trying to debug other test failures harder.

This commit addresses this by capturing stderr output to a file and then only printing that output to stderr if the test case fails. In cases where this doesn't work then we fail open and just allow printing to stderr.