### PR TITLE
Convert `caffeine_assume` to be a proper external function

### DIFF
--- a/include/caffeine/Interpreter/ExternalFuncs/CaffeineAssume.h
+++ b/include/caffeine/Interpreter/ExternalFuncs/CaffeineAssume.h
@@ -1,0 +1,12 @@
+#pragma once
+
+#include "caffeine/Interpreter/ExternalFunction.h"
+
+namespace caffeine {
+
+class CaffeineAssumeFunction : public ExternalFunction {
+public:
+  void call(InterpreterContext& ctx, Span<LLVMValue> args) const override;
+};
+
+} // namespace caffeine

--- a/include/caffeine/Interpreter/Interpreter.h
+++ b/include/caffeine/Interpreter/Interpreter.h
@@ -128,7 +128,6 @@ private:
 private:
   ExecutionResult visitExternFunc(llvm::CallBase& inst);
 
-  ExecutionResult visitAssume(llvm::CallBase& inst);
   ExecutionResult visitSymbolicAlloca(llvm::CallBase& inst);
 
   ExecutionResult visitCalloc(llvm::CallBase& inst);

--- a/src/Interpreter/CaffeineContext.cpp
+++ b/src/Interpreter/CaffeineContext.cpp
@@ -1,5 +1,6 @@
 #include "caffeine/Interpreter/CaffeineContext.h"
 #include "caffeine/Interpreter/ExternalFuncs/CaffeineAssert.h"
+#include "caffeine/Interpreter/ExternalFuncs/CaffeineAssume.h"
 #include "caffeine/Interpreter/ExternalFunction.h"
 #include "caffeine/Interpreter/FailureLogger.h"
 #include "caffeine/Interpreter/Policy.h"
@@ -137,6 +138,7 @@ Builder& Builder::with_solver_builder(SolverBuilder&& builder) {
 
 Builder& Builder::with_default_functions() {
   with_function("caffeine_assert", std::make_unique<CaffeineAssertFunction>());
+  with_function("caffeine_assume", std::make_unique<CaffeineAssumeFunction>());
 
   return *this;
 }

--- a/src/Interpreter/ExternalFuncs/CaffeineAssert.cpp
+++ b/src/Interpreter/ExternalFuncs/CaffeineAssert.cpp
@@ -12,6 +12,7 @@ void CaffeineAssertFunction::call(InterpreterContext& ctx,
   }
 
   ctx.assert_or_fail(args[0].scalar().expr(), "assertion failure");
+  ctx.jump_return();
 }
 
 } // namespace caffeine

--- a/src/Interpreter/ExternalFuncs/CaffeineAssume.cpp
+++ b/src/Interpreter/ExternalFuncs/CaffeineAssume.cpp
@@ -1,0 +1,18 @@
+#include "caffeine/Interpreter/ExternalFuncs/CaffeineAssume.h"
+#include "caffeine/Interpreter/InterpreterContext.h"
+
+namespace caffeine {
+
+void CaffeineAssumeFunction::call(InterpreterContext& ctx,
+                                  Span<LLVMValue> args) const {
+  if (args.size() != 1) {
+    ctx.fail("caffeine_assume called with bad signature (wrong number of "
+             "arguments)");
+    return;
+  }
+
+  ctx.add_assertion(args[0].scalar().expr());
+  ctx.jump_return();
+}
+
+} // namespace caffeine

--- a/src/Interpreter/Interpreter.cpp
+++ b/src/Interpreter/Interpreter.cpp
@@ -576,9 +576,6 @@ ExecutionResult Interpreter::visitExternFunc(llvm::CallBase& call) {
     return ExecutionResult::Migrated;
   }
 
-  if (name == "caffeine_assume")
-    return visitAssume(call);
-
   if (name == "caffeine_calloc")
     return visitCalloc(call);
   if (name == "caffeine_malloc_aligned")
@@ -598,18 +595,6 @@ ExecutionResult Interpreter::visitExternFunc(llvm::CallBase& call) {
 
   CAFFEINE_ABORT(
       fmt::format("external function '{}' not implemented", name.str()));
-}
-
-ExecutionResult Interpreter::visitAssume(llvm::CallBase& call) {
-  CAFFEINE_ASSERT(call.getNumArgOperands() == 1);
-
-  auto cond = ctx->lookup(call.getArgOperand(0));
-  ctx->add(cond.scalar().expr());
-
-  // Don't check whether adding the assumption causes this path to become
-  // dead since assumptions are rare, solver calls are expensive, and it'll
-  // get caught at the next conditional branch anyway.
-  return ExecutionResult::Continue;
 }
 
 std::optional<std::string> readSymbolicName(std::shared_ptr<Solver> solver,

--- a/test/run-pass/intrin/caffeine_assert/BUILD
+++ b/test/run-pass/intrin/caffeine_assert/BUILD
@@ -1,0 +1,3 @@
+load("//test:tests.bzl", "generate_tests")
+
+generate_tests(skip_files = [])

--- a/test/run-pass/intrin/caffeine_assert/invoke-assert.ll
+++ b/test/run-pass/intrin/caffeine_assert/invoke-assert.ll
@@ -1,0 +1,33 @@
+target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128"
+target triple = "x86_64-pc-linux-gnu"
+
+; Here we sign extend an i8 to an i16
+define dso_local void @test() local_unnamed_addr #0 
+  personality i8* bitcast (i32 (...)* @__gxx_personality_v0 to i8*)
+{
+  %a = icmp eq i8 0, 0
+  invoke void @caffeine_assume(i1 zeroext %a)
+    to label %normal
+    unwind label %unwind
+
+unwind:
+  %res = landingpad { i8*, i32 } cleanup
+  unreachable
+
+normal:
+  ret void
+}
+
+declare dso_local void @caffeine_assume(i1 zeroext) local_unnamed_addr #1
+declare dso_local void @caffeine_assert(i1 zeroext) local_unnamed_addr #1
+declare dso_local i32 @__gxx_personality_v0(...)
+
+attributes #0 = { nounwind uwtable "correctly-rounded-divide-sqrt-fp-math"="false" "disable-tail-calls"="false" "frame-pointer"="none" "less-precise-fpmad"="false" "min-legal-vector-width"="0" "no-infs-fp-math"="false" "no-jump-tables"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="false" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
+attributes #1 = { "correctly-rounded-divide-sqrt-fp-math"="false" "disable-tail-calls"="false" "frame-pointer"="none" "less-precise-fpmad"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="false" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
+attributes #2 = { nounwind }
+
+!llvm.module.flags = !{!0}
+!llvm.ident = !{!1}
+
+!0 = !{i32 1, !"wchar_size", i32 4}
+!1 = !{!"clang version 10.0.0-4ubuntu1 "}

--- a/test/run-pass/intrin/caffeine_assert/invoke-assert.ll
+++ b/test/run-pass/intrin/caffeine_assert/invoke-assert.ll
@@ -6,7 +6,7 @@ define dso_local void @test() local_unnamed_addr #0
   personality i8* bitcast (i32 (...)* @__gxx_personality_v0 to i8*)
 {
   %a = icmp eq i8 0, 0
-  invoke void @caffeine_assume(i1 zeroext %a)
+  invoke void @caffeine_assert(i1 zeroext %a)
     to label %normal
     unwind label %unwind
 


### PR DESCRIPTION
This PR does 3 main things:
- The biggest one is the one from the title: convert `caffeine_assume` to be an external function that derives from `ExternalFunction` and is included in the default external function map.
- Beyond that, I've also introduced a test case to verify that invoking `caffeine_assert` works as expected.
- Finally, it includes a small fix to `caffeine_assert` to ensure that when it is invoked it returns to the right location.

/stack #554