### PR TITLE
Add helper method to get the allocation from a pointer

### DIFF
--- a/include/caffeine/Interpreter/InterpreterContext.h
+++ b/include/caffeine/Interpreter/InterpreterContext.h
@@ -231,6 +231,14 @@ public:
   llvm::SmallVector<Pointer, 1>
   resolve_ptr(const Pointer& ptr, const OpRef& width, std::string_view message);
 
+  /**
+   * @brief Get the allocation that this pointer points to.
+   *
+   * @return const Allocation* The allocation, or null if this pointer does not
+   *                           point to any allocation.
+   */
+  Allocation* ptr_allocation(const Pointer& ptr);
+
   // Methods managing forks and context queuing
 
   /**

--- a/src/Interpreter/InterpreterContext.cpp
+++ b/src/Interpreter/InterpreterContext.cpp
@@ -261,6 +261,13 @@ InterpreterContext::resolve_ptr(const Pointer& ptr, const OpRef& width,
   return context().heaps.resolve(solver(), ptr, context());
 }
 
+Allocation* InterpreterContext::ptr_allocation(const Pointer& ptr) {
+  if (!ptr.is_resolved())
+    return nullptr;
+
+  return &context().heaps.ptr_allocation(ptr);
+}
+
 InterpreterContext InterpreterContext::fork() const {
   auto entry = std::make_unique<ContextQueueEntry>(context().fork_once());
   auto index = queue_->size();


### PR DESCRIPTION
Pretty much as in comment, this is just exposing an existing method that was already present on `MemHeapMgr` in a more convenient form.