### PR TITLE
Add builder functions for all external functions

### DIFF
--- a/include/caffeine/Interpreter/ExternalFunction.h
+++ b/include/caffeine/Interpreter/ExternalFunction.h
@@ -52,4 +52,24 @@ protected:
   ExternalFunction& operator=(ExternalFunction&&) = default;
 };
 
+/**
+ * @brief Builder methods for all external function instances.
+ *
+ * This class is basically just a namespace for static builder functions so that
+ * downstream users (i.e. pretty much just CaffeineContext) don't need to
+ * include all the respective headers.
+ *
+ * The naming convention I've chosen to take here is that the function name in
+ * this class is exactly the same as whatever external function is modelling.
+ */
+class ExternalFunctions {
+public:
+  static std::unique_ptr<ExternalFunction> caffeine_assert();
+  static std::unique_ptr<ExternalFunction> caffeine_assume();
+  static std::unique_ptr<ExternalFunction> caffeine_malloc_aligned();
+
+private:
+  ExternalFunctions() = delete;
+};
+
 } // namespace caffeine

--- a/src/Interpreter/CaffeineContext.cpp
+++ b/src/Interpreter/CaffeineContext.cpp
@@ -1,7 +1,4 @@
 #include "caffeine/Interpreter/CaffeineContext.h"
-#include "caffeine/Interpreter/ExternalFuncs/CaffeineAssert.h"
-#include "caffeine/Interpreter/ExternalFuncs/CaffeineAssume.h"
-#include "caffeine/Interpreter/ExternalFuncs/MallocAlign.h"
 #include "caffeine/Interpreter/ExternalFunction.h"
 #include "caffeine/Interpreter/FailureLogger.h"
 #include "caffeine/Interpreter/Policy.h"
@@ -138,10 +135,10 @@ Builder& Builder::with_solver_builder(SolverBuilder&& builder) {
 }
 
 Builder& Builder::with_default_functions() {
-  with_function("caffeine_assert", std::make_unique<CaffeineAssertFunction>());
-  with_function("caffeine_assume", std::make_unique<CaffeineAssumeFunction>());
+  with_function("caffeine_assert", ExternalFunctions::caffeine_assert());
+  with_function("caffeine_assume", ExternalFunctions::caffeine_assume());
   with_function("caffeine_malloc_aligned",
-                std::make_unique<MallocAlignFunction>());
+                ExternalFunctions::caffeine_malloc_aligned());
 
   return *this;
 }

--- a/src/Interpreter/ExternalFuncs/CaffeineAssert.cpp
+++ b/src/Interpreter/ExternalFuncs/CaffeineAssert.cpp
@@ -15,4 +15,8 @@ void CaffeineAssertFunction::call(InterpreterContext& ctx,
   ctx.jump_return();
 }
 
+std::unique_ptr<ExternalFunction> ExternalFunctions::caffeine_assert() {
+  return std::make_unique<CaffeineAssertFunction>();
+}
+
 } // namespace caffeine

--- a/src/Interpreter/ExternalFuncs/CaffeineAssume.cpp
+++ b/src/Interpreter/ExternalFuncs/CaffeineAssume.cpp
@@ -15,4 +15,8 @@ void CaffeineAssumeFunction::call(InterpreterContext& ctx,
   ctx.jump_return();
 }
 
+std::unique_ptr<ExternalFunction> ExternalFunctions::caffeine_assume() {
+  return std::make_unique<CaffeineAssumeFunction>();
+}
+
 } // namespace caffeine

--- a/src/Interpreter/ExternalFuncs/MallocAlign.cpp
+++ b/src/Interpreter/ExternalFuncs/MallocAlign.cpp
@@ -61,4 +61,8 @@ void MallocAlignFunction::call(InterpreterContext& ctx,
       Pointer(alloc, ConstantInt::CreateZero(ptr_width), address_space)));
 }
 
+std::unique_ptr<ExternalFunction> ExternalFunctions::caffeine_malloc_aligned() {
+  return std::make_unique<MallocAlignFunction>();
+}
+
 } // namespace caffeine


### PR DESCRIPTION
As in title, this means that we don't have to add a new header include to `CaffeineContext.cpp` every time we add a new external function. It also means that external functions can be entirely contained within their source files which is also nice.