### PR TITLE
Convert `visitLoadInst` to use `InterpreterContext`

### DIFF
--- a/include/caffeine/Interpreter/InterpreterContext.h
+++ b/include/caffeine/Interpreter/InterpreterContext.h
@@ -259,17 +259,22 @@ public:
    * - Determine which allocations the pointer could point within and return all
    *   of them. If the pointer is already known to point to a specific
    *   allocation then this is efficient.
+   *
+   * The overload that takes a llvm::Type will resolve according to the provided
+   * type's store size.
    */
   llvm::SmallVector<Pointer, 1> resolve_ptr(const Pointer& ptr, uint32_t width,
                                             std::string_view message);
   llvm::SmallVector<Pointer, 1>
   resolve_ptr(const Pointer& ptr, const OpRef& width, std::string_view message);
+  llvm::SmallVector<Pointer, 1>
+  resolve_ptr(const Pointer& ptr, llvm::Type* type, std::string_view message);
 
   /**
    * @brief Get the allocation that this pointer points to.
    *
-   * @return const Allocation* The allocation, or null if this pointer does not
-   *                           point to any allocation.
+   * @return const Allocation* The allocation, or null if this pointer does
+   * not point to any allocation.
    */
   Allocation* ptr_allocation(const Pointer& ptr);
 

--- a/src/Interpreter/InterpreterContext.cpp
+++ b/src/Interpreter/InterpreterContext.cpp
@@ -285,6 +285,12 @@ InterpreterContext::resolve_ptr(const Pointer& ptr, const OpRef& width,
 
   return context().heaps.resolve(solver(), ptr, context());
 }
+llvm::SmallVector<Pointer, 1>
+InterpreterContext::resolve_ptr(const Pointer& ptr, llvm::Type* type,
+                                std::string_view message) {
+  const llvm::DataLayout& layout = getModule()->getDataLayout();
+  return resolve_ptr(ptr, layout.getTypeStoreSize(type), message);
+}
 
 Allocation* InterpreterContext::ptr_allocation(const Pointer& ptr) {
   if (!ptr.is_resolved())


### PR DESCRIPTION
This one used `TransformBuilder` instead of directly using `ctx` so it got missed in the first pass. Otherwise it's another straightforward conversion. I've taken advantage of some methods within `OperationBuilder` so I've stacked this change on top of that one. In addition, I've also added one more utility method to `InterpreterContext`.

/stack #570 