### PR TITLE
Convert all implemented intrinsics to use `InterpreterContext`

### DIFF
--- a/include/caffeine/Interpreter/ExternalFunction.h
+++ b/include/caffeine/Interpreter/ExternalFunction.h
@@ -72,4 +72,22 @@ private:
   ExternalFunctions() = delete;
 };
 
+/**
+ * @brief Builder metrhods for all external function instances.
+ *
+ * This class is basically just a namespace for static builder functions so that
+ * downstream users don't need to include all the relevant headers.
+ *
+ * The naming convention here is that functions in this class should match their
+ * LLVM intrinsic ID enum name.
+ */
+class Intrinsics {
+public:
+  static std::unique_ptr<ExternalFunction> smul_with_overflow();
+  static std::unique_ptr<ExternalFunction> umul_with_overflow();
+
+private:
+  Intrinsics() = delete;
+};
+
 } // namespace caffeine

--- a/include/caffeine/Interpreter/Interpreter.h
+++ b/include/caffeine/Interpreter/Interpreter.h
@@ -116,9 +116,6 @@ public:
 
   ExecutionResult visitDbgInfoIntrinsic(llvm::DbgInfoIntrinsic&);
 
-  ExecutionResult visitUMulWithOverflowIntrinsic(llvm::IntrinsicInst& inst);
-  ExecutionResult visitSMulWithOverflowIntrinsic(llvm::IntrinsicInst& inst);
-
 private:
   void logFailure(Context& ctx, const Assertion& assertion,
                   std::string_view message = "");

--- a/src/Interpreter/CaffeineContext.cpp
+++ b/src/Interpreter/CaffeineContext.cpp
@@ -144,6 +144,11 @@ Builder& Builder::with_default_functions() {
 }
 
 Builder& Builder::with_default_intrinsics() {
+  with_intrinsic(llvm::Intrinsic::umul_with_overflow,
+                 Intrinsics::umul_with_overflow());
+  with_intrinsic(llvm::Intrinsic::smul_with_overflow,
+                 Intrinsics::smul_with_overflow());
+
   return *this;
 }
 

--- a/src/Interpreter/Interpreter.cpp
+++ b/src/Interpreter/Interpreter.cpp
@@ -410,21 +410,38 @@ ExecutionResult Interpreter::visitInvokeInst(llvm::InvokeInst& invoke) {
 ExecutionResult Interpreter::visitIntrinsicInst(llvm::IntrinsicInst& intrin) {
   namespace Intrinsic = llvm::Intrinsic;
 
+  // Note that some intrinsics are quickly filtered out here since they
+  // have no effect on program behaviour and this way we don't need to
+  // write a bunch of boilerplate to handle them.
   switch (intrin.getIntrinsicID()) {
   // These are just markers for when lifetimes are supposed to end.
   case Intrinsic::lifetime_start:
   case Intrinsic::lifetime_end:
-    return ExecutionResult::Continue;
-  case Intrinsic::umul_with_overflow:
-    return visitUMulWithOverflowIntrinsic(intrin);
-  case Intrinsic::smul_with_overflow:
-    return visitSMulWithOverflowIntrinsic(intrin);
+  // These are for debug info, they have no run time behaviour.
+  case Intrinsic::dbg_addr:
+  case Intrinsic::dbg_declare:
+  case Intrinsic::dbg_label:
+  case Intrinsic::dbg_value:
+    return ExecutionResult::Migrated;
   default:
     break;
   }
 
-  CAFFEINE_ABORT(fmt::format("Intrinsic function '{}' is not supported",
+  auto func = interp->caffeine().intrinsic(intrin.getIntrinsicID());
+  if (!func) {
+    interp->fail(fmt::format("Intrinsic function '{}' is not supported",
                              intrin.getCalledFunction()->getName().str()));
+    return ExecutionResult::Migrated;
+  }
+
+  llvm::SmallVector<LLVMValue, 4> args;
+  args.reserve(intrin.getNumArgOperands());
+  for (auto& arg : intrin.args())
+    args.push_back(interp->load(arg.get()));
+
+  func->call(*interp, args);
+
+  return ExecutionResult::Migrated;
 }
 ExecutionResult Interpreter::visitIndirectCall(llvm::CallBase& call) {
   CAFFEINE_ASSERT(

--- a/src/Interpreter/Interpreter/llvm.smul.with.overflow.cpp
+++ b/src/Interpreter/Interpreter/llvm.smul.with.overflow.cpp
@@ -1,25 +1,33 @@
+#include "caffeine/IR/Value.h"
+#include "caffeine/Interpreter/ExternalFunction.h"
 #include "caffeine/Interpreter/Interpreter.h"
 
 namespace caffeine {
 
-ExecutionResult
-Interpreter::visitSMulWithOverflowIntrinsic(llvm::IntrinsicInst& inst) {
-  auto a = ctx->lookup(inst.getArgOperand(0));
-  auto b = ctx->lookup(inst.getArgOperand(1));
+namespace {
+  class SMulWithOverflowIntrinsic : public ExternalFunction {
+  public:
+    void call(InterpreterContext& ctx, Span<LLVMValue> args) const {
+      CAFFEINE_ASSERT(args.size() == 2);
 
-  auto vals = transform_exprs(
-      [&](const auto& a, const auto& b) { return BinaryOp::CreateMul(a, b); },
-      a, b);
-  auto overflow = transform_exprs(
-      [&](const auto& a, const auto& b) {
-        return BinaryOp::CreateSMulOverflow(a, b);
-      },
-      a, b);
+      auto values = transform_exprs(
+          [](const auto& a, const auto& b) {
+            return BinaryOp::CreateMul(a, b);
+          },
+          args[0], args[1]);
+      auto overflow = transform_exprs(
+          [&](const auto& a, const auto& b) {
+            return BinaryOp::CreateSMulOverflow(a, b);
+          },
+          args[0], args[1]);
 
-  ctx->stack_top().get_regular().insert(
-      &inst, LLVMValue(llvm::ArrayRef<LLVMValue>{vals, overflow}));
+      ctx.jump_return(LLVMValue(llvm::ArrayRef<LLVMValue>{values, overflow}));
+    }
+  };
+} // namespace
 
-  return ExecutionResult::Continue;
+std::unique_ptr<ExternalFunction> Intrinsics::smul_with_overflow() {
+  return std::make_unique<SMulWithOverflowIntrinsic>();
 }
 
 } // namespace caffeine


### PR DESCRIPTION
This PR is another fairly straightforward conversion. We've only implemented two intrinsics so I've gone and converted everything in one go.