### PR TITLE
Make mergify remove the ready-to-merge label after merging the PR

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -8,3 +8,6 @@ pull_request_rules:
     actions:
       merge:
         method: squash
+      label:
+        remove:
+          - ready-to-merge


### PR DESCRIPTION
As in title, this should make searching easier.