### PR TITLE
Add `--incompatible_strict_action_env` to `.bazelrc`

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -3,6 +3,10 @@ build --disk_cache=~/.cache/bazel-disk-cache
 build --action_env=BAZEL_CXXOPTS=-std=c++17
 build --cxxopt='-std=c++17'
 
+# Tell bazel to use a static value for PATH and not to inherit LD_LIBRARY_PATH or TMPDIR.
+# This is to prevent full recompiles whenever 
+build --incompatible_strict_action_env
+
 # Avoid warning messages in other workspaces since they are not helpful
 build --output_filter=^//
 


### PR DESCRIPTION
Without this flag bazel will automatically use the existing `PATH`, `LD_LIBRARY_PATH`, and `TMPDIR` variables from the environment. Unfortunately, these change fairly often and whenever that happens bazel will throw out the entire cache and rebuild everything from scratch. This is bad. It takes forever and we'd like to not have that happen.

This commit enables the strict_action_env flag which uses a hardcoded built-in `PATH` (unless overidden via action_env) and leaves `TMPDIR` and `LD_LIBRARY_PATH` empty.