### PR TITLE
Use `CaffeineContext` for external functions and convert `CaffeineAssert` to an external function

### DIFF
--- a/include/caffeine/ADT/StringMap.h
+++ b/include/caffeine/ADT/StringMap.h
@@ -42,7 +42,7 @@ namespace detail::string_map {
   struct string_hash : std::hash<std::string_view> {
     template <typename T>
     std::size_t operator()(const T& x) const {
-      return (*this)(string_equal::to_sv(x));
+      return std::hash<std::string_view>::operator()(string_equal::to_sv(x));
     }
   };
 } // namespace detail::string_map

--- a/include/caffeine/Interpreter/ExternalFuncs/CaffeineAssert.h
+++ b/include/caffeine/Interpreter/ExternalFuncs/CaffeineAssert.h
@@ -8,12 +8,4 @@ public:
   void call(InterpreterContext& ctx, Span<LLVMValue> args) const override;
 };
 
-class CaffeineAssertFunc : public ExternalStackFrame {
-public:
-  using ExternalStackFrame::ExternalStackFrame;
-
-  std::unique_ptr<ExternalStackFrame> clone() const override;
-  void step(InterpreterContext& context) override;
-};
-
 } // namespace caffeine

--- a/include/caffeine/Interpreter/ExternalFuncs/CaffeineAssert.h
+++ b/include/caffeine/Interpreter/ExternalFuncs/CaffeineAssert.h
@@ -1,6 +1,12 @@
+#include "caffeine/Interpreter/ExternalFunction.h"
 #include "caffeine/Interpreter/StackFrame.h"
 
 namespace caffeine {
+
+class CaffeineAssertFunction : public ExternalFunction {
+public:
+  void call(InterpreterContext& ctx, Span<LLVMValue> args) const override;
+};
 
 class CaffeineAssertFunc : public ExternalStackFrame {
 public:

--- a/include/caffeine/Interpreter/Interpreter.h
+++ b/include/caffeine/Interpreter/Interpreter.h
@@ -129,7 +129,6 @@ private:
   ExecutionResult visitExternFunc(llvm::CallBase& inst);
 
   ExecutionResult visitAssume(llvm::CallBase& inst);
-  ExecutionResult visitAssert(llvm::CallBase& call);
   ExecutionResult visitSymbolicAlloca(llvm::CallBase& inst);
 
   ExecutionResult visitCalloc(llvm::CallBase& inst);

--- a/include/caffeine/Interpreter/InterpreterContext.h
+++ b/include/caffeine/Interpreter/InterpreterContext.h
@@ -27,6 +27,11 @@ public:
   Context& context();
   const Context& context() const;
 
+  /**
+   * Get the CaffeineContext instance associated with this InterpreterContext.
+   */
+  const CaffeineContext& caffeine() const;
+
   // Accessors for LLVM data. These use the LLVM syntax for consistency with
   // existing code.
 

--- a/src/Interpreter/CaffeineContext.cpp
+++ b/src/Interpreter/CaffeineContext.cpp
@@ -1,4 +1,5 @@
 #include "caffeine/Interpreter/CaffeineContext.h"
+#include "caffeine/Interpreter/ExternalFuncs/CaffeineAssert.h"
 #include "caffeine/Interpreter/ExternalFunction.h"
 #include "caffeine/Interpreter/FailureLogger.h"
 #include "caffeine/Interpreter/Policy.h"
@@ -135,6 +136,8 @@ Builder& Builder::with_solver_builder(SolverBuilder&& builder) {
 }
 
 Builder& Builder::with_default_functions() {
+  with_function("caffeine_assert", std::make_unique<CaffeineAssertFunction>());
+
   return *this;
 }
 

--- a/src/Interpreter/ExternalFuncs/CaffeineAssert.cpp
+++ b/src/Interpreter/ExternalFuncs/CaffeineAssert.cpp
@@ -14,16 +14,4 @@ void CaffeineAssertFunction::call(InterpreterContext& ctx,
   ctx.assert_or_fail(args[0].scalar().expr(), "assertion failure");
 }
 
-std::unique_ptr<ExternalStackFrame> CaffeineAssertFunc::clone() const {
-  return std::make_unique<CaffeineAssertFunc>(*this);
-}
-
-void CaffeineAssertFunc::step(InterpreterContext& ic) {
-  auto cond = args.at(0);
-  auto assertion = Assertion(cond.scalar().expr());
-
-  ic.assert_or_fail(assertion, "assertion failure");
-  ic.function_return();
-}
-
 } // namespace caffeine

--- a/src/Interpreter/ExternalFuncs/CaffeineAssert.cpp
+++ b/src/Interpreter/ExternalFuncs/CaffeineAssert.cpp
@@ -3,6 +3,17 @@
 
 namespace caffeine {
 
+void CaffeineAssertFunction::call(InterpreterContext& ctx,
+                                  Span<LLVMValue> args) const {
+  if (args.size() != 1) {
+    ctx.fail("caffeine_assert called with bad signature (wrong number of "
+             "arguments)");
+    return;
+  }
+
+  ctx.assert_or_fail(args[0].scalar().expr(), "assertion failure");
+}
+
 std::unique_ptr<ExternalStackFrame> CaffeineAssertFunc::clone() const {
   return std::make_unique<CaffeineAssertFunc>(*this);
 }

--- a/src/Interpreter/Interpreter.cpp
+++ b/src/Interpreter/Interpreter.cpp
@@ -576,8 +576,6 @@ ExecutionResult Interpreter::visitExternFunc(llvm::CallBase& call) {
     return ExecutionResult::Migrated;
   }
 
-  if (name == "caffeine_assert")
-    return visitAssert(call);
   if (name == "caffeine_assume")
     return visitAssume(call);
 
@@ -612,20 +610,6 @@ ExecutionResult Interpreter::visitAssume(llvm::CallBase& call) {
   // dead since assumptions are rare, solver calls are expensive, and it'll
   // get caught at the next conditional branch anyway.
   return ExecutionResult::Continue;
-}
-ExecutionResult Interpreter::visitAssert(llvm::CallBase& call) {
-  CAFFEINE_ASSERT(call.getNumArgOperands() == 1);
-  auto func = call.getCalledFunction();
-
-  std::vector<LLVMValue> args;
-  for (unsigned int i = 0; i < call.getNumArgOperands(); i++) {
-    args.push_back(interp->load(call.getArgOperand(i)));
-  }
-
-  auto frame = std::make_unique<CaffeineAssertFunc>(std::move(args), func);
-
-  interp->call_external_function(std::move(frame));
-  return ExecutionResult::Migrated;
 }
 
 std::optional<std::string> readSymbolicName(std::shared_ptr<Solver> solver,

--- a/src/Interpreter/InterpreterContext.cpp
+++ b/src/Interpreter/InterpreterContext.cpp
@@ -17,6 +17,10 @@ const Context& InterpreterContext::context() const {
   return entry_->context;
 }
 
+const CaffeineContext& InterpreterContext::caffeine() const {
+  return *shared_;
+}
+
 llvm::Module* InterpreterContext::getModule() const {
   return context().mod;
 }


### PR DESCRIPTION
This is the next step towards using `CaffeineContext` everywhere. This PR just makes `Interpreter` attempt to find functions within `CaffeineContext` before running the hardcoded ones.

I've used `CaffeineAssert` as a demo since it was already used as an example of an external stack frame.