### PR TITLE
Only build LLVM with the X86 backend

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -49,7 +49,10 @@ boost_deps()
 llvm_configure(
     name = "llvm",
     src_path = ".",
-    src_workspace = "@llvm-raw//:WORKSPACE"
+    src_workspace = "@llvm-raw//:WORKSPACE",
+    targets = [
+        "X86",
+    ],
 )
 
 # Disables optional dependencies for Support like zlib and terminfo. You may


### PR DESCRIPTION
We don't actually need any of the LLVM backends so we can save some time by disabling as many as possible before LLVM stops compiling. Unfortunately, I wasn't able to disable all of them but this disables the X86 one and should cut down on a number of files that need to be built.

This is an intermediate step on the way to using a pre-built LLVM.