### PR TITLE
Convert `visitFree` to be an external function

### DIFF
--- a/include/caffeine/Interpreter/ExternalFunction.h
+++ b/include/caffeine/Interpreter/ExternalFunction.h
@@ -69,6 +69,7 @@ public:
   static std::unique_ptr<ExternalFunction> caffeine_malloc_aligned();
   static std::unique_ptr<ExternalFunction> caffeine_builtin_symbolic_alloca();
   static std::unique_ptr<ExternalFunction> caffeine_calloc();
+  static std::unique_ptr<ExternalFunction> caffeine_free();
 
 private:
   ExternalFunctions() = delete;

--- a/include/caffeine/Interpreter/Interpreter.h
+++ b/include/caffeine/Interpreter/Interpreter.h
@@ -125,8 +125,6 @@ private:
 private:
   ExecutionResult visitExternFunc(llvm::CallBase& inst);
 
-  ExecutionResult visitFree(llvm::CallBase& inst);
-
   ExecutionResult visitBuiltinResolve(llvm::CallBase& inst);
 
   ExecutionResult visitSetjmp(llvm::CallBase& inst);

--- a/include/caffeine/Interpreter/InterpreterContext.h
+++ b/include/caffeine/Interpreter/InterpreterContext.h
@@ -208,6 +208,15 @@ public:
                         std::string_view message);
 
   /**
+   * Assert that the pointer points to the start of an allocation.
+   *
+   * If this assertion fails then it will kill the current context and emit a
+   * test failure with the provided message as an explanatory string.
+   */
+  void assert_ptr_starts_allocation(const Pointer& ptr,
+                                    std::string_view message);
+
+  /**
    * Check whether a pointer is valid and, if so, resolve which concrete
    * allocations it could point to.
    *

--- a/src/Interpreter/CaffeineContext.cpp
+++ b/src/Interpreter/CaffeineContext.cpp
@@ -142,6 +142,7 @@ Builder& Builder::with_default_functions() {
   with_function("caffeine_builtin_symbolic_alloca",
                 ExternalFunctions::caffeine_builtin_symbolic_alloca());
   with_function("caffeine_calloc", ExternalFunctions::caffeine_calloc());
+  with_function("caffeine_free", ExternalFunctions::caffeine_free());
 
   return *this;
 }

--- a/src/Interpreter/ExternalFuncs/Free.cpp
+++ b/src/Interpreter/ExternalFuncs/Free.cpp
@@ -1,0 +1,67 @@
+#include "caffeine/Interpreter/ExternalFunction.h"
+#include "caffeine/Interpreter/InterpreterContext.h"
+#include <llvm/IR/Instructions.h>
+#include <llvm/IR/Module.h>
+
+namespace caffeine {
+namespace {
+
+  class CaffeineFreeFunction : public ExternalFunction {
+  public:
+    void call(InterpreterContext& ctx, Span<LLVMValue> args) const override {
+      if (args.size() != 1) {
+        ctx.fail(
+            "invalid caffeine_free signature (invalid number of arguments)");
+        return;
+      }
+
+      auto inst = ctx.getCurrentInstruction();
+      CAFFEINE_ASSERT(inst,
+                      "caffeine_free called without a current instruction");
+
+      auto call = llvm::dyn_cast<llvm::CallBase>(inst);
+      if (!call) {
+        ctx.fail("caffeine_free called from a non-call/invoke instruction");
+        return;
+      }
+
+      if (!call->getType()->isVoidTy()) {
+        ctx.fail("invalid caffeine_free signature (invalid return type)");
+        return;
+      }
+
+      if (!call->getArgOperand(0)->getType()->isPointerTy()) {
+        ctx.fail("invalid caffeine_free signature (invalid first argument)");
+        return;
+      }
+
+      auto memptr = args[0].scalar().pointer();
+      const auto& layout = ctx.getModule()->getDataLayout();
+      unsigned address_space = memptr.heap();
+      unsigned ptr_width = layout.getPointerSizeInBits(address_space);
+
+      ctx.assert_ptr_starts_allocation(memptr,
+                                       "free called with an invalid pointer");
+
+      auto resolved =
+          ctx.resolve_ptr(memptr, ConstantInt::CreateZero(ptr_width),
+                          "free called with a pointer not allocated by malloc");
+
+      ctx.kill();
+      for (auto ptr : resolved) {
+        auto fork = ctx.fork();
+        fork.add_assertion(
+            ICmpOp::CreateICmpEQ(memptr.value(fork.context().heaps),
+                                 ptr.value(fork.context().heaps)));
+        fork.context().heaps[ptr.heap()].deallocate(ptr.alloc());
+      }
+    }
+  };
+
+} // namespace
+
+std::unique_ptr<ExternalFunction> ExternalFunctions::caffeine_free() {
+  return std::make_unique<CaffeineFreeFunction>();
+}
+
+} // namespace caffeine

--- a/src/Interpreter/InterpreterContext.cpp
+++ b/src/Interpreter/InterpreterContext.cpp
@@ -225,6 +225,9 @@ void InterpreterContext::assert_or_fail(const Assertion& assertion,
 void InterpreterContext::assert_ptr_valid(const Pointer& ptr,
                                           const OpRef& width,
                                           std::string_view message) {
+  if (is_dead())
+    return;
+
   auto& ctx = context();
   auto assertion = !ctx.heaps.check_valid(ptr, width);
   auto result = resolve(assertion);
@@ -240,6 +243,11 @@ void InterpreterContext::assert_ptr_valid(const Pointer& ptr, uint32_t width,
       ptr,
       ConstantInt::Create(llvm::APInt(ptr.offset()->type().bitwidth(), width)),
       message);
+}
+
+void InterpreterContext::assert_ptr_starts_allocation(
+    const Pointer& ptr, std::string_view message) {
+  assert_or_fail(context().heaps.check_starts_allocation(ptr), message);
 }
 
 llvm::SmallVector<Pointer, 1>


### PR DESCRIPTION
As in title. This is another straightforward refactoring change. I've also added another helper function to `InterpreterContext` that simplifies some of the work around asserting that a pointer points to the start of an allocation.