### PR TITLE
Add an empty context store for testing purposes

### DIFF
--- a/include/caffeine/Interpreter/Store.h
+++ b/include/caffeine/Interpreter/Store.h
@@ -75,4 +75,20 @@ private:
   std::queue<Context> queue;
 };
 
+/**
+ * @brief A context store which drops all added contexts.
+ *
+ * This is mainly meant to be used for testing and would not be useful for
+ * actually running the interpreter.
+ */
+class NullContextStore : public ExecutionContextStore {
+public:
+  NullContextStore() = default;
+
+  std::optional<Context> next_context() override final;
+
+  void add_context(Context&& ctx) override final;
+  void add_context_multi(Span<Context> ctxs) override final;
+};
+
 } // namespace caffeine

--- a/src/Interpreter/Store/NullContextStore.cpp
+++ b/src/Interpreter/Store/NullContextStore.cpp
@@ -9,4 +9,4 @@ std::optional<Context> NullContextStore::next_context() {
 void NullContextStore::add_context(Context&&) {}
 void NullContextStore::add_context_multi(Span<Context>) {}
 
-}
+} // namespace caffeine

--- a/src/Interpreter/Store/NullContextStore.cpp
+++ b/src/Interpreter/Store/NullContextStore.cpp
@@ -1,0 +1,12 @@
+#include "caffeine/Interpreter/Store.h"
+
+namespace caffeine {
+
+std::optional<Context> NullContextStore::next_context() {
+  return std::nullopt;
+}
+
+void NullContextStore::add_context(Context&&) {}
+void NullContextStore::add_context_multi(Span<Context>) {}
+
+}


### PR DESCRIPTION
Sometimes we need a store for a test but don't want to actually store anything in it. For this, the NullContextStore is a store which just drops all inserted contexts and never returns any when queried.

This is needed for some of the refactoring done to use CaffeineContext everywhere.

/stack #543 