### PR TITLE
Write ExternalFunction interface

### DIFF
--- a/include/caffeine/Interpreter/ExternalFunction.h
+++ b/include/caffeine/Interpreter/ExternalFunction.h
@@ -1,0 +1,48 @@
+#pragma once
+
+#include "caffeine/ADT/Span.h"
+
+namespace caffeine {
+class InterpreterContext;
+class LLVMValue;
+
+/**
+ * Interface for an external (non-LLVM-IR) function.
+ *
+ * To implement a new external function all that is needed is to derive from
+ * this class and then register that instance with the interpreter at startup
+ * time.
+ */
+class ExternalFunction {
+public:
+  /**
+   * @brief Call the external function this class implements.
+   *
+   * This method is responsible for carrying out the behaviour of the external
+   * function. For simple functions, all that this may involve is computing the
+   * result of the function (possibly forking along the way) and placing the
+   * result on the stack of all the forks. More complicated functions can create
+   * a custom external stack frame and place that on the stack for whatever
+   * behaviours are needed.
+   *
+   * This function should be thread-safe as it may be called concurrently from
+   * multiple threads.
+   *
+   * @param ctx An InterpreterContext which represents the current thread of
+   *            execution.
+   * @param args The arguments to the current function.
+   */
+  virtual void call(InterpreterContext& ctx, Span<LLVMValue> args) const = 0;
+
+  ExternalFunction() = default;
+  virtual ~ExternalFunction() = default;
+
+protected:
+  ExternalFunction(const ExternalFunction&) = default;
+  ExternalFunction(ExternalFunction&&) = default;
+
+  ExternalFunction& operator=(const ExternalFunction&) = default;
+  ExternalFunction& operator=(ExternalFunction&&) = default;
+};
+
+} // namespace caffeine

--- a/include/caffeine/Interpreter/ExternalFunction.h
+++ b/include/caffeine/Interpreter/ExternalFunction.h
@@ -12,6 +12,13 @@ class LLVMValue;
  * To implement a new external function all that is needed is to derive from
  * this class and then register that instance with the interpreter at startup
  * time.
+ *
+ * Note that this is different from an ExternalStackFrame instance. An external
+ * stack frame allows for more easily dealing with forking and is necessary if
+ * an external function wants to call out to other functions. An external
+ * function _may_ create an external stack frame and put it on the stack but
+ * this is not necessary and most external functions will likely not need to do
+ * so.
  */
 class ExternalFunction {
 public:


### PR DESCRIPTION
This PR introduces the interface for an external function. @mishazharov I realize you were probably going to do this but I needed it now and figured I'd just add it instead of kludging around it not existing yet and having to fix it again later.

The interface itself is pretty simple: all it has is a `call` function that takes an `InterpreterContext` and the function arguments. That's it. That function then does whatever is needed to actually run the function which may include creating an external stack frame if necessary. 