### PR TITLE
Introduce `CaffeineContext` and builder

### DIFF
--- a/include/caffeine/ADT/StringMap.h
+++ b/include/caffeine/ADT/StringMap.h
@@ -1,0 +1,57 @@
+#pragma once
+
+#include <llvm/ADT/SmallString.h>
+#include <llvm/ADT/StringRef.h>
+#include <string>
+#include <string_view>
+#include <tsl/hopscotch_map.h>
+
+namespace caffeine {
+
+namespace detail::string_map {
+  struct string_equal {
+    using is_transparent = void;
+
+  private:
+    static std::string_view to_sv(const char* s) {
+      return s;
+    }
+    static std::string_view to_sv(const std::string& s) {
+      return s;
+    }
+    static std::string_view to_sv(std::string_view v) {
+      return v;
+    }
+    static std::string_view to_sv(llvm::StringRef s) {
+      return std::string_view(s.data(), s.size());
+    }
+    template <size_t N>
+    static std::string_view to_sv(const llvm::SmallString<N>& s) {
+      return to_sv(s.str());
+    }
+
+    friend struct string_hash;
+
+  public:
+    template <typename T, typename U>
+    bool operator()(const T& a, const U& b) const {
+      return to_sv(a) == to_sv(b);
+    }
+  };
+
+  struct string_hash : std::hash<std::string_view> {
+    template <typename T>
+    std::size_t operator()(const T& x) const {
+      return (*this)(string_equal::to_sv(x));
+    }
+  };
+} // namespace detail::string_map
+
+// A instantiation of tsl::hopscotch_map that fills in the details needed to get
+// transparent key comparisons when using a string map.
+template <typename V>
+using StringMap =
+    tsl::hopscotch_map<std::string, V, detail::string_map::string_hash,
+                       detail::string_map::string_equal>;
+
+} // namespace caffeine

--- a/include/caffeine/Interpreter/CaffeineContext.h
+++ b/include/caffeine/Interpreter/CaffeineContext.h
@@ -1,0 +1,80 @@
+#pragma once
+
+#include "caffeine/ADT/StringMap.h"
+#include <llvm/IR/Intrinsics.h>
+#include <memory>
+
+namespace caffeine {
+
+class ExternalFunction;
+
+/**
+ * @brief Global info/context shared by all interpreter and executor instances.
+ *
+ * At the moment, this only includes external function and intrinsic registries.
+ */
+class CaffeineContext {
+private:
+  // All external functions along with their corresponding names.
+  StringMap<std::unique_ptr<ExternalFunction>> functions_;
+  // All intrinsic functions by LLVM Intrinsic ID.
+  tsl::hopscotch_map<llvm::Intrinsic::ID, std::unique_ptr<ExternalFunction>>
+      intrinsics_;
+
+public:
+  const ExternalFunction* function(std::string_view name) const;
+  const ExternalFunction* intrinsic(llvm::Intrinsic::ID id) const;
+
+public:
+  // Builder class for CaffeineContext.
+  //
+  // This is the only supported way of creating a CaffeineContext instance.
+  class Builder {
+  private:
+    StringMap<std::unique_ptr<ExternalFunction>> functions_;
+    tsl::hopscotch_map<llvm::Intrinsic::ID, std::unique_ptr<ExternalFunction>>
+        intrinsics_;
+
+  public:
+    Builder() = default;
+    ~Builder();
+
+    Builder(const Builder&) = delete;
+    Builder& operator=(const Builder&) = delete;
+
+    Builder(Builder&&) = default;
+    Builder& operator=(Builder&&) = default;
+
+    CaffeineContext build();
+
+    // Add a new external function with the provided name. If another external
+    // function is already registered with the same name then this will
+    // overwrite the previous function.
+    Builder& with_function(const std::string& name,
+                           std::unique_ptr<ExternalFunction>&& func);
+
+    // Add a new intrinsic with the provided ID.
+    Builder& with_intrinsic(llvm::Intrinsic::ID id,
+                            std::unique_ptr<ExternalFunction>&& func);
+
+    Builder& with_default_functions();
+    Builder& with_default_intrinsics();
+  };
+
+  static Builder builder();
+
+private:
+  CaffeineContext() = default;
+  CaffeineContext(const CaffeineContext&) = delete;
+  CaffeineContext& operator=(const CaffeineContext&) = delete;
+
+  friend class Builder;
+
+public:
+  CaffeineContext(CaffeineContext&&) = default;
+  CaffeineContext& operator=(CaffeineContext&&) = default;
+
+  ~CaffeineContext();
+};
+
+} // namespace caffeine

--- a/include/caffeine/Interpreter/CaffeineContext.h
+++ b/include/caffeine/Interpreter/CaffeineContext.h
@@ -9,6 +9,8 @@ namespace caffeine {
 class ExternalFunction;
 class ExecutionPolicy;
 class ExecutionContextStore;
+class Solver;
+class SolverBuilder;
 
 /**
  * @brief Global info/context shared by all interpreter and executor instances.
@@ -25,6 +27,7 @@ private:
 
   std::unique_ptr<ExecutionPolicy> policy_;
   std::unique_ptr<ExecutionContextStore> store_;
+  std::unique_ptr<SolverBuilder> builder_;
 
 public:
   const ExternalFunction* function(std::string_view name) const;
@@ -32,6 +35,8 @@ public:
 
   ExecutionPolicy* policy() const;
   ExecutionContextStore* store() const;
+
+  std::shared_ptr<Solver> build_solver() const;
 
 public:
   // Builder class for CaffeineContext.
@@ -45,6 +50,7 @@ public:
 
     std::unique_ptr<ExecutionPolicy> policy_;
     std::unique_ptr<ExecutionContextStore> store_;
+    std::unique_ptr<SolverBuilder> builder_;
 
   public:
     Builder() = default;
@@ -79,6 +85,9 @@ public:
     // Add a new intrinsic with the provided ID.
     Builder& with_intrinsic(llvm::Intrinsic::ID id,
                             std::unique_ptr<ExternalFunction>&& func);
+
+    // Add an already-initialized solver builder.
+    Builder& with_solver_builder(SolverBuilder&& builder);
 
     Builder& with_default_functions();
     Builder& with_default_intrinsics();

--- a/include/caffeine/Interpreter/CaffeineContext.h
+++ b/include/caffeine/Interpreter/CaffeineContext.h
@@ -97,6 +97,8 @@ public:
     Builder(Builder&&) = default;
     Builder& operator=(Builder&&) = default;
 
+    // Build a new CaffeineContext from the components specified through this
+    // builder. This will leave the builder empty as if it was moved.
     CaffeineContext build();
 
     // Set the policy used to determine whether to continue executing a live

--- a/src/Interpreter/CaffeineContext.cpp
+++ b/src/Interpreter/CaffeineContext.cpp
@@ -1,0 +1,77 @@
+#include "caffeine/Interpreter/CaffeineContext.h"
+#include "caffeine/Interpreter/ExternalFunction.h"
+
+namespace caffeine {
+
+using Builder = CaffeineContext::Builder;
+
+// Destructors must be declared in here since the header doesn't necessarily
+// have the definition for ExternalFunction.
+
+CaffeineContext::~CaffeineContext() {}
+
+Builder::~Builder() {}
+
+Builder CaffeineContext::builder() {
+  Builder builder;
+
+  builder.with_default_functions();
+  builder.with_default_intrinsics();
+
+  return builder;
+}
+
+const ExternalFunction* CaffeineContext::function(std::string_view name) const {
+  auto it = functions_.find(name);
+  if (it == functions_.end())
+    return nullptr;
+  return it->second.get();
+}
+
+const ExternalFunction*
+CaffeineContext::intrinsic(llvm::Intrinsic::ID id) const {
+  auto it = functions_.find(id);
+  if (it == functions_.end())
+    return nullptr;
+  return it->second.get();
+}
+
+// All builder functions
+
+CaffeineContext Builder::build() {
+  CaffeineContext ctx;
+  ctx.functions_ = std::move(functions_);
+  ctx.intrinsics_ = std::move(intrinsics_);
+
+  return ctx;
+}
+
+Builder& Builder::with_function(const std::string& name,
+                                std::unique_ptr<ExternalFunction>&& func) {
+  auto it = functions_.find(name);
+  if (it != functions_.end())
+    functions_.erase(it);
+
+  functions_.emplace(name, std::move(func));
+  return *this;
+}
+
+Builder& Builder::with_intrinsic(llvm::Intrinsic::ID id,
+                                 std::unique_ptr<ExternalFunction>&& func) {
+  auto it = intrinsics_.find(id);
+  if (it != intrinsics_.end())
+    intrinsics_.erase(it);
+
+  intrinsics_.emplace(id, std::move(func));
+  return *this;
+}
+
+Builder& Builder::with_default_functions() {
+  return *this;
+}
+
+Builder& Builder::with_default_intrinsics() {
+  return *this;
+}
+
+} // namespace caffeine

--- a/src/Interpreter/CaffeineContext.cpp
+++ b/src/Interpreter/CaffeineContext.cpp
@@ -2,6 +2,7 @@
 #include "caffeine/Interpreter/ExternalFunction.h"
 #include "caffeine/Interpreter/Policy.h"
 #include "caffeine/Interpreter/Store.h"
+#include "caffeine/Solver/Solver.h"
 
 namespace caffeine {
 
@@ -46,6 +47,10 @@ ExecutionContextStore* CaffeineContext::store() const {
   return store_.get();
 }
 
+std::shared_ptr<Solver> CaffeineContext::build_solver() const {
+  return builder_->build();
+}
+
 // All builder functions
 
 CaffeineContext Builder::build() {
@@ -62,6 +67,13 @@ CaffeineContext Builder::build() {
   if (!store_)
     throw std::logic_error("No store provided when building CaffeineContext");
   ctx.store_ = std::move(store_);
+
+  if (builder_) {
+    ctx.builder_ = std::move(builder_);
+  } else {
+    ctx.builder_ =
+        std::make_unique<SolverBuilder>(SolverBuilder::with_default());
+  }
 
   return ctx;
 }
@@ -93,6 +105,11 @@ Builder& Builder::with_intrinsic(llvm::Intrinsic::ID id,
     intrinsics_.erase(it);
 
   intrinsics_.emplace(id, std::move(func));
+  return *this;
+}
+
+Builder& Builder::with_solver_builder(SolverBuilder&& builder) {
+  builder_ = std::make_unique<SolverBuilder>(std::move(builder));
   return *this;
 }
 


### PR DESCRIPTION
This PR introduces `CaffeineContext` it stores all the miscellaneous global bits which are part of the interpreter. That includes the policy, the context store, the options, the solver builder, and the registry of external and intrinsic functions.

Currently this PR doesn't actually make anything else use the `CaffeineContext` or add any functions external functions to the default set. Follow-up PRs will go and add this.