### PR TITLE
Convert `visitCalloc` to be an external function

### DIFF
--- a/include/caffeine/Interpreter/ExternalFunction.h
+++ b/include/caffeine/Interpreter/ExternalFunction.h
@@ -68,6 +68,7 @@ public:
   static std::unique_ptr<ExternalFunction> caffeine_assume();
   static std::unique_ptr<ExternalFunction> caffeine_malloc_aligned();
   static std::unique_ptr<ExternalFunction> caffeine_builtin_symbolic_alloca();
+  static std::unique_ptr<ExternalFunction> caffeine_calloc();
 
 private:
   ExternalFunctions() = delete;

--- a/include/caffeine/Interpreter/Interpreter.h
+++ b/include/caffeine/Interpreter/Interpreter.h
@@ -125,7 +125,6 @@ private:
 private:
   ExecutionResult visitExternFunc(llvm::CallBase& inst);
 
-  ExecutionResult visitCalloc(llvm::CallBase& inst);
   ExecutionResult visitFree(llvm::CallBase& inst);
 
   ExecutionResult visitBuiltinResolve(llvm::CallBase& inst);

--- a/src/Interpreter/CaffeineContext.cpp
+++ b/src/Interpreter/CaffeineContext.cpp
@@ -141,6 +141,7 @@ Builder& Builder::with_default_functions() {
                 ExternalFunctions::caffeine_malloc_aligned());
   with_function("caffeine_builtin_symbolic_alloca",
                 ExternalFunctions::caffeine_builtin_symbolic_alloca());
+  with_function("caffeine_calloc", ExternalFunctions::caffeine_calloc());
 
   return *this;
 }

--- a/src/Interpreter/ExternalFuncs/Calloc.cpp
+++ b/src/Interpreter/ExternalFuncs/Calloc.cpp
@@ -1,0 +1,67 @@
+#include "caffeine/Interpreter/CaffeineContext.h"
+#include "caffeine/Interpreter/ExternalFunction.h"
+#include "caffeine/Interpreter/InterpreterContext.h"
+#include <llvm/IR/Instructions.h>
+#include <llvm/IR/Module.h>
+
+namespace caffeine {
+namespace {
+
+  class CallocFunction : public ExternalFunction {
+  public:
+    void call(InterpreterContext& ctx, Span<LLVMValue> args) const {
+      if (args.size() != 1) {
+        ctx.fail(
+            "invalid caffeine_calloc signature (invalid number of arguments)");
+        return;
+      }
+
+      auto inst = ctx.getCurrentInstruction();
+      CAFFEINE_ASSERT(inst, "cannot call calloc without a current instruction");
+
+      auto call = llvm::dyn_cast<llvm::CallBase>(inst);
+      CAFFEINE_ASSERT(
+          call, "caffeine_calloc called from a non-call/invoke instruction?");
+
+      if (!call->getType()->isPointerTy()) {
+        ctx.fail("invalid caffeine_calloc signature (invalid return type)");
+        return;
+      }
+
+      const llvm::DataLayout& layout = ctx.getModule()->getDataLayout();
+      unsigned address_space = call->getType()->getPointerAddressSpace();
+      unsigned ptr_width = layout.getPointerTypeSizeInBits(call->getType());
+
+      auto size_ty = call->getArgOperand(0)->getType();
+      if (!size_ty->isIntegerTy() ||
+          size_ty->getIntegerBitWidth() !=
+              layout.getIndexSizeInBits(address_space)) {
+        ctx.fail("invalid caffeine_calloc signature (invalid first argument)");
+        return;
+      }
+
+      if (ctx.caffeine().options().malloc_can_return_null) {
+        auto fork = ctx.fork();
+        fork.jump_return(LLVMValue(
+            Pointer(ConstantInt::CreateZero(ptr_width), address_space)));
+      }
+
+      auto size = UnaryOp::CreateTruncOrZExt(Type::int_ty(ptr_width),
+                                             args[0].scalar().expr());
+      auto align = ConstantInt::Create(
+          llvm::APInt(ptr_width, ctx.caffeine().options().malloc_alignment));
+      auto alloc = ctx.allocate_repeated(
+          size, align, ConstantInt::Create(llvm::APInt(8, 0x00)), address_space,
+          AllocationKind::Malloc, AllocationPermissions::ReadWrite);
+
+      ctx.jump_return(LLVMValue(alloc));
+    }
+  };
+
+} // namespace
+
+std::unique_ptr<ExternalFunction> ExternalFunctions::caffeine_calloc() {
+  return std::make_unique<CallocFunction>();
+}
+
+} // namespace caffeine

--- a/src/Interpreter/Interpreter.cpp
+++ b/src/Interpreter/Interpreter.cpp
@@ -590,8 +590,6 @@ ExecutionResult Interpreter::visitExternFunc(llvm::CallBase& call) {
     return ExecutionResult::Migrated;
   }
 
-  if (name == "caffeine_calloc")
-    return visitCalloc(call);
   if (name == "caffeine_free")
     return visitFree(call);
 
@@ -635,43 +633,6 @@ std::optional<std::string> readSymbolicName(std::shared_ptr<Solver> solver,
   return std::string(start, end);
 }
 
-ExecutionResult Interpreter::visitCalloc(llvm::CallBase& call) {
-  CAFFEINE_ASSERT(call.getNumArgOperands() == 1, "Invalid calloc signature");
-  CAFFEINE_ASSERT(call.getType()->isPointerTy(), "Invalid calloc signature");
-
-  auto size = ctx->lookup(call.getArgOperand(0)).scalar().expr();
-  const llvm::DataLayout& layout = call.getModule()->getDataLayout();
-
-  unsigned address_space = call.getType()->getPointerAddressSpace();
-  auto ptr_width = layout.getPointerSizeInBits(address_space);
-
-  CAFFEINE_ASSERT(size->type().is_int(), "Invalid calloc signature");
-  CAFFEINE_ASSERT(size->type().bitwidth() ==
-                      layout.getIndexSizeInBits(address_space),
-                  "Invalid calloc signature");
-
-  if (options.malloc_can_return_null) {
-    Context forked = ctx->fork_once();
-    forked.stack_top().get_regular().insert(
-        &call, LLVMValue(Pointer(ConstantInt::Create(llvm::APInt(ptr_width, 0)),
-                                 address_space)));
-    queueContext(std::move(forked));
-  }
-
-  auto size_op = UnaryOp::CreateTruncOrZExt(Type::int_ty(ptr_width), size);
-  auto alloc = ctx->heaps[address_space].allocate(
-      size_op,
-      ConstantInt::Create(llvm::APInt(ptr_width, options.malloc_alignment)),
-      AllocOp::Create(size_op, ConstantInt::Create(llvm::APInt(8, 0x00))),
-      AllocationKind::Malloc, AllocationPermissions::ReadWrite, *ctx);
-
-  ctx->stack_top().get_regular().insert(
-      &call,
-      LLVMValue(Pointer(alloc, ConstantInt::Create(llvm::APInt(ptr_width, 0)),
-                        address_space)));
-
-  return ExecutionResult::Continue;
-}
 /**
  * caffeine_free is a more limited version of free that doesn't expect the input
  * to be a null pointer.


### PR DESCRIPTION
As in title. This is another straightforward refactoring change.