### PR TITLE
Convert various structs to use `CaffeineContext`

### DIFF
--- a/include/caffeine/Interpreter/Executor.h
+++ b/include/caffeine/Interpreter/Executor.h
@@ -11,6 +11,7 @@ namespace caffeine {
 
 class ExecutionPolicy;
 class ExecutionContextStore;
+class CaffeineContext;
 
 struct ExecutorOptions {
   uint32_t num_threads = 2;
@@ -20,16 +21,14 @@ struct ExecutorOptions {
 
 class Executor {
 private:
+  CaffeineContext* caffeine;
   ExecutionPolicy* policy;
   ExecutionContextStore* store;
   FailureLogger* logger;
-  const SolverBuilder* builder;
   ExecutorOptions options;
 
 public:
-  Executor(ExecutionPolicy* policy, ExecutionContextStore* store,
-           FailureLogger* logger, const SolverBuilder* builder,
-           const ExecutorOptions& options = {});
+  Executor(CaffeineContext* caffeine, const ExecutorOptions& options = {});
 
   /**
    * Runs the contexts in its possesion until there are none left

--- a/include/caffeine/Interpreter/InterpreterContext.h
+++ b/include/caffeine/Interpreter/InterpreterContext.h
@@ -7,6 +7,7 @@
 namespace caffeine {
 
 class FailureLogger;
+class CaffeineContext;
 
 /**
  * Wrapper around the current execution context.
@@ -269,21 +270,16 @@ public:
     ContextQueueEntry(Context&& ctx);
   };
 
-  class SharedData {
-  public:
-    FailureLogger* logger;
-    ExecutionPolicy* policy;
-  };
-
   using BackingList = std::vector<std::unique_ptr<ContextQueueEntry>>;
 
   InterpreterContext(BackingList* queue, size_t entry_index,
-                     const std::shared_ptr<Solver>& solver, SharedData* shared);
+                     const std::shared_ptr<Solver>& solver,
+                     CaffeineContext* shared);
 
 private:
   std::vector<std::unique_ptr<ContextQueueEntry>>* queue_;
   ContextQueueEntry* entry_;
-  SharedData* shared_;
+  CaffeineContext* shared_;
   std::shared_ptr<Solver> solver_;
 };
 

--- a/src/Interpreter/Executor.cpp
+++ b/src/Interpreter/Executor.cpp
@@ -1,4 +1,5 @@
 #include "caffeine/Interpreter/Executor.h"
+#include "caffeine/Interpreter/CaffeineContext.h"
 #include "caffeine/Interpreter/Interpreter.h"
 #include "caffeine/Interpreter/Store.h"
 #include "caffeine/Support/UnsupportedOperation.h"
@@ -9,7 +10,7 @@
 namespace caffeine {
 
 void Executor::run_worker() {
-  auto solver = builder->build();
+  auto solver = caffeine->build_solver();
   InterpreterContext::BackingList queue;
   InterpreterContext::SharedData shared{logger, policy};
 
@@ -52,11 +53,9 @@ void Executor::run_worker() {
   }
 }
 
-Executor::Executor(ExecutionPolicy* policy, ExecutionContextStore* store,
-                   FailureLogger* logger, const SolverBuilder* builder,
-                   const ExecutorOptions& options)
-    : policy(policy), store(store), logger(logger), builder(builder),
-      options(options) {}
+Executor::Executor(CaffeineContext* caffeine, const ExecutorOptions& options)
+    : caffeine(caffeine), policy(caffeine->policy()), store(caffeine->store()),
+      logger(caffeine->logger()), options(options) {}
 
 void Executor::run() {
   if (options.num_threads == 1) {

--- a/src/Interpreter/Executor.cpp
+++ b/src/Interpreter/Executor.cpp
@@ -12,7 +12,6 @@ namespace caffeine {
 void Executor::run_worker() {
   auto solver = caffeine->build_solver();
   InterpreterContext::BackingList queue;
-  InterpreterContext::SharedData shared{logger, policy};
 
   while (auto ctx = store->next_context()) {
     queue.clear();
@@ -25,7 +24,7 @@ void Executor::run_worker() {
     while (!queue.empty()) {
       guard.update(&queue.front()->context);
 
-      InterpreterContext ictx{&queue, 0, solver, &shared};
+      InterpreterContext ictx{&queue, 0, solver, caffeine};
 
       try {
         Interpreter interp{policy, store, logger, &ictx, solver};

--- a/src/Interpreter/InterpreterContext.cpp
+++ b/src/Interpreter/InterpreterContext.cpp
@@ -1,5 +1,6 @@
 
 #include "caffeine/Interpreter/InterpreterContext.h"
+#include "caffeine/Interpreter/CaffeineContext.h"
 #include "caffeine/Interpreter/FailureLogger.h"
 #include "caffeine/Interpreter/Policy.h"
 #include "caffeine/Support/UnsupportedOperation.h"
@@ -143,8 +144,8 @@ void InterpreterContext::assert_or_fail(const Assertion& assertion,
   auto result = resolve(checked);
   if (result == SolverResult::SAT) {
     emit_failure(message, result.model(), checked);
-    shared_->policy->on_path_complete(context(), ExecutionPolicy::Fail,
-                                      checked);
+    shared_->policy()->on_path_complete(context(), ExecutionPolicy::Fail,
+                                        checked);
   }
 
   add_assertion(assertion);
@@ -228,13 +229,13 @@ void InterpreterContext::fail(std::string_view message) {
 void InterpreterContext::emit_failure(std::string_view message,
                                       const Model* model,
                                       const Assertion& assertion) {
-  shared_->logger->log_failure(model, context(), Failure(assertion, message));
+  shared_->logger()->log_failure(model, context(), Failure(assertion, message));
 }
 
 void InterpreterContext::set_dead(ExecutionPolicy::ExitStatus status,
                                   const Assertion& assertion) {
   entry_->dead = true;
-  shared_->policy->on_path_complete(context(), status, assertion);
+  shared_->policy()->on_path_complete(context(), status, assertion);
 }
 
 void InterpreterContext::call_external_function(
@@ -244,7 +245,7 @@ void InterpreterContext::call_external_function(
 
 InterpreterContext::InterpreterContext(BackingList* queue, size_t entry_index,
                                        const std::shared_ptr<Solver>& solver,
-                                       SharedData* shared)
+                                       CaffeineContext* shared)
     : queue_(queue), entry_(queue->at(entry_index).get()), shared_(shared),
       solver_(solver) {
   CAFFEINE_ASSERT(queue_);

--- a/test/unit/Interpreter/InterpreterContext.cpp
+++ b/test/unit/Interpreter/InterpreterContext.cpp
@@ -22,7 +22,7 @@ public:
   CaffeineContext caffeine =
       CaffeineContext::builder()
           .with_logger(std::make_unique<PrintingFailureLogger>(std::cout))
-          .with_store(NullContextStore())
+          .with_store(std::make_unique<NullContextStore>())
           .build();
 
   std::shared_ptr<Solver> solver = caffeine.build_solver();

--- a/tools/caffeine/main.cpp
+++ b/tools/caffeine/main.cpp
@@ -1,4 +1,5 @@
 
+#include "caffeine/Interpreter/CaffeineContext.h"
 #include "caffeine/Interpreter/Context.h"
 #include "caffeine/Interpreter/Interpreter.h"
 #include "caffeine/Interpreter/Policy.h"
@@ -158,6 +159,9 @@ int main(int argc, char** argv) {
     WithColor::error() << " unknown store type '" << store_type << "'\n";
     return 2;
   }
+
+  auto caffeine =
+      CaffeineContext::builder().with_store(std::move(store)).build();
 
   auto policy = caffeine::AlwaysAllowExecutionPolicy();
   auto builder = caffeine::SolverBuilder::with_default();

--- a/tools/guided-fuzzing/include/GuidedExecutionPolicy.h
+++ b/tools/guided-fuzzing/include/GuidedExecutionPolicy.h
@@ -28,7 +28,6 @@ public:
   void on_path_complete(const Context& ctx, ExitStatus status,
                         const Assertion& assertion = Assertion()) override;
 
-protected:
   GuidedExecutionPolicy(GuidedExecutionPolicy&&) = default;
   GuidedExecutionPolicy(const GuidedExecutionPolicy&) = default;
 

--- a/tools/guided-fuzzing/src/CaffeineMutator.cpp
+++ b/tools/guided-fuzzing/src/CaffeineMutator.cpp
@@ -128,11 +128,12 @@ size_t CaffeineMutator::mutate(caffeine::Span<char> data) {
       Context(this->fuzz_target,
               {ConstantInt::Create(llvm::APInt(bitwidth, data.size()))});
 
-  auto caffeine = CaffeineContext::builder()
-                      .with_policy(GuidedExecutionPolicy(data, "__caffeine_mut",
-                                                         this, cases))
-                      .with_logger(std::make_unique<PrintingFailureLogger>(std::cout))
-                      .build();
+  auto caffeine =
+      CaffeineContext::builder()
+          .with_policy(std::make_unique<GuidedExecutionPolicy>(
+              data, "__caffeine_mut", this, cases))
+          .with_logger(std::make_unique<PrintingFailureLogger>(std::cout))
+          .build();
   auto exec = caffeine::Executor(&caffeine, options);
 
   caffeine.store()->add_context(std::move(context));


### PR DESCRIPTION
This converts most of the structs that would take a policy or a store to now interact with a `CaffeineContext`. This is mostly a straightforward change that 1:1 replaces the existing pointers with accesses to `CaffeineContext`.