### PR TITLE
Implement an `OperationBuilder` and have `InterpreterBuilder` derive from it

### DIFF
--- a/include/caffeine/IR/OperationBuilder.h
+++ b/include/caffeine/IR/OperationBuilder.h
@@ -1,0 +1,147 @@
+#pragma once
+
+#include "caffeine/IR/Operation.h"
+
+namespace caffeine {
+class Context;
+class LLVMValue;
+class LLVMScalar;
+class Pointer;
+
+#define CAFFEINE_DECL_BINOP(op)                                                \
+  OpRef create##op(const OpRef& lhs, const OpRef& rhs);                        \
+  LLVMValue create##op(const LLVMValue& lhs, const LLVMValue& rhs)
+
+#define CAFFEINE_DECL_INT_BINOP(op)                                            \
+  CAFFEINE_DECL_BINOP(op);                                                     \
+  OpRef create##op(const OpRef& lhs, int64_t rhs);                             \
+  OpRef create##op(const int64_t lhs, const OpRef& rhs)
+
+#define CAFFEINE_DECL_PTR_BINOP(op)                                            \
+  CAFFEINE_DECL_INT_BINOP(op);                                                 \
+  OpRef create##op(const Pointer& lhs, const OpRef& rhs);                      \
+  OpRef create##op(const OpRef& lhs, const Pointer& rhs);                      \
+  OpRef create##op(const Pointer& lhs, const Pointer& rhs)
+
+#define CAFFEINE_DECL_OPCODE_BINOP(op, opty)                                   \
+  LLVMValue create##op(opty opcode, const LLVMValue& lhs,                      \
+                       const LLVMValue& rhs);                                  \
+  OpRef create##op(opty opcode, const OpRef& lhs, const OpRef& rhs)
+
+#define CAFFEINE_DECL_UNOP(op)                                                 \
+  OpRef create##op(const OpRef& operand);                                      \
+  LLVMValue create##op(const LLVMValue& operand)
+
+#define CAFFEINE_DECL_CONVERT_OP(op)                                           \
+  OpRef create##op(Type tgt, const OpRef& operand);                            \
+  LLVMValue create##op(Type tgt, const LLVMValue& operand)
+
+class OperationBuilder {
+public:
+  OperationBuilder(Context* ctx);
+
+public:
+  OpRef createConstantZero(unsigned bitwidth);
+
+  OpRef createConstantInt(unsigned bitwidth, uint64_t value);
+  OpRef createConstantInt(const llvm::APInt& value);
+  OpRef createConstantInt(llvm::APInt&& value);
+
+  OpRef createConstantFloat(const llvm::APFloat& value);
+  OpRef createConstantFloat(llvm::APFloat&& value);
+
+  OpRef createConstant(Type t, const Symbol& symbol);
+  OpRef createConstant(Type t, Symbol&& symbol);
+
+  OpRef createConstantArray(const Symbol& symbol, const OpRef& size);
+  OpRef createConstantArray(Symbol&& symbol, const OpRef& size);
+
+  CAFFEINE_DECL_PTR_BINOP(Add);
+  CAFFEINE_DECL_PTR_BINOP(Sub);
+  CAFFEINE_DECL_INT_BINOP(Mul);
+  CAFFEINE_DECL_INT_BINOP(UDiv);
+  CAFFEINE_DECL_INT_BINOP(SDiv);
+  CAFFEINE_DECL_INT_BINOP(URem);
+  CAFFEINE_DECL_INT_BINOP(SRem);
+
+  CAFFEINE_DECL_INT_BINOP(And);
+  CAFFEINE_DECL_INT_BINOP(Or);
+  CAFFEINE_DECL_INT_BINOP(Xor);
+  CAFFEINE_DECL_INT_BINOP(Shl);
+  CAFFEINE_DECL_INT_BINOP(LShr);
+  CAFFEINE_DECL_INT_BINOP(AShr);
+
+  CAFFEINE_DECL_BINOP(FAdd);
+  CAFFEINE_DECL_BINOP(FSub);
+  CAFFEINE_DECL_BINOP(FMul);
+  CAFFEINE_DECL_BINOP(FDiv);
+  CAFFEINE_DECL_BINOP(FRem);
+
+  CAFFEINE_DECL_INT_BINOP(UMulOverflow);
+  CAFFEINE_DECL_INT_BINOP(SMulOverflow);
+
+  CAFFEINE_DECL_UNOP(Not);
+  CAFFEINE_DECL_UNOP(FNeg);
+  CAFFEINE_DECL_UNOP(FIsNaN);
+
+  CAFFEINE_DECL_CONVERT_OP(Trunc);
+  CAFFEINE_DECL_CONVERT_OP(ZExt);
+  CAFFEINE_DECL_CONVERT_OP(SExt);
+  CAFFEINE_DECL_CONVERT_OP(FpTrunc);
+  CAFFEINE_DECL_CONVERT_OP(FpExt);
+  CAFFEINE_DECL_CONVERT_OP(FpToUI);
+  CAFFEINE_DECL_CONVERT_OP(FpToSI);
+  CAFFEINE_DECL_CONVERT_OP(UIToFp);
+  CAFFEINE_DECL_CONVERT_OP(SIToFp);
+  CAFFEINE_DECL_CONVERT_OP(Bitcast);
+
+  CAFFEINE_DECL_CONVERT_OP(TruncOrZExt);
+  CAFFEINE_DECL_CONVERT_OP(TruncOrSExt);
+
+  OpRef createSelect(const OpRef& cond, const OpRef& true_value,
+                     const OpRef& false_value);
+  LLVMValue createSelect(const LLVMValue& cond, const LLVMValue& true_value,
+                         const LLVMValue& false_value);
+
+  CAFFEINE_DECL_OPCODE_BINOP(ICmp, ICmpOpcode);
+
+  CAFFEINE_DECL_PTR_BINOP(ICmpEQ);
+  CAFFEINE_DECL_PTR_BINOP(ICmpNE);
+  CAFFEINE_DECL_PTR_BINOP(ICmpUGT);
+  CAFFEINE_DECL_PTR_BINOP(ICmpUGE);
+  CAFFEINE_DECL_PTR_BINOP(ICmpULT);
+  CAFFEINE_DECL_PTR_BINOP(ICmpULE);
+  CAFFEINE_DECL_PTR_BINOP(ICmpSGT);
+  CAFFEINE_DECL_PTR_BINOP(ICmpSGE);
+  CAFFEINE_DECL_PTR_BINOP(ICmpSLT);
+  CAFFEINE_DECL_PTR_BINOP(ICmpSLE);
+
+  LLVMValue createFCmp(FCmpOpcode opcode, const LLVMValue& lhs,
+                       const LLVMValue& rhs);
+  OpRef createFCmp(FCmpOpcode opcode, const OpRef& lhs, const OpRef& rhs);
+
+  OpRef createAlloc(const OpRef& size, const OpRef& defaultval);
+  OpRef createLoad(const OpRef& data, const OpRef& offset);
+  OpRef createStore(const OpRef& data, const OpRef& offset, const OpRef& value);
+  OpRef createUndef(Type t);
+
+  OpRef createFixedArray(Type index_ty, const PersistentArray<OpRef>& data);
+  OpRef createFixedArray(Type index_ty, const OpRef& value, size_t size);
+
+  OpRef createFunctionObject(llvm::Function* function);
+
+private:
+  OpRef to_expr(const LLVMScalar& scalar);
+  OpRef to_expr(const Pointer& ptr);
+
+  Context* ctx;
+};
+
+#undef CAFFEINE_DECL_BINOP
+#undef CAFFEINE_DECL_INT_BINOP
+#undef CAFFEINE_DECL_PTR_BINOP
+#undef CAFFEINE_DECL_OPCODE_BINOP
+#undef CAFFEINE_DECL_UNOP
+#undef CAFFEINE_DECL_CONVERT_OP
+
+} // namespace caffeine

--- a/include/caffeine/Interpreter/InterpreterContext.h
+++ b/include/caffeine/Interpreter/InterpreterContext.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "caffeine/IR/OperationBuilder.h"
 #include "caffeine/Interpreter/Context.h"
 #include "caffeine/Interpreter/Policy.h"
 #include "caffeine/Solver/Solver.h"
@@ -23,7 +24,7 @@ class CaffeineContext;
  * and if you find yourself repeating the same set of actions across a bunch of
  * different places then this class would probably be a good place to put it.
  */
-class InterpreterContext {
+class InterpreterContext : public OperationBuilder {
 public:
   // Various accessors
 

--- a/src/IR/OperationBuilder.cpp
+++ b/src/IR/OperationBuilder.cpp
@@ -1,0 +1,243 @@
+#include "caffeine/IR/OperationBuilder.h"
+#include "caffeine/Interpreter/Context.h"
+#include "caffeine/Model/Value.h"
+
+namespace caffeine {
+
+OperationBuilder::OperationBuilder(Context* ctx) : ctx(ctx) {}
+
+OpRef OperationBuilder::createConstantZero(unsigned bitwidth) {
+  return createConstantInt(llvm::APInt::getNullValue(bitwidth));
+}
+
+OpRef OperationBuilder::createConstantInt(unsigned bitwidth, uint64_t value) {
+  return createConstantInt(llvm::APInt(bitwidth, value));
+}
+OpRef OperationBuilder::createConstantInt(llvm::APInt&& value) {
+  return ConstantInt::Create(std::move(value));
+}
+OpRef OperationBuilder::createConstantInt(const llvm::APInt& value) {
+  return ConstantInt::Create(value);
+}
+
+OpRef OperationBuilder::createConstantFloat(const llvm::APFloat& value) {
+  return ConstantFloat::Create(value);
+}
+OpRef OperationBuilder::createConstantFloat(llvm::APFloat&& value) {
+  return ConstantFloat::Create(std::move(value));
+}
+
+OpRef OperationBuilder::createConstant(Type t, const Symbol& symbol) {
+  return Constant::Create(t, symbol);
+}
+OpRef OperationBuilder::createConstant(Type t, Symbol&& symbol) {
+  return Constant::Create(t, std::move(symbol));
+}
+
+OpRef OperationBuilder::createConstantArray(const Symbol& symbol,
+                                            const OpRef& size) {
+  return ConstantArray::Create(symbol, size);
+}
+OpRef OperationBuilder::createConstantArray(Symbol&& symbol,
+                                            const OpRef& size) {
+  return ConstantArray::Create(std::move(symbol), size);
+}
+
+#define DEF_BINOP_REST(op)                                                     \
+  LLVMValue OperationBuilder::create##op(const LLVMValue& lhs,                 \
+                                         const LLVMValue& rhs) {               \
+    return transform_elements(                                                 \
+        [&](const LLVMScalar& a, const LLVMScalar& b) {                        \
+          return this->create##op(this->to_expr(a), this->to_expr(b));         \
+        },                                                                     \
+        lhs, rhs);                                                             \
+  }                                                                            \
+  static_assert(true)
+
+#define DEF_INT_BINOP_OVERLOADS(op)                                            \
+  OpRef OperationBuilder::create##op(const OpRef& lhs, int64_t rhs) {          \
+    CAFFEINE_ASSERT(lhs, "lhs was null");                                      \
+    CAFFEINE_ASSERT(lhs->type().is_int());                                     \
+                                                                               \
+    auto literal = llvm::APInt(64, static_cast<uint64_t>(rhs));                \
+    auto value =                                                               \
+        createConstantInt(literal.sextOrTrunc(lhs->type().bitwidth()));        \
+    return this->create##op(lhs, value);                                       \
+  }                                                                            \
+  OpRef OperationBuilder::create##op(int64_t lhs, const OpRef& rhs) {          \
+    CAFFEINE_ASSERT(rhs, "rhs was null");                                      \
+    CAFFEINE_ASSERT(rhs->type().is_int());                                     \
+                                                                               \
+    auto literal = llvm::APInt(64, static_cast<uint64_t>(lhs));                \
+    auto value =                                                               \
+        createConstantInt(literal.sextOrTrunc(rhs->type().bitwidth()));        \
+    return create##op(value, rhs);                                             \
+  }                                                                            \
+  static_assert(true)
+
+#define DEF_PTR_BINOP_OVERLOADS(op)                                            \
+  OpRef OperationBuilder::create##op(const Pointer& lhs, const OpRef& rhs) {   \
+    return create##op(to_expr(lhs), rhs);                                      \
+  }                                                                            \
+  OpRef OperationBuilder::create##op(const OpRef& lhs, const Pointer& rhs) {   \
+    return create##op(lhs, to_expr(rhs));                                      \
+  }                                                                            \
+  OpRef OperationBuilder::create##op(const Pointer& lhs, const Pointer& rhs) { \
+    return create##op(to_expr(lhs), to_expr(rhs));                             \
+  }                                                                            \
+  static_assert(true)
+
+#define DEF_CMP_BINOP_OVERLOADS(op)                                            \
+  DEF_PTR_BINOP_OVERLOADS(op);                                                 \
+  DEF_INT_BINOP_OVERLOADS(op);                                                 \
+  DEF_BINOP_REST(op)
+
+#define DEF_ICMP_BINOP_FWD(op)                                                 \
+  OpRef OperationBuilder::createICmp##op(const OpRef& lhs, const OpRef& rhs) { \
+    return createICmp(ICmpOpcode::op, lhs, rhs);                               \
+  }                                                                            \
+  DEF_CMP_BINOP_OVERLOADS(ICmp##op)
+
+#define DEF_BINOP(op)                                                          \
+  OpRef OperationBuilder::create##op(const OpRef& lhs, const OpRef& rhs) {     \
+    return BinaryOp::Create##op(lhs, rhs);                                     \
+  }                                                                            \
+  static_assert(true)
+#define DEF_UNOP(op)                                                           \
+  OpRef OperationBuilder::create##op(const OpRef& operand) {                   \
+    return UnaryOp::Create##op(operand);                                       \
+  }                                                                            \
+  static_assert(true)
+#define DEF_CONVERT(op)                                                        \
+  OpRef OperationBuilder::create##op(Type tgt, const OpRef& operand) {         \
+    return UnaryOp::Create##op(tgt, operand);                                  \
+  }                                                                            \
+  static_assert(true)
+
+#define DEF_INT_BINOP(op)                                                      \
+  DEF_BINOP(op);                                                               \
+  DEF_BINOP_REST(op);                                                          \
+  DEF_INT_BINOP_OVERLOADS(op)
+
+#define DEF_PTR_BINOP(op)                                                      \
+  DEF_INT_BINOP(op);                                                           \
+  DEF_PTR_BINOP_OVERLOADS(op)
+
+DEF_PTR_BINOP(Add);
+DEF_PTR_BINOP(Sub);
+DEF_INT_BINOP(Mul);
+DEF_INT_BINOP(UDiv);
+DEF_INT_BINOP(SDiv);
+DEF_INT_BINOP(URem);
+DEF_INT_BINOP(SRem);
+
+DEF_INT_BINOP(UMulOverflow);
+DEF_INT_BINOP(SMulOverflow);
+
+DEF_INT_BINOP(And);
+DEF_INT_BINOP(Or);
+DEF_INT_BINOP(Xor);
+DEF_INT_BINOP(Shl);
+DEF_INT_BINOP(LShr);
+DEF_INT_BINOP(AShr);
+
+DEF_BINOP(FAdd);
+DEF_BINOP(FSub);
+DEF_BINOP(FMul);
+DEF_BINOP(FDiv);
+DEF_BINOP(FRem);
+
+DEF_UNOP(Not);
+DEF_UNOP(FNeg);
+DEF_UNOP(FIsNaN);
+
+DEF_CONVERT(Trunc);
+DEF_CONVERT(ZExt);
+DEF_CONVERT(SExt);
+DEF_CONVERT(FpTrunc);
+DEF_CONVERT(FpExt);
+DEF_CONVERT(FpToUI);
+DEF_CONVERT(FpToSI);
+DEF_CONVERT(UIToFp);
+DEF_CONVERT(SIToFp);
+DEF_CONVERT(Bitcast);
+
+DEF_CONVERT(TruncOrZExt);
+DEF_CONVERT(TruncOrSExt);
+
+LLVMValue OperationBuilder::createICmp(ICmpOpcode opcode, const LLVMValue& lhs,
+                                       const LLVMValue& rhs) {
+  return transform_elements(
+      [&](const LLVMScalar& a, const LLVMScalar& b) -> LLVMScalar {
+        return this->createICmp(opcode, a.expr(), b.expr());
+      },
+      lhs, rhs);
+}
+OpRef OperationBuilder::createICmp(ICmpOpcode opcode, const OpRef& lhs,
+                                   const OpRef& rhs) {
+  return ICmpOp::CreateICmp(opcode, lhs, rhs);
+}
+
+DEF_ICMP_BINOP_FWD(EQ);
+DEF_ICMP_BINOP_FWD(NE);
+DEF_ICMP_BINOP_FWD(UGT);
+DEF_ICMP_BINOP_FWD(UGE);
+DEF_ICMP_BINOP_FWD(ULT);
+DEF_ICMP_BINOP_FWD(ULE);
+DEF_ICMP_BINOP_FWD(SGT);
+DEF_ICMP_BINOP_FWD(SGE);
+DEF_ICMP_BINOP_FWD(SLT);
+DEF_ICMP_BINOP_FWD(SLE);
+
+LLVMValue OperationBuilder::createFCmp(FCmpOpcode opcode, const LLVMValue& lhs,
+                                       const LLVMValue& rhs) {
+  return transform_elements(
+      [&](const LLVMScalar& a, const LLVMScalar& b) -> LLVMScalar {
+        return this->createFCmp(opcode, a.expr(), b.expr());
+      },
+      lhs, rhs);
+}
+OpRef OperationBuilder::createFCmp(FCmpOpcode opcode, const OpRef& lhs,
+                                   const OpRef& rhs) {
+  return FCmpOp::CreateFCmp(opcode, lhs, rhs);
+}
+
+OpRef OperationBuilder::createAlloc(const OpRef& size,
+                                    const OpRef& defaultval) {
+  return AllocOp::Create(size, defaultval);
+}
+OpRef OperationBuilder::createLoad(const OpRef& data, const OpRef& offset) {
+  return LoadOp::Create(data, offset);
+}
+OpRef OperationBuilder::createStore(const OpRef& data, const OpRef& offset,
+                                    const OpRef& value) {
+  return StoreOp::Create(data, offset, value);
+}
+OpRef OperationBuilder::createUndef(Type t) {
+  return Undef::Create(t);
+}
+
+OpRef OperationBuilder::createFixedArray(Type index_ty,
+                                         const PersistentArray<OpRef>& data) {
+  return FixedArray::Create(index_ty, data);
+}
+OpRef OperationBuilder::createFixedArray(Type index_ty, const OpRef& value,
+                                         size_t size) {
+  return FixedArray::Create(index_ty, value, size);
+}
+
+OpRef OperationBuilder::createFunctionObject(llvm::Function* function) {
+  return FunctionObject::Create(function);
+}
+
+OpRef OperationBuilder::to_expr(const LLVMScalar& scalar) {
+  if (scalar.is_expr())
+    return scalar.expr();
+
+  return to_expr(scalar.pointer());
+}
+OpRef OperationBuilder::to_expr(const Pointer& ptr) {
+  return ptr.value(ctx->heaps);
+}
+
+} // namespace caffeine

--- a/src/Interpreter/InterpreterContext.cpp
+++ b/src/Interpreter/InterpreterContext.cpp
@@ -349,8 +349,8 @@ void InterpreterContext::call_external_function(
 InterpreterContext::InterpreterContext(BackingList* queue, size_t entry_index,
                                        const std::shared_ptr<Solver>& solver,
                                        CaffeineContext* shared)
-    : queue_(queue), entry_(queue->at(entry_index).get()), shared_(shared),
-      solver_(solver) {
+    : OperationBuilder(&queue->at(entry_index)->context), queue_(queue),
+      entry_(queue->at(entry_index).get()), shared_(shared), solver_(solver) {
   CAFFEINE_ASSERT(queue_);
   CAFFEINE_ASSERT(shared_);
   CAFFEINE_ASSERT(solver_);


### PR DESCRIPTION
By giving the operation builder access to the current context we can provide a bunch of convenience methods that have needed to be implemented manually before this. This includes
- Constructors for creating operations that operate on `LLVMValue`s
- Constructors for creating operations that operate on `Pointer`s

Beyond that, it means that all constructions of `Operation` instances can (in the future) go through a single location. This isn't something I intend to go out an actively convert all expressions to, however, it will come into play once we want to take advantage of e-graphs.

Nevertheless, I'm intending for this builder to be useful _now_ and I'm going to use it to some effect when integrating e-graphs into the codebase.