### PR TITLE
Refactor `IRStackFrame::variables` to be private

### DIFF
--- a/include/caffeine/Interpreter/InterpreterContext.h
+++ b/include/caffeine/Interpreter/InterpreterContext.h
@@ -90,6 +90,15 @@ public:
   LLVMValue load(llvm::Value* value);
 
   /**
+   * Look up a value only within the current stack frame.
+   *
+   * If `value` does not refer to a value created within the current stack frame
+   * then this will return nullopt. This will happen even if value refers to a
+   * valid constant expression or an existing global.
+   */
+  std::optional<LLVMValue> lookup(llvm::Value* value) const;
+
+  /**
    * Store a value into the current stack frame.
    *
    * In order for this method to be correct the value should be a local value

--- a/include/caffeine/Interpreter/StackFrame.h
+++ b/include/caffeine/Interpreter/StackFrame.h
@@ -72,7 +72,15 @@ public:
   // Allocations within the current frame.
   std::vector<StackAllocation> allocations;
 
+private:
   std::unordered_map<llvm::Value*, LLVMValue> variables;
+
+  // These classes are the only ones that should be using the variables
+  // directly.
+  friend class InterpreterContext;
+  friend class Context;
+
+public:
   /**
    * Iterators used by Interpreter::execute
    */

--- a/include/caffeine/Interpreter/StackFrame.h
+++ b/include/caffeine/Interpreter/StackFrame.h
@@ -80,6 +80,10 @@ public:
   llvm::BasicBlock* prev_block = nullptr;
   llvm::BasicBlock::iterator current;
 
+private:
+  IRStackFrame(llvm::Function* function, uint64_t frame_id);
+
+public:
   /**
    * Change the instruction pointer to point at the start of the provided
    * block and update the previous block accordingly.
@@ -88,10 +92,6 @@ public:
    */
   void jump_to(llvm::BasicBlock* block);
 
-private:
-  IRStackFrame(llvm::Function* function, uint64_t frame_id);
-
-public:
   /**
    * Insert a new value into the current stack frame. If that value
    * is already in the current stack frame then it overwrites it.

--- a/src/Interpreter/ExprEval.cpp
+++ b/src/Interpreter/ExprEval.cpp
@@ -48,10 +48,9 @@ OpRef ExprEvaluator::scalarize(const LLVMScalar& scalar) const {
 }
 
 LLVMValue ExprEvaluator::visit(llvm::Value* val) {
-  const auto& frame = interp->context().stack_top().get_regular();
-  auto it = frame.variables.find(val);
-  if (it != frame.variables.end())
-    return it->second;
+  if (auto variable = interp->lookup(val)) {
+    return std::move(variable).value();
+  }
 
   return evaluate(val);
 }

--- a/src/Interpreter/Interpreter.cpp
+++ b/src/Interpreter/Interpreter.cpp
@@ -56,11 +56,8 @@ void Interpreter::execute() {
     // Printing expressions can be potentially very expensive so we only do it
     // if expensive annotations are enabled.
     if (CAFFEINE_TRACING_EXPENSIVE_ANNOTATIONS) {
-      auto& frame = interp->context().stack_top().get_regular();
-      auto it = frame.variables.find(&inst);
-      if (it != frame.variables.end()) {
-        traceblock.annotate("value", fmt::format("{}", it->second));
-      }
+      if (auto variable = interp->lookup(&inst))
+        traceblock.annotate("value", fmt::format("{}", *variable));
     }
   }
 


### PR DESCRIPTION
In order to integrate e-graphs I will need to modify `IRStackFrame`. However, in order to do this I need to not have a bunch of random places modifying it at will. This PR refactors all but two of the uses to use a helper method within `InterpreterContext` so that when I change it I only have to modify two locations.