### PR TITLE
Convert `ExprEvaluator` to use `InterpreterContext` and `OperationBuilder`

### DIFF
--- a/include/caffeine/Interpreter/Context.h
+++ b/include/caffeine/Interpreter/Context.h
@@ -95,26 +95,6 @@ public:
   void add(Assertion&& assertion);
 
   /**
-   * Lookup a value within the top stack frame.
-   *
-   * There are two main cases here:
-   * 1. `value` is an existing variable, or
-   * 2. `value` is a constant.
-   *
-   * In the first place we look up the variable within the context at the top of
-   * the stack. In the second case we build an expression that represents the
-   * constant and return that.
-   *
-   * This method should be preferred over directly looking up variables in the
-   * stack frame as it properly handles global constants.
-   *
-   * The constant variant of the method will not create allocations and
-   * modify the registered globals table. The non const variant may do so.
-   */
-  std::optional<LLVMValue> lookup_const(llvm::Value* value) const;
-  LLVMValue lookup(llvm::Value* value);
-
-  /**
    * Validate whether the set of assertions combined with the extra assertion is
    * satisfiable.
    *

--- a/include/caffeine/Interpreter/ExprEval.h
+++ b/include/caffeine/Interpreter/ExprEval.h
@@ -50,7 +50,7 @@ public:
   };
 
   explicit ExprEvaluator(InterpreterContext* ctx, Options options = Options());
-  explicit ExprEvaluator(Context* ctx, Options options = Options());
+  [[deprecated]] explicit ExprEvaluator(Context* ctx, Options options = Options());
 
 public:
   LLVMValue visit(llvm::Value* val);

--- a/include/caffeine/Interpreter/ExprEval.h
+++ b/include/caffeine/Interpreter/ExprEval.h
@@ -12,6 +12,7 @@ namespace caffeine {
 class Context;
 class LLVMValue;
 class LLVMScalar;
+class InterpreterContext;
 
 /**
  * LLVM IR expression evaluator.
@@ -48,6 +49,7 @@ public:
     llvm::Value* expr() const;
   };
 
+  explicit ExprEvaluator(InterpreterContext* ctx, Options options = Options());
   explicit ExprEvaluator(Context* ctx, Options options = Options());
 
 public:

--- a/include/caffeine/Interpreter/ExprEval.h
+++ b/include/caffeine/Interpreter/ExprEval.h
@@ -50,7 +50,6 @@ public:
   };
 
   explicit ExprEvaluator(InterpreterContext* ctx, Options options = Options());
-  [[deprecated]] explicit ExprEvaluator(Context* ctx, Options options = Options());
 
 public:
   LLVMValue visit(llvm::Value* val);
@@ -150,7 +149,7 @@ private:
                     const LLVMScalar& f_val) const;
 
 private:
-  Context* ctx;
+  InterpreterContext* interp;
   Options options;
 };
 

--- a/src/Interpreter/Context.cpp
+++ b/src/Interpreter/Context.cpp
@@ -113,21 +113,6 @@ void Context::add(Assertion&& assertion) {
   assertions.insert(std::move(assertion));
 }
 
-std::optional<LLVMValue> Context::lookup_const(llvm::Value* value) const {
-  ExprEvaluator::Options options;
-  options.create_allocations = false;
-
-  // The const cast is a bit ugly here but ExprEvaluator will not modify the
-  // context if we have specified create_allocations = false.
-  if (auto v = ExprEvaluator{const_cast<Context*>(this)}.try_visit(value))
-    return (LLVMValue)*v;
-  return std::nullopt;
-}
-
-LLVMValue Context::lookup(llvm::Value* value) {
-  return (LLVMValue)ExprEvaluator{this}.visit(value);
-}
-
 SolverResult Context::check(std::shared_ptr<Solver> solver,
                             const Assertion& extra) {
   auto result = solver->check(assertions, extra);

--- a/src/Interpreter/ExprEval.cpp
+++ b/src/Interpreter/ExprEval.cpp
@@ -1,6 +1,7 @@
 #include "caffeine/Interpreter/ExprEval.h"
 
 #include "caffeine/Interpreter/Context.h"
+#include "caffeine/Interpreter/InterpreterContext.h"
 #include "caffeine/Memory/MemHeap.h"
 #include "caffeine/Model/Value.h"
 #include "caffeine/Support/LLVMFmt.h"
@@ -37,6 +38,9 @@ const char* ExprEvaluator::Unevaluatable::what() const throw() {
 llvm::Value* ExprEvaluator::Unevaluatable::expr() const {
   return expr_;
 }
+
+ExprEvaluator::ExprEvaluator(InterpreterContext* interp, Options options)
+    : ctx(&interp->context()), options(options) {}
 
 ExprEvaluator::ExprEvaluator(Context* ctx, Options options)
     : ctx(ctx), options(options) {}

--- a/src/Interpreter/Interpreter.cpp
+++ b/src/Interpreter/Interpreter.cpp
@@ -71,7 +71,7 @@ void Interpreter::visitInstruction(llvm::Instruction& inst) {
 
 #define DEF_SIMPLE_OP(opname, optype)                                          \
   void Interpreter::visit##opname(llvm::optype& op) {                          \
-    interp->store(&op, ExprEvaluator(&interp->context()).evaluate(op));        \
+    interp->store(&op, ExprEvaluator(interp).evaluate(op));                    \
   }                                                                            \
   static_assert(true)
 

--- a/src/Interpreter/InterpreterContext.cpp
+++ b/src/Interpreter/InterpreterContext.cpp
@@ -1,6 +1,7 @@
 
 #include "caffeine/Interpreter/InterpreterContext.h"
 #include "caffeine/Interpreter/CaffeineContext.h"
+#include "caffeine/Interpreter/ExprEval.h"
 #include "caffeine/Interpreter/FailureLogger.h"
 #include "caffeine/Interpreter/Policy.h"
 #include "caffeine/Support/UnsupportedOperation.h"
@@ -72,7 +73,13 @@ LLVMValue InterpreterContext::load(llvm::Value* value) {
                            "still being implemented");
   }
 
-  return context().lookup(value);
+  auto& regular = frame.get_regular();
+  auto it = regular.variables.find(value);
+  if (it != regular.variables.end()) {
+    return it->second;
+  }
+
+  return ExprEvaluator{this}.visit(value);
 }
 
 void InterpreterContext::store(llvm::Value* ident, const LLVMValue& value) {


### PR DESCRIPTION
The main thrust of this PR is as in the title. However, there were also some other bits that I needed to do in order to make everything work:
- I've removed some APIs from `Context` that are incompatible with the new API for `ExprEvaluator`. Specifically, this means `Context::lookup` and `Context::lookup_const`. The only user of these APIs was `InterpreterContext` so I've just migrated that use to lookup variables within the context directly.
- There were some builder methods that I forgot to implement when writing `OperationBuilder`. These are now implemented.
- One test suite had to be modified to also construct an `InterpreterContext` instance with which to build the `ExprEvaluator`.