### PR TITLE
Convert bazel `:check-format` target to be a test

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -1,7 +1,7 @@
 load("@bazel_skylib//rules:common_settings.bzl", "bool_flag", "string_flag")
 load("//bazel:configure.bzl", "configure_file")
 load("//bazel:warnings.bzl", "WARNING_FLAGS")
-load("//bazel:clang-format.bzl", "check_format", "do_format")
+load("//bazel:clang-format.bzl", "format_test", "do_format")
 load("//bazel:compile-commands.bzl", "compile_commands")
 
 package(default_visibility = ["//visibility:public"])
@@ -114,7 +114,7 @@ CAFFEINE_TARGETS = [
     "//tools/opt-plugin",
 ]
 
-check_format(
+format_test(
     name = "check-format",
     deps = CAFFEINE_TARGETS,
 )

--- a/bazel/clang-format.bzl
+++ b/bazel/clang-format.bzl
@@ -97,7 +97,7 @@ process()
 def _check_format(ctx):
     return _format_rule(
         ctx,
-        """diff --color -u "$1" <("$CLANG_FORMAT" "$1")"""
+        """diff --color -u "$1" <("$CLANG_FORMAT" "$1")""",
     )
 
 def _do_format(ctx):
@@ -110,10 +110,10 @@ if [ -s temp.diff ]; then
     echo "Formatting $1"
     cat temp.cpp > "$1"
 fi
-"""
+""",
     )
 
-check_format = rule(
+format_test = rule(
     implementation = _check_format,
     attrs = {
         "deps": attr.label_list(
@@ -131,6 +131,7 @@ check_format = rule(
         ),
     },
     executable = True,
+    test = True,
 )
 
 do_format = rule(


### PR DESCRIPTION
This means that it is run automatically whenever unit tests are run which should (hopefully) be helpful.