### PR TITLE
Add utilities for handling function returns to `InterpreterContext`

### DIFF
--- a/include/caffeine/Interpreter/InterpreterContext.h
+++ b/include/caffeine/Interpreter/InterpreterContext.h
@@ -101,6 +101,22 @@ public:
   void jump_to(llvm::BasicBlock* block);
 
   /**
+   * Jump as if the current function is returning normally. For regular call
+   * instructions this is a no-op, however for invoke instructions this will
+   * make the appropriate jump to reach the block for the normal execution
+   * flow.
+   */
+  void jump_return(std::optional<LLVMValue> retval = std::nullopt);
+
+  /**
+   * Jump as if the current function call returned by throwing an exception.
+   * This will jump to the unwind label for invoke instructions. It will
+   * cause the current context to fail if the function call instruction was not
+   * an invoke instruction.
+   */
+  void jump_resume(const LLVMValue& resume);
+
+  /**
    * Return from the current stack frame with an optional return value. If this
    * causes the stack to be empty then the context will also be killed.
    *

--- a/src/Interpreter/InterpreterContext.cpp
+++ b/src/Interpreter/InterpreterContext.cpp
@@ -49,9 +49,14 @@ llvm::Instruction* InterpreterContext::getCurrentInstruction() const {
     return nullptr;
 
   const auto& regular = frame.get_regular();
-  if (regular.current == regular.current_block->end())
-    return nullptr;
-  return &*regular.current;
+  if (regular.current == regular.current_block->begin()) {
+    if (!regular.prev_block)
+      return nullptr;
+
+    return regular.prev_block->getTerminator();
+  }
+
+  return &*std::prev(regular.current);
 }
 
 // TODO: This is basically a placeholder. We need to figure out how to deal

--- a/test/unit/Interpreter/InterpreterContext.cpp
+++ b/test/unit/Interpreter/InterpreterContext.cpp
@@ -39,8 +39,11 @@ public:
 
     ASSERT_NE(M, nullptr);
 
+    Context ctx{M->getFunction("func")};
+    ++ctx.stack_top().get_regular().current;
+
     backing.push_back(std::make_unique<InterpreterContext::ContextQueueEntry>(
-        Context(M->getFunction("func"))));
+        std::move(ctx)));
   }
 
 private:


### PR DESCRIPTION
This PR includes two new methods and a bugfix to `InterpreterContext`:
- The new methods are utilities for performing the correct jump when simulating a return from an external function that doesn't actually create a custom external stack frame. This is expected to be the majority of external functions so these should be fairly important utilities.
- The fix changes `interpreter:;getCurrentInstruction` to actually return the currently executing instruction instead of the one that is scheduled to execute next. When calling `getCurrentInstruction` this is usually what is actually wanted.