### PR TITLE
Linecov

### DIFF
--- a/include/caffeine/Interpreter/CaffeineContext.h
+++ b/include/caffeine/Interpreter/CaffeineContext.h
@@ -42,7 +42,7 @@ struct CaffeineOptions {
   /**
    * @brief Determines whether to track line coverage
    */
-  bool run_line_coverage = true;
+  bool run_line_coverage = false;
 
   CaffeineOptions() = default;
 };

--- a/include/caffeine/Interpreter/CaffeineContext.h
+++ b/include/caffeine/Interpreter/CaffeineContext.h
@@ -40,8 +40,8 @@ struct CaffeineOptions {
   uint64_t malloc_alignment = 16;
 
   /**
-  * @brief Determines whether to track line coverage
-  */
+   * @brief Determines whether to track line coverage
+   */
   bool run_line_coverage = true;
 
   CaffeineOptions() = default;

--- a/include/caffeine/Interpreter/CaffeineContext.h
+++ b/include/caffeine/Interpreter/CaffeineContext.h
@@ -39,11 +39,6 @@ struct CaffeineOptions {
    */
   uint64_t malloc_alignment = 16;
 
-  /**
-   * @brief Determines whether to track line coverage
-   */
-  bool run_line_coverage = false;
-
   CaffeineOptions() = default;
 };
 

--- a/include/caffeine/Interpreter/CaffeineContext.h
+++ b/include/caffeine/Interpreter/CaffeineContext.h
@@ -39,6 +39,11 @@ struct CaffeineOptions {
    */
   uint64_t malloc_alignment = 16;
 
+  /**
+  * @brief Determines whether to track line coverage
+  */
+  bool run_line_coverage = true;
+
   CaffeineOptions() = default;
 };
 
@@ -136,7 +141,7 @@ public:
     Builder& with_options(const CaffeineOptions& options);
 
     // Set the coverage counter used by this context.
-    Builder& with_coverage(CoverageTracker& tracker);
+    Builder& with_coverage(std::unique_ptr<CoverageTracker>&& tracker);
 
     Builder& with_default_functions();
     Builder& with_default_intrinsics();

--- a/include/caffeine/Interpreter/CaffeineContext.h
+++ b/include/caffeine/Interpreter/CaffeineContext.h
@@ -58,6 +58,7 @@ private:
   std::unique_ptr<ExecutionContextStore> store_;
   std::unique_ptr<SolverBuilder> builder_;
   std::unique_ptr<FailureLogger> logger_;
+  std::unique_ptr<CoverageTracker> cov_;
   CaffeineOptions options_;
 
 public:
@@ -67,6 +68,7 @@ public:
   ExecutionPolicy* policy() const;
   ExecutionContextStore* store() const;
   FailureLogger* logger() const;
+  CoverageTracker* coverage() const;
   const CaffeineOptions& options() const;
 
   std::shared_ptr<Solver> build_solver() const;
@@ -85,6 +87,7 @@ public:
     std::unique_ptr<ExecutionContextStore> store_;
     std::unique_ptr<SolverBuilder> builder_;
     std::unique_ptr<FailureLogger> logger_;
+    std::unique_ptr<CoverageReporter> cov_;
     CaffeineOptions options_;
 
   public:
@@ -130,6 +133,9 @@ public:
 
     // Set the options used by this context.
     Builder& with_options(const CaffeineOptions& options);
+
+    // Set the coverage counter used by this context.
+    Builder& with_coverage(const CoverageTracker& tracker);
 
     Builder& with_default_functions();
     Builder& with_default_intrinsics();

--- a/include/caffeine/Interpreter/CaffeineContext.h
+++ b/include/caffeine/Interpreter/CaffeineContext.h
@@ -12,6 +12,7 @@ class ExecutionContextStore;
 class Solver;
 class SolverBuilder;
 class FailureLogger;
+class CoverageTracker;
 
 /**
  * @brief Options controlling various behaviours of the caffeine interpreter.
@@ -87,7 +88,7 @@ public:
     std::unique_ptr<ExecutionContextStore> store_;
     std::unique_ptr<SolverBuilder> builder_;
     std::unique_ptr<FailureLogger> logger_;
-    std::unique_ptr<CoverageReporter> cov_;
+    std::unique_ptr<CoverageTracker> cov_;
     CaffeineOptions options_;
 
   public:
@@ -135,7 +136,7 @@ public:
     Builder& with_options(const CaffeineOptions& options);
 
     // Set the coverage counter used by this context.
-    Builder& with_coverage(const CoverageTracker& tracker);
+    Builder& with_coverage(CoverageTracker& tracker);
 
     Builder& with_default_functions();
     Builder& with_default_intrinsics();

--- a/include/caffeine/Interpreter/Interpreter.h
+++ b/include/caffeine/Interpreter/Interpreter.h
@@ -31,6 +31,8 @@ public:
 
   void execute();
 
+  void visit(llvm::Instruction& inst);
+
   void visitInstruction(llvm::Instruction& inst);
 
   void visitBinaryOperator(llvm::BinaryOperator& op);
@@ -72,6 +74,7 @@ public:
   void visitDbgInfoIntrinsic(llvm::DbgInfoIntrinsic&);
 
 private:
+  void getInstLine(llvm::Instruction& inst);
   void visitExternFunc(llvm::CallBase& inst);
 };
 

--- a/include/caffeine/Interpreter/Options.h
+++ b/include/caffeine/Interpreter/Options.h
@@ -19,7 +19,7 @@ struct InterpreterOptions {
   bool run_line_coverage_debugger = true;
 
   /**
-   * This wont be implemented for a while but is nice to have it so for now 
+   * This wont be implemented for a while but is nice to have it so for now
    * its false.
    */
   bool run_branch_coverage_debugger = false;

--- a/include/caffeine/Interpreter/Options.h
+++ b/include/caffeine/Interpreter/Options.h
@@ -16,6 +16,14 @@ struct InterpreterOptions {
 
   uint64_t malloc_alignment = 16;
 
+  bool run_line_coverage_debugger = true;
+
+  /**
+   * This wont be implemented for a while but is nice to have it so for now 
+   * its false.
+   */
+  bool run_branch_coverage_debugger = false;
+
   InterpreterOptions() = default;
 };
 

--- a/include/caffeine/Support/Coverage.h
+++ b/include/caffeine/Support/Coverage.h
@@ -3,6 +3,7 @@
 #include <map>
 #include <memory>
 #include <string>
+#include <vector>
 
 namespace caffeine {
 
@@ -16,20 +17,21 @@ public:
 
 class CoverageTracker {
 private:
-    Map<std::string, std::unique_ptr<Map<size_t, std::unique_ptr<Line>>>> lines_;
-    
+    std::vector<std::map<size_t, Line>> file_lines;
+    std::map<std::string, size_t> file_to_vec;
+
 public:
     CoverageTracker() = default;
     ~CoverageTracker() = default;
 
-    CoverageTracker(const CoverageTracker) = default;
+    CoverageTracker(const CoverageTracker&) = default;
     CoverageTracker(CoverageTracker&&) = default;
 
-    CoverageTracker operator=(const CoverageTracker&) = default;
-    CoverageTracker operator=(CoverageTracker&&) = default;
+    // CoverageTracker operator=(const CoverageTracker&) = default;
+    // CoverageTracker operator=(CoverageTracker&&) = default;
 
     void touch(std::string filename, size_t line);
-    CoverageReport report() const;
+    // CoverageReport report() const;
 };
 
 class Line {
@@ -38,8 +40,15 @@ private:
     size_t hits_;
 
 public:
-    excplicit Line(size_t line_num, size_t hits = 1);
+    Line() = default;
+    Line(size_t line_num, size_t hits = 1);
     ~Line() = default;
+
+    Line(const Line&) = default;
+    Line(Line&&) = default;
+
+    // Line operator=(const Line&) = default;
+    // Line operator=(Line&&) = default;
 
     /**
      * Used to keep track how many times this line has been seen
@@ -48,6 +57,6 @@ public:
     void touch(size_t hits = 1);
     size_t LineNumber() const;
     size_t Hits() const;
-}
+};
 
 } // namespace caffeine

--- a/include/caffeine/Support/Coverage.h
+++ b/include/caffeine/Support/Coverage.h
@@ -61,12 +61,12 @@ public:
   /**
    *  Used to track branch statements
    */
-  void touch_branch(size_t branch_id, size_t hits);
+  void touch_branch(size_t branch_id, size_t hits = 1);
 
   /**
    * Used to track switch statements
    */
-  void touch_switch(size_t switch_id, size_t hits);
+  void touch_switch(size_t switch_id, size_t hits = 1);
 
   // Values
   size_t line() const;

--- a/include/caffeine/Support/Coverage.h
+++ b/include/caffeine/Support/Coverage.h
@@ -58,16 +58,6 @@ public:
    */
   void touch(size_t hits = 1);
 
-  /**
-   *  Used to track branch statements
-   */
-  void touch_branch(size_t branch_id, size_t hits = 1);
-
-  /**
-   * Used to track switch statements
-   */
-  void touch_switch(size_t switch_id, size_t hits = 1);
-
   // Values
   size_t line() const;
   size_t hits() const;

--- a/include/caffeine/Support/Coverage.h
+++ b/include/caffeine/Support/Coverage.h
@@ -1,0 +1,53 @@
+#pragma once 
+
+#include <map>
+#include <memory>
+#include <string>
+
+namespace caffeine {
+
+class Line;
+
+class CoverageReport {
+public:
+    CoverageReport();
+    ~CoverageReport();
+};
+
+class CoverageTracker {
+private:
+    Map<std::string, std::unique_ptr<Map<size_t, std::unique_ptr<Line>>>> lines_;
+    
+public:
+    CoverageTracker() = default;
+    ~CoverageTracker() = default;
+
+    CoverageTracker(const CoverageTracker) = default;
+    CoverageTracker(CoverageTracker&&) = default;
+
+    CoverageTracker operator=(const CoverageTracker&) = default;
+    CoverageTracker operator=(CoverageTracker&&) = default;
+
+    void touch(std::string filename, size_t line);
+    CoverageReport report() const;
+};
+
+class Line {
+private:
+    size_t line_;
+    size_t hits_;
+
+public:
+    excplicit Line(size_t line_num, size_t hits = 1);
+    ~Line() = default;
+
+    /**
+     * Used to keep track how many times this line has been seen
+     * during execution.
+     */
+    void touch(size_t hits = 1);
+    size_t LineNumber() const;
+    size_t Hits() const;
+}
+
+} // namespace caffeine

--- a/include/caffeine/Support/Coverage.h
+++ b/include/caffeine/Support/Coverage.h
@@ -1,62 +1,76 @@
-#pragma once 
+#pragma once
 
 #include <map>
 #include <memory>
 #include <string>
 #include <vector>
 
+#include "caffeine/ADT/StringMap.h"
+
 namespace caffeine {
 
 class Line;
 
 class CoverageReport {
+  StringMap<std::vector<size_t>> file_lines;
+
 public:
-    CoverageReport();
-    ~CoverageReport();
+  CoverageReport() = default;
+  ~CoverageReport() = default;
+
+  void add_file(std::string, std::map<size_t, Line>);
+
+  void print(std::ostream& out) const;
 };
 
 class CoverageTracker {
 private:
-    std::vector<std::map<size_t, Line>> file_lines;
-    std::map<std::string, size_t> file_to_vec;
+  std::vector<std::map<size_t, Line>> file_lines;
+  StringMap<size_t> file_to_vec;
 
 public:
-    CoverageTracker() = default;
-    ~CoverageTracker() = default;
+  CoverageTracker() = default;
+  ~CoverageTracker() = default;
 
-    CoverageTracker(const CoverageTracker&) = default;
-    CoverageTracker(CoverageTracker&&) = default;
+  CoverageTracker(const CoverageTracker&) = default;
+  CoverageTracker(CoverageTracker&&) = default;
 
-    // CoverageTracker operator=(const CoverageTracker&) = default;
-    // CoverageTracker operator=(CoverageTracker&&) = default;
-
-    void touch(std::string filename, size_t line);
-    // CoverageReport report() const;
+  void touch(std::string filename, size_t line);
+  CoverageReport report() const;
 };
 
 class Line {
 private:
-    size_t line_;
-    size_t hits_;
+  size_t line_;
+  size_t hits_;
 
 public:
-    Line() = default;
-    Line(size_t line_num, size_t hits = 1);
-    ~Line() = default;
+  Line() = default;
+  Line(size_t line_num, size_t hits = 1);
+  ~Line() = default;
 
-    Line(const Line&) = default;
-    Line(Line&&) = default;
+  Line(const Line&) = default;
+  Line(Line&&) = default;
 
-    // Line operator=(const Line&) = default;
-    // Line operator=(Line&&) = default;
+  /**
+   * Used to keep track how many times this line has been seen
+   * during execution.
+   */
+  void touch(size_t hits = 1);
 
-    /**
-     * Used to keep track how many times this line has been seen
-     * during execution.
-     */
-    void touch(size_t hits = 1);
-    size_t LineNumber() const;
-    size_t Hits() const;
+  /**
+   *  Used to track branch statements
+   */
+  void touch_branch(size_t branch_id, size_t hits);
+
+  /**
+   * Used to track switch statements
+   */
+  void touch_switch(size_t switch_id, size_t hits);
+
+  // Values
+  size_t line() const;
+  size_t hits() const;
 };
 
 } // namespace caffeine

--- a/src/Interpreter/CaffeineContext.cpp
+++ b/src/Interpreter/CaffeineContext.cpp
@@ -65,9 +65,7 @@ std::shared_ptr<Solver> CaffeineContext::build_solver() const {
 }
 
 CoverageTracker* CaffeineContext::coverage() const {
-  if (cov_)
-    return cov_.get();
-  return nullptr;
+  return cov_.get();
 }
 
 // All builder functions

--- a/src/Interpreter/CaffeineContext.cpp
+++ b/src/Interpreter/CaffeineContext.cpp
@@ -4,6 +4,7 @@
 #include "caffeine/Interpreter/Policy.h"
 #include "caffeine/Interpreter/Store.h"
 #include "caffeine/Solver/Solver.h"
+#include "caffeine/Support/Coverage.h"
 
 namespace caffeine {
 
@@ -158,6 +159,11 @@ Builder& Builder::with_default_intrinsics() {
   with_intrinsic(llvm::Intrinsic::smul_with_overflow,
                  Intrinsics::smul_with_overflow());
 
+  return *this;
+}
+
+Builder& Builder::with_coverage(CoverageTracker& tracker) {
+  cov_ = std::make_unique<CoverageTracker>(std::move(tracker));
   return *this;
 }
 

--- a/src/Interpreter/CaffeineContext.cpp
+++ b/src/Interpreter/CaffeineContext.cpp
@@ -64,6 +64,10 @@ std::shared_ptr<Solver> CaffeineContext::build_solver() const {
   return builder_->build();
 }
 
+CoverageTracker* CaffeineContext::coverage() const {
+  return cov_.get();
+}
+
 // All builder functions
 
 CaffeineContext Builder::build() {

--- a/src/Interpreter/CaffeineContext.cpp
+++ b/src/Interpreter/CaffeineContext.cpp
@@ -88,9 +88,6 @@ CaffeineContext Builder::build() {
   if (!logger_)
     throw std::logic_error("No logger provided when building CaffeineContext");
   ctx.logger_ = std::move(logger_);
-  if (ctx.options().run_line_coverage && !cov_)
-    throw std::logic_error(
-        "No coverage tracker provided when building CaffeineContext");
   ctx.cov_ = std::move(cov_);
 
   if (builder_) {

--- a/src/Interpreter/CaffeineContext.cpp
+++ b/src/Interpreter/CaffeineContext.cpp
@@ -89,7 +89,8 @@ CaffeineContext Builder::build() {
     throw std::logic_error("No logger provided when building CaffeineContext");
   ctx.logger_ = std::move(logger_);
   if (!cov_)
-    throw std::logic_error("No coverage tacker provided when building CaffeineContext");
+    throw std::logic_error(
+        "No coverage tacker provided when building CaffeineContext");
   ctx.cov_ = std::move(cov_);
 
   if (builder_) {

--- a/src/Interpreter/CaffeineContext.cpp
+++ b/src/Interpreter/CaffeineContext.cpp
@@ -65,7 +65,9 @@ std::shared_ptr<Solver> CaffeineContext::build_solver() const {
 }
 
 CoverageTracker* CaffeineContext::coverage() const {
-  return cov_.get();
+  if (cov_)
+    return cov_.get();
+  return nullptr;
 }
 
 // All builder functions
@@ -88,9 +90,9 @@ CaffeineContext Builder::build() {
   if (!logger_)
     throw std::logic_error("No logger provided when building CaffeineContext");
   ctx.logger_ = std::move(logger_);
-  if (!cov_)
+  if (ctx.options().run_line_coverage && !cov_)
     throw std::logic_error(
-        "No coverage tacker provided when building CaffeineContext");
+        "No coverage tracker provided when building CaffeineContext");
   ctx.cov_ = std::move(cov_);
 
   if (builder_) {

--- a/src/Interpreter/CaffeineContext.cpp
+++ b/src/Interpreter/CaffeineContext.cpp
@@ -88,6 +88,9 @@ CaffeineContext Builder::build() {
   if (!logger_)
     throw std::logic_error("No logger provided when building CaffeineContext");
   ctx.logger_ = std::move(logger_);
+  if (!cov_)
+    throw std::logic_error("No coverage tacker provided when building CaffeineContext");
+  ctx.cov_ = std::move(cov_);
 
   if (builder_) {
     ctx.builder_ = std::move(builder_);
@@ -166,8 +169,8 @@ Builder& Builder::with_default_intrinsics() {
   return *this;
 }
 
-Builder& Builder::with_coverage(CoverageTracker& tracker) {
-  cov_ = std::make_unique<CoverageTracker>(std::move(tracker));
+Builder& Builder::with_coverage(std::unique_ptr<CoverageTracker>&& tracker) {
+  cov_ = std::move(tracker);
   return *this;
 }
 

--- a/src/Interpreter/Interpreter.cpp
+++ b/src/Interpreter/Interpreter.cpp
@@ -477,10 +477,11 @@ std::optional<std::string> readSymbolicName(std::shared_ptr<Solver> solver,
 }
 
 void Interpreter::getInstLine(llvm::Instruction& inst) {
-  if (llvm::MDNode* md = inst.getMetadata("dbg")) {
-    llvm::DILocation loc(md);
-    unsigned line = loc.Line;
-    llvm::StringRef file = loc.getFilename();
+  if (const auto& loc = inst.getDebugLoc()) {
+    unsigned line = loc.getLine();
+    auto* dfile = static_cast<llvm::DIScope*>(loc.getScope());
+    std::string file = dfile->getFilename().str();
+    // llvm::StringRef file = loc.getFilename();
   }
 }
 

--- a/src/Interpreter/Interpreter.cpp
+++ b/src/Interpreter/Interpreter.cpp
@@ -482,8 +482,8 @@ void Interpreter::getInstLine(llvm::Instruction& inst) {
     unsigned line = loc.getLine();
     auto* dfile = static_cast<llvm::DIScope*>(loc.getScope());
     std::string file = dfile->getFilename().str();
-
-    if (auto* cov = interp->caffeine().coverage()) {
+    std::cout << file << std::endl;
+    if (auto cov = interp->caffeine().coverage()) {
       cov->touch(file, line);
     }
   }

--- a/src/Interpreter/Interpreter.cpp
+++ b/src/Interpreter/Interpreter.cpp
@@ -68,13 +68,13 @@ void Interpreter::execute() {
 }
 
 void Interpreter::visit(llvm::Instruction& inst) {
-  if (options.run_line_coverage_debugger) {
+  if (interp->caffeine().options().run_line_coverage) {
     getInstLine(inst);
   }
-  llvm::InstVisitor<Interpreter, ExecutionResult>::visit(inst);
+  llvm::InstVisitor<Interpreter, void>::visit(inst);
 }
 
-ExecutionResult Interpreter::visitInstruction(llvm::Instruction& inst) {
+void Interpreter::visitInstruction(llvm::Instruction& inst) {
   CAFFEINE_ABORT(
       fmt::format("Instruction '{}' not implemented!", inst.getOpcodeName()));
 }
@@ -482,10 +482,7 @@ void Interpreter::getInstLine(llvm::Instruction& inst) {
     unsigned line = loc.getLine();
     auto* dfile = static_cast<llvm::DIScope*>(loc.getScope());
     std::string file = dfile->getFilename().str();
-    std::cout << file << std::endl;
-    if (auto cov = interp->caffeine().coverage()) {
-      cov->touch(file, line);
-    }
+    interp->caffeine().coverage()->touch(file, line);
   }
 }
 

--- a/src/Interpreter/Interpreter.cpp
+++ b/src/Interpreter/Interpreter.cpp
@@ -68,7 +68,7 @@ void Interpreter::execute() {
 }
 
 void Interpreter::visit(llvm::Instruction& inst) {
-  if (interp->caffeine().options().coverage()) {
+  if (interp->caffeine().coverage()) {
     getInstLine(inst);
   }
   llvm::InstVisitor<Interpreter, void>::visit(inst);

--- a/src/Interpreter/Interpreter.cpp
+++ b/src/Interpreter/Interpreter.cpp
@@ -68,7 +68,7 @@ void Interpreter::execute() {
 }
 
 void Interpreter::visit(llvm::Instruction& inst) {
-  if (interp->caffeine().options().run_line_coverage) {
+  if (interp->caffeine().options().coverage()) {
     getInstLine(inst);
   }
   llvm::InstVisitor<Interpreter, void>::visit(inst);

--- a/src/Interpreter/Interpreter.cpp
+++ b/src/Interpreter/Interpreter.cpp
@@ -10,6 +10,7 @@
 #include "caffeine/Support/LLVMFmt.h"
 #include "caffeine/Support/Tracing.h"
 #include "caffeine/Support/UnsupportedOperation.h"
+#include "caffeine/Support/Coverage.h"
 
 #include <boost/range/adaptor/transformed.hpp>
 #include <boost/range/combine.hpp>
@@ -481,7 +482,10 @@ void Interpreter::getInstLine(llvm::Instruction& inst) {
     unsigned line = loc.getLine();
     auto* dfile = static_cast<llvm::DIScope*>(loc.getScope());
     std::string file = dfile->getFilename().str();
-    // llvm::StringRef file = loc.getFilename();
+
+    if (auto* cov = interp->caffeine().coverage()) {
+      cov->touch(file, line);
+    }
   }
 }
 

--- a/src/Interpreter/Interpreter.cpp
+++ b/src/Interpreter/Interpreter.cpp
@@ -7,10 +7,10 @@
 #include "caffeine/Interpreter/Store.h"
 #include "caffeine/Model/Value.h"
 #include "caffeine/Support/Assert.h"
+#include "caffeine/Support/Coverage.h"
 #include "caffeine/Support/LLVMFmt.h"
 #include "caffeine/Support/Tracing.h"
 #include "caffeine/Support/UnsupportedOperation.h"
-#include "caffeine/Support/Coverage.h"
 
 #include <boost/range/adaptor/transformed.hpp>
 #include <boost/range/combine.hpp>

--- a/src/Support/Coverage.cpp
+++ b/src/Support/Coverage.cpp
@@ -6,23 +6,25 @@ namespace caffeine {
 // CoverageTracker
 
 void CoverageTracker::touch(std::string filename, size_t line) {
-    auto fileIterator = lines_.find(filename);
-    if (fileIterator == lines_.end()) {
-        lines_.emplace(filename, std::make_unique<Map<size_t, std::unique_ptr<Line>>());
-    }
-
-    auto lineIterator = lines_[filename]->find(line);
-    if (lineIterator == lines_[filename]->end()) {
-        lines_[filename].emplace(line, std::make_unique<Line>(line));
+    // Check if this file is already being tracked
+    auto it_file = file_to_vec.find(filename);
+    size_t vecPos = 0;
+    if (it_file == file_to_vec.end()) {
+        vecPos = file_lines.size();
+        std::map<size_t, Line> m;
+        file_lines.push_back(m);
     } else {
-        (*lineIterator)[line]->touch();
+        vecPos = (*it_file).second;
+    }
+    // Check if line has already been seen.
+    auto it_line = file_lines[vecPos].find(line);
+    if (it_line == file_lines[vecPos].end()) {
+        Line l{line};
+        file_lines[vecPos].emplace(line, l);
+    } else {
+        file_lines[vecPos][line].touch();
     }
 }
-
-CoverageReport CoverageTracker::report() const {
-    // TODO
-}
-
 
 // --- Line
 
@@ -33,11 +35,11 @@ void Line::touch(size_t hits) {
     hits_ += hits;
 }
 
-size_t Line::LineNumber() {
+size_t Line::LineNumber() const {
     return line_;
 }
 
-size_t Line::Hits() {
+size_t Line::Hits() const {
     return hits_;
 }
 

--- a/src/Support/Coverage.cpp
+++ b/src/Support/Coverage.cpp
@@ -73,14 +73,6 @@ void Line::touch(size_t hits) {
   hits_ += hits;
 }
 
-void Line::touch_branch(size_t branch_id, size_t hits) {
-  // TODO: Later expansion
-}
-
-void Line::touch_switch(size_t switch_id, size_t hits) {
-  // TODO: Later expansion
-}
-
 size_t Line::line() const {
   return line_;
 }

--- a/src/Support/Coverage.cpp
+++ b/src/Support/Coverage.cpp
@@ -2,8 +2,8 @@
 
 #include <algorithm>
 #include <iostream>
-#include <sstream>
 #include <iterator>
+#include <sstream>
 
 namespace caffeine {
 
@@ -23,11 +23,11 @@ void CoverageReport::print(std::ostream& out) const {
   for (const auto& [file, lines] : file_lines) {
     std::ostringstream oss;
     if (!lines.empty()) {
-      std::copy(lines.begin(), lines.end()-1,
-        std::ostream_iterator<size_t>(oss, ","));
+      std::copy(lines.begin(), lines.end() - 1,
+                std::ostream_iterator<size_t>(oss, ","));
       oss << lines.back();
     }
-    out << "-> " << file << ": [" << oss.str() <<  "]" << std::endl;
+    out << "-> " << file << ": [" << oss.str() << "]" << std::endl;
   }
   out << "=========================================" << std::endl;
 }

--- a/src/Support/Coverage.cpp
+++ b/src/Support/Coverage.cpp
@@ -1,0 +1,44 @@
+#include "caffeine/Support/Coverage.h"
+
+namespace caffeine {
+
+
+// CoverageTracker
+
+void CoverageTracker::touch(std::string filename, size_t line) {
+    auto fileIterator = lines_.find(filename);
+    if (fileIterator == lines_.end()) {
+        lines_.emplace(filename, std::make_unique<Map<size_t, std::unique_ptr<Line>>());
+    }
+
+    auto lineIterator = lines_[filename]->find(line);
+    if (lineIterator == lines_[filename]->end()) {
+        lines_[filename].emplace(line, std::make_unique<Line>(line));
+    } else {
+        (*lineIterator)[line]->touch();
+    }
+}
+
+CoverageReport CoverageTracker::report() const {
+    // TODO
+}
+
+
+// --- Line
+
+Line::Line(size_t line_number, size_t hits): 
+    line_{line_number}, hits_{hits} {}
+
+void Line::touch(size_t hits) {
+    hits_ += hits;
+}
+
+size_t Line::LineNumber() {
+    return line_;
+}
+
+size_t Line::Hits() {
+    return hits_;
+}
+
+} // namespace caffeine

--- a/src/Support/Coverage.cpp
+++ b/src/Support/Coverage.cpp
@@ -1,46 +1,73 @@
 #include "caffeine/Support/Coverage.h"
 
+#include <algorithm>
+
 namespace caffeine {
 
+// CoverageReport
+
+void CoverageReport::add_file(std::string filename,
+                              std::map<size_t, Line> lines) {
+  std::vector<size_t> l;
+  std::transform(lines.begin(), lines.end(), std::back_inserter(l),
+                 [](std::pair<size_t, Line> line) { return line.first; });
+  file_lines.emplace(filename, l);
+}
+
+void CoverageReport::print(std::ostream& out) const {
+  // out << "Report" << std::endl;
+
+  // for (const auto& [file, lines] : file_lines) {
+  //     std::string s(lines.begin(), lines.end())
+  //     out << "\t" << file << " [" << s << "]" << std::endl;
+  // }
+}
 
 // CoverageTracker
 
 void CoverageTracker::touch(std::string filename, size_t line) {
-    // Check if this file is already being tracked
-    auto it_file = file_to_vec.find(filename);
-    size_t vecPos = 0;
-    if (it_file == file_to_vec.end()) {
-        vecPos = file_lines.size();
-        std::map<size_t, Line> m;
-        file_lines.push_back(m);
-    } else {
-        vecPos = (*it_file).second;
-    }
-    // Check if line has already been seen.
-    auto it_line = file_lines[vecPos].find(line);
-    if (it_line == file_lines[vecPos].end()) {
-        Line l{line};
-        file_lines[vecPos].emplace(line, l);
-    } else {
-        file_lines[vecPos][line].touch();
-    }
+  // Check if this file is already being tracked
+  auto it_file = file_to_vec.find(filename);
+  size_t vecPos = 0;
+  if (it_file == file_to_vec.end()) {
+    vecPos = file_lines.size();
+    std::map<size_t, Line> m;
+    file_lines.push_back(m);
+  } else {
+    vecPos = (*it_file).second;
+  }
+  // Check if line has already been seen.
+  auto it_line = file_lines[vecPos].find(line);
+  if (it_line == file_lines[vecPos].end()) {
+    Line l{line};
+    file_lines[vecPos].emplace(line, l);
+  } else {
+    file_lines[vecPos][line].touch();
+  }
 }
 
 // --- Line
 
-Line::Line(size_t line_number, size_t hits): 
-    line_{line_number}, hits_{hits} {}
+Line::Line(size_t line_number, size_t hits) : line_{line_number}, hits_{hits} {}
 
 void Line::touch(size_t hits) {
-    hits_ += hits;
+  hits_ += hits;
 }
 
-size_t Line::LineNumber() const {
-    return line_;
+void Line::touch_branch(size_t branch_id, size_t hits) {
+  // TODO: Later expansion
 }
 
-size_t Line::Hits() const {
-    return hits_;
+void Line::touch_switch(size_t switch_id, size_t hits) {
+  // TODO: Later expansion
+}
+
+size_t Line::line() const {
+  return line_;
+}
+
+size_t Line::hits() const {
+  return hits_;
 }
 
 } // namespace caffeine

--- a/src/Support/Coverage.cpp
+++ b/src/Support/Coverage.cpp
@@ -1,6 +1,7 @@
 #include "caffeine/Support/Coverage.h"
 
 #include <algorithm>
+#include <iostream>
 
 namespace caffeine {
 
@@ -17,10 +18,11 @@ void CoverageReport::add_file(std::string filename,
 void CoverageReport::print(std::ostream& out) const {
   // out << "Report" << std::endl;
 
-  // for (const auto& [file, lines] : file_lines) {
-  //     std::string s(lines.begin(), lines.end())
-  //     out << "\t" << file << " [" << s << "]" << std::endl;
-  // }
+  for (const auto& [file, lines] : file_lines) {
+      // std::string s(lines.begin(), lines.end())
+      // std::cout << "\t" << file << " [" << s << "]" << std::endl;
+  }
+
 }
 
 // CoverageTracker

--- a/tools/caffeine/main.cpp
+++ b/tools/caffeine/main.cpp
@@ -6,9 +6,9 @@
 #include "caffeine/Interpreter/Store.h"
 #include "caffeine/Interpreter/ThreadQueueStore.h"
 #include "caffeine/Solver/LoggingSolver.h"
+#include "caffeine/Support/Coverage.h"
 #include "caffeine/Support/DiagnosticHandler.h"
 #include "caffeine/Support/Signal.h"
-#include "caffeine/Support/Coverage.h"
 #include "caffeine/Support/Tracing.h"
 
 #include <cstdlib>
@@ -159,12 +159,11 @@ int main(int argc, char** argv) {
     return 2;
   }
 
-  CoverageTracker cov;
   auto caffeine = CaffeineContext::builder()
                       .with_store(std::move(store))
                       .with_logger(std::make_unique<CountingFailureLogger>(
                           std::cout, function))
-                      .with_coverage(cov)
+                      .with_coverage(CoverageTracker())
                       .build();
   auto exec = caffeine::Executor(&caffeine, options);
 

--- a/tools/caffeine/main.cpp
+++ b/tools/caffeine/main.cpp
@@ -86,6 +86,8 @@ cl::opt<std::string> store_type{
              "thread-queue."),
     cl::value_desc("store"), cl::init("thread-queue"),
     cl::cat(caffeine_options)};
+cl::opt<bool> enable_coverage{"coverage", cl::desc("Enable coverage tracking"),
+                              cl::cat(caffeine_options)};
 
 static ExitOnError exit_on_err;
 
@@ -159,7 +161,9 @@ int main(int argc, char** argv) {
     return 2;
   }
 
-  std::unique_ptr<CoverageTracker> cov = std::make_unique<CoverageTracker>();
+  std::unique_ptr<CoverageTracker> cov = nullptr;
+  if (enable_coverage)
+    cov = std::make_unique<CoverageTracker>();
 
   auto caffeine = CaffeineContext::builder()
                       .with_store(std::move(store))
@@ -178,7 +182,7 @@ int main(int argc, char** argv) {
   auto logger = static_cast<CountingFailureLogger*>(caffeine.logger());
   int exitcode = logger->num_failures == 0 ? 0 : 1;
 
-  if (caffeine.options().run_line_coverage) {
+  if (caffeine.coverage()) {
     caffeine.coverage()->report().print(std::cout);
   }
 

--- a/tools/caffeine/main.cpp
+++ b/tools/caffeine/main.cpp
@@ -159,11 +159,12 @@ int main(int argc, char** argv) {
     return 2;
   }
 
+  CoverageTracker cov;
   auto caffeine = CaffeineContext::builder()
                       .with_store(std::move(store))
                       .with_logger(std::make_unique<CountingFailureLogger>(
                           std::cout, function))
-                      .with_coverage(CoverageTracker())
+                      .with_coverage(cov)
                       .build();
   auto exec = caffeine::Executor(&caffeine, options);
 

--- a/tools/caffeine/main.cpp
+++ b/tools/caffeine/main.cpp
@@ -8,6 +8,7 @@
 #include "caffeine/Solver/LoggingSolver.h"
 #include "caffeine/Support/DiagnosticHandler.h"
 #include "caffeine/Support/Signal.h"
+#include "caffeine/Support/Coverage.h"
 #include "caffeine/Support/Tracing.h"
 
 #include <cstdlib>
@@ -158,10 +159,12 @@ int main(int argc, char** argv) {
     return 2;
   }
 
+  CoverageTracker cov;
   auto caffeine = CaffeineContext::builder()
                       .with_store(std::move(store))
                       .with_logger(std::make_unique<CountingFailureLogger>(
                           std::cout, function))
+                      .with_coverage(cov)
                       .build();
   auto exec = caffeine::Executor(&caffeine, options);
 


### PR DESCRIPTION
Adds Line coverage tracking.

Report format:
```
=============Coverage report==============
-> libraries/builtins/string.c: [5,6]
-> libraries/builtins/make_symbolic.c: [5,6,8,9,10]
-> test/run-pass/branch-false.c: [5,6,8,9,10,14,15]
=========================================
```

Next steps:
* Add coverage ignore files/directories
* Print file with line coverage.
* Branch coverage
* Check how to do it for distributed