### PR TITLE
Add helpers for reading/writing memory to `InterpreterContext`

### DIFF
--- a/include/caffeine/Interpreter/InterpreterContext.h
+++ b/include/caffeine/Interpreter/InterpreterContext.h
@@ -4,6 +4,10 @@
 #include "caffeine/Interpreter/Policy.h"
 #include "caffeine/Solver/Solver.h"
 
+namespace llvm {
+class Type;
+}
+
 namespace caffeine {
 
 class FailureLogger;
@@ -111,6 +115,24 @@ public:
                             AllocationKind kind, AllocationPermissions perms);
 
   // Utilities for performing common control flow operations
+
+  /**
+   * Write a value to the memory pointed to by ptr.
+   *
+   * The pointer be resolved and it must be valid to write to ptr for at least
+   * the number of bytes it takes to write out value. That is, this pointer
+   * should be one returned by a call to resolve with the correct parameters.
+   */
+  void mem_write(const Pointer& ptr, llvm::Type* type, const LLVMValue& value);
+
+  /**
+   * Read a LLVM value of the provided type from the memory pointed to by ptr.
+   *
+   * The pointer must be resolved and it must be valid to read from ptr for at
+   * least the number of bytes it takes to represent the provided type. That is,
+   * the pointer should be one returned from a call to resolve.
+   */
+  LLVMValue mem_read(const Pointer& ptr, llvm::Type* type);
 
   /**
    * Set the instruction pointer of the current stack frame to the first

--- a/src/Interpreter/InterpreterContext.cpp
+++ b/src/Interpreter/InterpreterContext.cpp
@@ -6,6 +6,7 @@
 #include "caffeine/Support/UnsupportedOperation.h"
 #include <llvm/IR/Instructions.h>
 #include <llvm/IR/Module.h>
+#include <llvm/IR/Type.h>
 
 namespace caffeine {
 
@@ -124,6 +125,22 @@ Pointer InterpreterContext::allocate_repeated(
     unsigned address_space, AllocationKind kind, AllocationPermissions perms) {
   return allocate(size, align, AllocOp::Create(size, byte), address_space, kind,
                   perms);
+}
+
+void InterpreterContext::mem_write(const Pointer& ptr, llvm::Type* type,
+                                   const LLVMValue& value) {
+  CAFFEINE_ASSERT(ptr.is_resolved());
+
+  Allocation& alloc = context().heaps.ptr_allocation(ptr);
+  alloc.write(ptr.offset(), type, value, context().heaps,
+              getModule()->getDataLayout());
+}
+
+LLVMValue InterpreterContext::mem_read(const Pointer& ptr, llvm::Type* type) {
+  CAFFEINE_ASSERT(ptr.is_resolved());
+
+  Allocation& alloc = context().heaps.ptr_allocation(ptr);
+  return alloc.read(ptr.offset(), type, getModule()->getDataLayout());
 }
 
 void InterpreterContext::jump_to(llvm::BasicBlock* block) {


### PR DESCRIPTION
This PR adds two new methods to `InterpreterContext`:
- `mem_read`: read a `LLVMValue` instance from a resolved pointer
- `mem_write`: write a `LLVMValue` instance to a resolved pointer

Both of these are methods that I've extracted from my work on `setjmp`/`longjmp`.