### PR TITLE
[bazel] Add args parameter to caffeine_bitcode_test

### DIFF
--- a/bazel/bitcode.bzl
+++ b/bazel/bitcode.bzl
@@ -370,6 +370,12 @@ def caffeine_bitcode_test(should_fail = False, skip = False, **kwargs):
         test_args.update({"size": kwargs["size"]})
         kwargs["size"] = None
 
+    if "args" in kwargs:
+        extra_args = kwargs["args"]
+        kwargs["args"] = None
+    else:
+        extra_args = []
+
     name = kwargs["name"]
 
     kwargs["name"] += "#binary"
@@ -389,7 +395,7 @@ def caffeine_bitcode_test(should_fail = False, skip = False, **kwargs):
         "$(location {}#bitcode)".format(name),
         "-t",
         "1",
-    ]
+    ] + extra_args
 
     if "tags" in kwargs:
         tags += kwargs["tags"]


### PR DESCRIPTION
This allows tests that need custom command line arguments (e.g. coverage) to be defined. The new command line arguments are passed by adding an `args` parameter to the caffeine_bitcode_test macro call.