### PR TITLE
Clean up `OperationSimplifier` 

### DIFF
--- a/include/caffeine/IR/OperationSimplifier.h
+++ b/include/caffeine/IR/OperationSimplifier.h
@@ -13,56 +13,56 @@ namespace caffeine {
  */
 template <bool MoveOut = false>
 class OperationSimplifier
-    : public ConstOpVisitor<OperationSimplifier<MoveOut>, OpRef> {
+    : public OpVisitor<OperationSimplifier<MoveOut>, OpRef> {
 private:
-  using BaseType = ConstOpVisitor<OperationSimplifier<MoveOut>, OpRef>;
+  using BaseType = OpVisitor<OperationSimplifier<MoveOut>, OpRef>;
 
   static constexpr bool move_input = MoveOut;
 
 public:
-  OpRef visit(const Operation& op);
+  OpRef visit(Operation& op);
 
-  OpRef visitOperation(const Operation& op);
+  OpRef visitOperation(Operation& op);
 
-  OpRef visitAdd(const BinaryOp& op);
-  OpRef visitSub(const BinaryOp& op);
-  OpRef visitMul(const BinaryOp& op);
+  OpRef visitAdd(BinaryOp& op);
+  OpRef visitSub(BinaryOp& op);
+  OpRef visitMul(BinaryOp& op);
 
-  OpRef visitUDiv(const BinaryOp& op);
-  OpRef visitSDiv(const BinaryOp& op);
-  OpRef visitURem(const BinaryOp& op);
-  OpRef visitSRem(const BinaryOp& op);
+  OpRef visitUDiv(BinaryOp& op);
+  OpRef visitSDiv(BinaryOp& op);
+  OpRef visitURem(BinaryOp& op);
+  OpRef visitSRem(BinaryOp& op);
 
-  OpRef visitAnd(const BinaryOp& op);
-  OpRef visitOr(const BinaryOp& op);
-  OpRef visitXor(const BinaryOp& op);
-  OpRef visitShl(const BinaryOp& op);
-  OpRef visitLShr(const BinaryOp& op);
-  OpRef visitAShr(const BinaryOp& op);
+  OpRef visitAnd(BinaryOp& op);
+  OpRef visitOr(BinaryOp& op);
+  OpRef visitXor(BinaryOp& op);
+  OpRef visitShl(BinaryOp& op);
+  OpRef visitLShr(BinaryOp& op);
+  OpRef visitAShr(BinaryOp& op);
 
-  OpRef visitFAdd(const BinaryOp& op);
-  OpRef visitFSub(const BinaryOp& op);
-  OpRef visitFMul(const BinaryOp& op);
-  OpRef visitFDiv(const BinaryOp& op);
-  OpRef visitFRem(const BinaryOp& op);
+  OpRef visitFAdd(BinaryOp& op);
+  OpRef visitFSub(BinaryOp& op);
+  OpRef visitFMul(BinaryOp& op);
+  OpRef visitFDiv(BinaryOp& op);
+  OpRef visitFRem(BinaryOp& op);
 
-  OpRef visitFIsNaN(const UnaryOp& op);
-  OpRef visitNot(const UnaryOp& op);
-  OpRef visitTrunc(const UnaryOp& op);
-  OpRef visitZExt(const UnaryOp& op);
-  OpRef visitSExt(const UnaryOp& op);
-  OpRef visitBitcast(const UnaryOp& op);
+  OpRef visitFIsNaN(UnaryOp& op);
+  OpRef visitNot(UnaryOp& op);
+  OpRef visitTrunc(UnaryOp& op);
+  OpRef visitZExt(UnaryOp& op);
+  OpRef visitSExt(UnaryOp& op);
+  OpRef visitBitcast(UnaryOp& op);
 
-  OpRef visitSelectOp(const SelectOp& op);
+  OpRef visitSelectOp(SelectOp& op);
 
-  OpRef visitICmp(const ICmpOp& op);
-  OpRef visitFCmp(const FCmpOp& op);
+  OpRef visitICmp(ICmpOp& op);
+  OpRef visitFCmp(FCmpOp& op);
 
-  OpRef visitAllocOp(const AllocOp& op);
-  OpRef visitLoadOp(const LoadOp& op);
-  OpRef visitStoreOp(const StoreOp& op);
+  OpRef visitAllocOp(AllocOp& op);
+  OpRef visitLoadOp(LoadOp& op);
+  OpRef visitStoreOp(StoreOp& op);
 
-  OpRef visitFixedArray(const FixedArray& op);
+  OpRef visitFixedArray(FixedArray& op);
 
 private:
   template <typename... Ts>

--- a/include/caffeine/IR/OperationSimplifier.h
+++ b/include/caffeine/IR/OperationSimplifier.h
@@ -11,13 +11,11 @@ namespace caffeine {
  * This is called internally by the various derived construction functions so
  * you should never have to use it directly.
  */
-template <bool MoveOut = false>
-class OperationSimplifier
-    : public OpVisitor<OperationSimplifier<MoveOut>, OpRef> {
+class OperationSimplifier : public OpVisitor<OperationSimplifier, OpRef> {
 private:
-  using BaseType = OpVisitor<OperationSimplifier<MoveOut>, OpRef>;
+  using BaseType = OpVisitor<OperationSimplifier, OpRef>;
 
-  static constexpr bool move_input = MoveOut;
+  static constexpr bool move_input = true;
 
 public:
   OpRef visit(Operation& op);
@@ -105,8 +103,5 @@ private:
     return nullptr;
   }
 };
-
-extern template class OperationSimplifier<true>;
-extern template class OperationSimplifier<false>;
 
 } // namespace caffeine

--- a/include/caffeine/IR/OperationSimplifier.h
+++ b/include/caffeine/IR/OperationSimplifier.h
@@ -15,8 +15,6 @@ class OperationSimplifier : public OpVisitor<OperationSimplifier, OpRef> {
 private:
   using BaseType = OpVisitor<OperationSimplifier, OpRef>;
 
-  static constexpr bool move_input = true;
-
 public:
   OpRef visit(Operation& op);
 

--- a/src/IR/Operation.h
+++ b/src/IR/Operation.h
@@ -13,8 +13,7 @@ inline uint64_t ilog2(uint64_t x) {
 
 template <typename T>
 OpRef constant_fold(T&& value) {
-  OperationSimplifier<true> fold;
-  return fold(value);
+  return OperationSimplifier()(value);
 }
 
 OpRef extract_bit(const OpRef& op, uint32_t bit) {

--- a/src/IR/Operation.h
+++ b/src/IR/Operation.h
@@ -16,7 +16,7 @@ OpRef constant_fold(T&& value) {
   return OperationSimplifier()(value);
 }
 
-OpRef extract_bit(const OpRef& op, uint32_t bit) {
+inline OpRef extract_bit(const OpRef& op, uint32_t bit) {
   CAFFEINE_ASSERT(op->type().is_int());
   CAFFEINE_ASSERT(bit < op->type().bitwidth());
 

--- a/src/IR/OperationSimplifier.cpp
+++ b/src/IR/OperationSimplifier.cpp
@@ -92,7 +92,7 @@ namespace {
   } while (false)
 
 template <bool M>
-OpRef OperationSimplifier<M>::visit(const Operation& op) {
+OpRef OperationSimplifier<M>::visit(Operation& op) {
 #ifdef CAFFEINE_ENABLE_IMPLICIT_CONSTANT_FOLDING
   return BaseType::visit(op);
 #else
@@ -101,7 +101,7 @@ OpRef OperationSimplifier<M>::visit(const Operation& op) {
 }
 
 template <bool M>
-OpRef OperationSimplifier<M>::visitOperation(const Operation& op) {
+OpRef OperationSimplifier<M>::visitOperation(Operation& op) {
   if constexpr (move_input) {
     return OperationCache::default_cache()->cache(
         std::move(const_cast<Operation&>(op)));
@@ -112,7 +112,7 @@ OpRef OperationSimplifier<M>::visitOperation(const Operation& op) {
 }
 
 template <bool M>
-OpRef OperationSimplifier<M>::visitAdd(const BinaryOp& op) {
+OpRef OperationSimplifier<M>::visitAdd(BinaryOp& op) {
   if (op.lhs()->is<Undef>() || op.rhs()->is<Undef>())
     return Undef::Create(op.type());
 
@@ -126,7 +126,7 @@ OpRef OperationSimplifier<M>::visitAdd(const BinaryOp& op) {
   return this->visitBinaryOp(op);
 }
 template <bool M>
-OpRef OperationSimplifier<M>::visitSub(const BinaryOp& op) {
+OpRef OperationSimplifier<M>::visitSub(BinaryOp& op) {
   if (op.lhs()->is<Undef>() || op.rhs()->is<Undef>())
     return Undef::Create(op.type());
 
@@ -141,7 +141,7 @@ OpRef OperationSimplifier<M>::visitSub(const BinaryOp& op) {
   return this->visitBinaryOp(op);
 }
 template <bool M>
-OpRef OperationSimplifier<M>::visitMul(const BinaryOp& op) {
+OpRef OperationSimplifier<M>::visitMul(BinaryOp& op) {
   if (is_constant_int(op.lhs(), 0))
     return op.lhs();
   if (is_constant_int(op.rhs(), 0))
@@ -153,7 +153,7 @@ OpRef OperationSimplifier<M>::visitMul(const BinaryOp& op) {
 }
 
 template <bool M>
-OpRef OperationSimplifier<M>::visitUDiv(const BinaryOp& op) {
+OpRef OperationSimplifier<M>::visitUDiv(BinaryOp& op) {
   if (is_constant_int(op.lhs(), 0) || is_constant_int(*op.rhs(), 1))
     return op.lhs();
 
@@ -165,7 +165,7 @@ OpRef OperationSimplifier<M>::visitUDiv(const BinaryOp& op) {
   return this->visitBinaryOp(op);
 }
 template <bool M>
-OpRef OperationSimplifier<M>::visitSDiv(const BinaryOp& op) {
+OpRef OperationSimplifier<M>::visitSDiv(BinaryOp& op) {
   if (is_constant_int(op.lhs(), 0))
     return op.lhs();
   if (is_constant_int(op.rhs(), 1) && op.type().bitwidth() > 1)
@@ -179,7 +179,7 @@ OpRef OperationSimplifier<M>::visitSDiv(const BinaryOp& op) {
   return this->visitBinaryOp(op);
 }
 template <bool M>
-OpRef OperationSimplifier<M>::visitURem(const BinaryOp& op) {
+OpRef OperationSimplifier<M>::visitURem(BinaryOp& op) {
   if (is_constant_int(op.lhs(), 0))
     return op.lhs();
   if (is_constant_int(op.rhs(), 1))
@@ -193,7 +193,7 @@ OpRef OperationSimplifier<M>::visitURem(const BinaryOp& op) {
   return this->visitBinaryOp(op);
 }
 template <bool M>
-OpRef OperationSimplifier<M>::visitSRem(const BinaryOp& op) {
+OpRef OperationSimplifier<M>::visitSRem(BinaryOp& op) {
   if (is_constant_int(op.lhs(), 0))
     return op.lhs();
   if (is_constant_int(op.rhs(), 1) && op.type().bitwidth() > 1)
@@ -208,7 +208,7 @@ OpRef OperationSimplifier<M>::visitSRem(const BinaryOp& op) {
 }
 
 template <bool M>
-OpRef OperationSimplifier<M>::visitAnd(const BinaryOp& op) {
+OpRef OperationSimplifier<M>::visitAnd(BinaryOp& op) {
   namespace m = matching;
 
   if (is_constant_int(op.lhs(), 0))
@@ -256,7 +256,7 @@ OpRef OperationSimplifier<M>::visitAnd(const BinaryOp& op) {
   return this->visitBinaryOp(op);
 }
 template <bool M>
-OpRef OperationSimplifier<M>::visitOr(const BinaryOp& op) {
+OpRef OperationSimplifier<M>::visitOr(BinaryOp& op) {
   namespace m = matching;
 
   if (is_constant_int(op.lhs(), 0))
@@ -283,7 +283,7 @@ OpRef OperationSimplifier<M>::visitOr(const BinaryOp& op) {
   return this->visitBinaryOp(op);
 }
 template <bool M>
-OpRef OperationSimplifier<M>::visitXor(const BinaryOp& op) {
+OpRef OperationSimplifier<M>::visitXor(BinaryOp& op) {
   if (op.lhs()->is<Undef>() || op.rhs()->is<Undef>())
     return Undef::Create(op.type());
 
@@ -297,7 +297,7 @@ OpRef OperationSimplifier<M>::visitXor(const BinaryOp& op) {
   return this->visitBinaryOp(op);
 }
 template <bool M>
-OpRef OperationSimplifier<M>::visitShl(const BinaryOp& op) {
+OpRef OperationSimplifier<M>::visitShl(BinaryOp& op) {
   namespace m = matching;
 
   if (is_constant_int(op.lhs(), 0) || is_constant_int(op.rhs(), 0))
@@ -324,7 +324,7 @@ OpRef OperationSimplifier<M>::visitShl(const BinaryOp& op) {
   return this->visitBinaryOp(op);
 }
 template <bool M>
-OpRef OperationSimplifier<M>::visitLShr(const BinaryOp& op) {
+OpRef OperationSimplifier<M>::visitLShr(BinaryOp& op) {
   if (is_constant_int(op.lhs(), 0) || is_constant_int(op.rhs(), 0))
     return op.lhs();
 
@@ -333,7 +333,7 @@ OpRef OperationSimplifier<M>::visitLShr(const BinaryOp& op) {
   return this->visitBinaryOp(op);
 }
 template <bool M>
-OpRef OperationSimplifier<M>::visitAShr(const BinaryOp& op) {
+OpRef OperationSimplifier<M>::visitAShr(BinaryOp& op) {
   if (is_constant_int(op.lhs(), 0) || is_constant_int(op.rhs(), 0))
     return op.lhs();
 
@@ -343,31 +343,31 @@ OpRef OperationSimplifier<M>::visitAShr(const BinaryOp& op) {
 }
 
 template <bool M>
-OpRef OperationSimplifier<M>::visitFAdd(const BinaryOp& op) {
+OpRef OperationSimplifier<M>::visitFAdd(BinaryOp& op) {
   TRY_CONST_FLOAT(ConstantFloat::Create(lhs.value() + rhs.value()));
 
   return this->visitBinaryOp(op);
 }
 template <bool M>
-OpRef OperationSimplifier<M>::visitFSub(const BinaryOp& op) {
+OpRef OperationSimplifier<M>::visitFSub(BinaryOp& op) {
   TRY_CONST_FLOAT(ConstantFloat::Create(lhs.value() - rhs.value()));
 
   return this->visitBinaryOp(op);
 }
 template <bool M>
-OpRef OperationSimplifier<M>::visitFMul(const BinaryOp& op) {
+OpRef OperationSimplifier<M>::visitFMul(BinaryOp& op) {
   TRY_CONST_FLOAT(ConstantFloat::Create(lhs.value() * rhs.value()));
 
   return this->visitBinaryOp(op);
 }
 template <bool M>
-OpRef OperationSimplifier<M>::visitFDiv(const BinaryOp& op) {
+OpRef OperationSimplifier<M>::visitFDiv(BinaryOp& op) {
   TRY_CONST_FLOAT(ConstantFloat::Create(lhs.value() / rhs.value()));
 
   return this->visitBinaryOp(op);
 }
 template <bool M>
-OpRef OperationSimplifier<M>::visitFRem(const BinaryOp& op) {
+OpRef OperationSimplifier<M>::visitFRem(BinaryOp& op) {
   TRY_CONST_FLOAT(
       ConstantFloat::Create(llvm::APFloat(lhs.value()).remainder(rhs.value())));
 
@@ -375,7 +375,7 @@ OpRef OperationSimplifier<M>::visitFRem(const BinaryOp& op) {
 }
 
 template <bool M>
-OpRef OperationSimplifier<M>::visitFIsNaN(const UnaryOp& op) {
+OpRef OperationSimplifier<M>::visitFIsNaN(UnaryOp& op) {
   if (const auto* val = llvm::dyn_cast<ConstantFloat>(op.operand().get())) {
     const llvm::APFloat& apf = val->value();
     return ConstantInt::Create(apf.isNaN());
@@ -384,7 +384,7 @@ OpRef OperationSimplifier<M>::visitFIsNaN(const UnaryOp& op) {
   return this->visitUnaryOp(op);
 }
 template <bool M>
-OpRef OperationSimplifier<M>::visitNot(const UnaryOp& op) {
+OpRef OperationSimplifier<M>::visitNot(UnaryOp& op) {
   if (const auto* val = llvm::dyn_cast<ConstantInt>(op.operand().get()))
     return ConstantInt::Create(~val->value());
 
@@ -395,7 +395,7 @@ OpRef OperationSimplifier<M>::visitNot(const UnaryOp& op) {
   return this->visitUnaryOp(op);
 }
 template <bool M>
-OpRef OperationSimplifier<M>::visitTrunc(const UnaryOp& op) {
+OpRef OperationSimplifier<M>::visitTrunc(UnaryOp& op) {
   if (const auto* val = llvm::dyn_cast<ConstantInt>(op.operand().get()))
     return ConstantInt::Create(val->value().trunc(op.type().bitwidth()));
 
@@ -405,7 +405,7 @@ OpRef OperationSimplifier<M>::visitTrunc(const UnaryOp& op) {
   return this->visitUnaryOp(op);
 }
 template <bool M>
-OpRef OperationSimplifier<M>::visitZExt(const UnaryOp& op) {
+OpRef OperationSimplifier<M>::visitZExt(UnaryOp& op) {
   namespace m = matching;
 
   if (const auto* val = llvm::dyn_cast<ConstantInt>(op.operand().get()))
@@ -431,7 +431,7 @@ OpRef OperationSimplifier<M>::visitZExt(const UnaryOp& op) {
   return this->visitUnaryOp(op);
 }
 template <bool M>
-OpRef OperationSimplifier<M>::visitSExt(const UnaryOp& op) {
+OpRef OperationSimplifier<M>::visitSExt(UnaryOp& op) {
   if (const auto* val = llvm::dyn_cast<ConstantInt>(op.operand().get()))
     return ConstantInt::Create(val->value().sext(op.type().bitwidth()));
 
@@ -441,7 +441,7 @@ OpRef OperationSimplifier<M>::visitSExt(const UnaryOp& op) {
   return this->visitUnaryOp(op);
 }
 template <bool M>
-OpRef OperationSimplifier<M>::visitBitcast(const UnaryOp& op) {
+OpRef OperationSimplifier<M>::visitBitcast(UnaryOp& op) {
   {
     OpRef value;
     if (matches(op.operand(), matching::Bitcast(value)) &&
@@ -454,7 +454,7 @@ OpRef OperationSimplifier<M>::visitBitcast(const UnaryOp& op) {
 }
 
 template <bool M>
-OpRef OperationSimplifier<M>::visitSelectOp(const SelectOp& op) {
+OpRef OperationSimplifier<M>::visitSelectOp(SelectOp& op) {
   if (const auto* vcond = llvm::dyn_cast<ConstantInt>(op.condition().get()))
     return vcond->value() == 1 ? op.true_value() : op.false_value();
   if (op.true_value() == op.false_value())
@@ -464,7 +464,7 @@ OpRef OperationSimplifier<M>::visitSelectOp(const SelectOp& op) {
 }
 
 template <bool M>
-OpRef OperationSimplifier<M>::visitICmp(const ICmpOp& op) {
+OpRef OperationSimplifier<M>::visitICmp(ICmpOp& op) {
   TRY_CONST_INT(ConstantInt::Create(
       constant_int_compare(op.comparison(), lhs.value(), rhs.value())));
 
@@ -491,7 +491,7 @@ OpRef OperationSimplifier<M>::visitICmp(const ICmpOp& op) {
   return this->visitBinaryOp(op);
 }
 template <bool M>
-OpRef OperationSimplifier<M>::visitFCmp(const FCmpOp& op) {
+OpRef OperationSimplifier<M>::visitFCmp(FCmpOp& op) {
   TRY_CONST_FLOAT(ConstantInt::Create(
       constant_float_compare(op.comparison(), lhs.value(), rhs.value())));
 
@@ -512,7 +512,7 @@ OpRef OperationSimplifier<M>::visitFCmp(const FCmpOp& op) {
 }
 
 template <bool M>
-OpRef OperationSimplifier<M>::visitAllocOp(const AllocOp& op) {
+OpRef OperationSimplifier<M>::visitAllocOp(AllocOp& op) {
   if (const auto* cnst = llvm::dyn_cast<ConstantInt>(op.size().get())) {
     if (cnst->value().getLimitedValue(SIZE_MAX) < SIZE_MAX) {
       return FixedArray::Create(cnst->type(), op.default_value(),
@@ -523,7 +523,7 @@ OpRef OperationSimplifier<M>::visitAllocOp(const AllocOp& op) {
   return this->visitArrayBase(op);
 }
 template <bool M>
-OpRef OperationSimplifier<M>::visitLoadOp(const LoadOp& op) {
+OpRef OperationSimplifier<M>::visitLoadOp(LoadOp& op) {
   const auto* fixedarray = llvm::dyn_cast<FixedArray>(op.data().get());
   const auto* offset_int = llvm::dyn_cast<ConstantInt>(op.offset().get());
 
@@ -551,7 +551,7 @@ OpRef OperationSimplifier<M>::visitLoadOp(const LoadOp& op) {
   return this->visitOperation(op);
 }
 template <bool M>
-OpRef OperationSimplifier<M>::visitStoreOp(const StoreOp& op) {
+OpRef OperationSimplifier<M>::visitStoreOp(StoreOp& op) {
   const auto* offset_cnst = llvm::dyn_cast<ConstantInt>(op.offset().get());
   const auto* fixedarray = llvm::dyn_cast<FixedArray>(op.data().get());
 
@@ -569,11 +569,11 @@ OpRef OperationSimplifier<M>::visitStoreOp(const StoreOp& op) {
 }
 
 template <bool M>
-OpRef OperationSimplifier<M>::visitFixedArray(const FixedArray& op) {
+OpRef OperationSimplifier<M>::visitFixedArray(FixedArray& op) {
   // Note: We don't cache FixedArray instances since the cost of hashing the
   //       whole array after every change causes quadratic blowups on just about
   //       every program that interacts with memory.
-  return std::make_shared<FixedArray>(std::move(const_cast<FixedArray&>(op)));
+  return std::make_shared<FixedArray>(std::move(op));
 }
 
 // Note that these have to be after all the method definitions

--- a/src/IR/OperationSimplifier.cpp
+++ b/src/IR/OperationSimplifier.cpp
@@ -100,13 +100,8 @@ OpRef OperationSimplifier::visit(Operation& op) {
 }
 
 OpRef OperationSimplifier::visitOperation(Operation& op) {
-  if constexpr (move_input) {
-    return OperationCache::default_cache()->cache(
-        std::move(const_cast<Operation&>(op)));
-  } else {
-    (void)op;
-    CAFFEINE_UNREACHABLE();
-  }
+  return OperationCache::default_cache()->cache(
+      std::move(const_cast<Operation&>(op)));
 }
 
 OpRef OperationSimplifier::visitAdd(BinaryOp& op) {

--- a/src/IR/OperationSimplifier.cpp
+++ b/src/IR/OperationSimplifier.cpp
@@ -91,8 +91,7 @@ namespace {
       return constval;                                                         \
   } while (false)
 
-template <bool M>
-OpRef OperationSimplifier<M>::visit(Operation& op) {
+OpRef OperationSimplifier::visit(Operation& op) {
 #ifdef CAFFEINE_ENABLE_IMPLICIT_CONSTANT_FOLDING
   return BaseType::visit(op);
 #else
@@ -100,8 +99,7 @@ OpRef OperationSimplifier<M>::visit(Operation& op) {
 #endif
 }
 
-template <bool M>
-OpRef OperationSimplifier<M>::visitOperation(Operation& op) {
+OpRef OperationSimplifier::visitOperation(Operation& op) {
   if constexpr (move_input) {
     return OperationCache::default_cache()->cache(
         std::move(const_cast<Operation&>(op)));
@@ -111,8 +109,7 @@ OpRef OperationSimplifier<M>::visitOperation(Operation& op) {
   }
 }
 
-template <bool M>
-OpRef OperationSimplifier<M>::visitAdd(BinaryOp& op) {
+OpRef OperationSimplifier::visitAdd(BinaryOp& op) {
   if (op.lhs()->is<Undef>() || op.rhs()->is<Undef>())
     return Undef::Create(op.type());
 
@@ -125,8 +122,7 @@ OpRef OperationSimplifier<M>::visitAdd(BinaryOp& op) {
 
   return this->visitBinaryOp(op);
 }
-template <bool M>
-OpRef OperationSimplifier<M>::visitSub(BinaryOp& op) {
+OpRef OperationSimplifier::visitSub(BinaryOp& op) {
   if (op.lhs()->is<Undef>() || op.rhs()->is<Undef>())
     return Undef::Create(op.type());
 
@@ -140,8 +136,7 @@ OpRef OperationSimplifier<M>::visitSub(BinaryOp& op) {
 
   return this->visitBinaryOp(op);
 }
-template <bool M>
-OpRef OperationSimplifier<M>::visitMul(BinaryOp& op) {
+OpRef OperationSimplifier::visitMul(BinaryOp& op) {
   if (is_constant_int(op.lhs(), 0))
     return op.lhs();
   if (is_constant_int(op.rhs(), 0))
@@ -152,8 +147,7 @@ OpRef OperationSimplifier<M>::visitMul(BinaryOp& op) {
   return this->visitBinaryOp(op);
 }
 
-template <bool M>
-OpRef OperationSimplifier<M>::visitUDiv(BinaryOp& op) {
+OpRef OperationSimplifier::visitUDiv(BinaryOp& op) {
   if (is_constant_int(op.lhs(), 0) || is_constant_int(*op.rhs(), 1))
     return op.lhs();
 
@@ -164,8 +158,7 @@ OpRef OperationSimplifier<M>::visitUDiv(BinaryOp& op) {
 
   return this->visitBinaryOp(op);
 }
-template <bool M>
-OpRef OperationSimplifier<M>::visitSDiv(BinaryOp& op) {
+OpRef OperationSimplifier::visitSDiv(BinaryOp& op) {
   if (is_constant_int(op.lhs(), 0))
     return op.lhs();
   if (is_constant_int(op.rhs(), 1) && op.type().bitwidth() > 1)
@@ -178,8 +171,7 @@ OpRef OperationSimplifier<M>::visitSDiv(BinaryOp& op) {
 
   return this->visitBinaryOp(op);
 }
-template <bool M>
-OpRef OperationSimplifier<M>::visitURem(BinaryOp& op) {
+OpRef OperationSimplifier::visitURem(BinaryOp& op) {
   if (is_constant_int(op.lhs(), 0))
     return op.lhs();
   if (is_constant_int(op.rhs(), 1))
@@ -192,8 +184,7 @@ OpRef OperationSimplifier<M>::visitURem(BinaryOp& op) {
 
   return this->visitBinaryOp(op);
 }
-template <bool M>
-OpRef OperationSimplifier<M>::visitSRem(BinaryOp& op) {
+OpRef OperationSimplifier::visitSRem(BinaryOp& op) {
   if (is_constant_int(op.lhs(), 0))
     return op.lhs();
   if (is_constant_int(op.rhs(), 1) && op.type().bitwidth() > 1)
@@ -207,8 +198,7 @@ OpRef OperationSimplifier<M>::visitSRem(BinaryOp& op) {
   return this->visitBinaryOp(op);
 }
 
-template <bool M>
-OpRef OperationSimplifier<M>::visitAnd(BinaryOp& op) {
+OpRef OperationSimplifier::visitAnd(BinaryOp& op) {
   namespace m = matching;
 
   if (is_constant_int(op.lhs(), 0))
@@ -255,8 +245,7 @@ OpRef OperationSimplifier<M>::visitAnd(BinaryOp& op) {
 
   return this->visitBinaryOp(op);
 }
-template <bool M>
-OpRef OperationSimplifier<M>::visitOr(BinaryOp& op) {
+OpRef OperationSimplifier::visitOr(BinaryOp& op) {
   namespace m = matching;
 
   if (is_constant_int(op.lhs(), 0))
@@ -282,8 +271,7 @@ OpRef OperationSimplifier<M>::visitOr(BinaryOp& op) {
 
   return this->visitBinaryOp(op);
 }
-template <bool M>
-OpRef OperationSimplifier<M>::visitXor(BinaryOp& op) {
+OpRef OperationSimplifier::visitXor(BinaryOp& op) {
   if (op.lhs()->is<Undef>() || op.rhs()->is<Undef>())
     return Undef::Create(op.type());
 
@@ -296,8 +284,7 @@ OpRef OperationSimplifier<M>::visitXor(BinaryOp& op) {
 
   return this->visitBinaryOp(op);
 }
-template <bool M>
-OpRef OperationSimplifier<M>::visitShl(BinaryOp& op) {
+OpRef OperationSimplifier::visitShl(BinaryOp& op) {
   namespace m = matching;
 
   if (is_constant_int(op.lhs(), 0) || is_constant_int(op.rhs(), 0))
@@ -323,8 +310,7 @@ OpRef OperationSimplifier<M>::visitShl(BinaryOp& op) {
 
   return this->visitBinaryOp(op);
 }
-template <bool M>
-OpRef OperationSimplifier<M>::visitLShr(BinaryOp& op) {
+OpRef OperationSimplifier::visitLShr(BinaryOp& op) {
   if (is_constant_int(op.lhs(), 0) || is_constant_int(op.rhs(), 0))
     return op.lhs();
 
@@ -332,8 +318,7 @@ OpRef OperationSimplifier<M>::visitLShr(BinaryOp& op) {
 
   return this->visitBinaryOp(op);
 }
-template <bool M>
-OpRef OperationSimplifier<M>::visitAShr(BinaryOp& op) {
+OpRef OperationSimplifier::visitAShr(BinaryOp& op) {
   if (is_constant_int(op.lhs(), 0) || is_constant_int(op.rhs(), 0))
     return op.lhs();
 
@@ -342,40 +327,34 @@ OpRef OperationSimplifier<M>::visitAShr(BinaryOp& op) {
   return this->visitBinaryOp(op);
 }
 
-template <bool M>
-OpRef OperationSimplifier<M>::visitFAdd(BinaryOp& op) {
+OpRef OperationSimplifier::visitFAdd(BinaryOp& op) {
   TRY_CONST_FLOAT(ConstantFloat::Create(lhs.value() + rhs.value()));
 
   return this->visitBinaryOp(op);
 }
-template <bool M>
-OpRef OperationSimplifier<M>::visitFSub(BinaryOp& op) {
+OpRef OperationSimplifier::visitFSub(BinaryOp& op) {
   TRY_CONST_FLOAT(ConstantFloat::Create(lhs.value() - rhs.value()));
 
   return this->visitBinaryOp(op);
 }
-template <bool M>
-OpRef OperationSimplifier<M>::visitFMul(BinaryOp& op) {
+OpRef OperationSimplifier::visitFMul(BinaryOp& op) {
   TRY_CONST_FLOAT(ConstantFloat::Create(lhs.value() * rhs.value()));
 
   return this->visitBinaryOp(op);
 }
-template <bool M>
-OpRef OperationSimplifier<M>::visitFDiv(BinaryOp& op) {
+OpRef OperationSimplifier::visitFDiv(BinaryOp& op) {
   TRY_CONST_FLOAT(ConstantFloat::Create(lhs.value() / rhs.value()));
 
   return this->visitBinaryOp(op);
 }
-template <bool M>
-OpRef OperationSimplifier<M>::visitFRem(BinaryOp& op) {
+OpRef OperationSimplifier::visitFRem(BinaryOp& op) {
   TRY_CONST_FLOAT(
       ConstantFloat::Create(llvm::APFloat(lhs.value()).remainder(rhs.value())));
 
   return this->visitBinaryOp(op);
 }
 
-template <bool M>
-OpRef OperationSimplifier<M>::visitFIsNaN(UnaryOp& op) {
+OpRef OperationSimplifier::visitFIsNaN(UnaryOp& op) {
   if (const auto* val = llvm::dyn_cast<ConstantFloat>(op.operand().get())) {
     const llvm::APFloat& apf = val->value();
     return ConstantInt::Create(apf.isNaN());
@@ -383,8 +362,7 @@ OpRef OperationSimplifier<M>::visitFIsNaN(UnaryOp& op) {
 
   return this->visitUnaryOp(op);
 }
-template <bool M>
-OpRef OperationSimplifier<M>::visitNot(UnaryOp& op) {
+OpRef OperationSimplifier::visitNot(UnaryOp& op) {
   if (const auto* val = llvm::dyn_cast<ConstantInt>(op.operand().get()))
     return ConstantInt::Create(~val->value());
 
@@ -394,8 +372,7 @@ OpRef OperationSimplifier<M>::visitNot(UnaryOp& op) {
 
   return this->visitUnaryOp(op);
 }
-template <bool M>
-OpRef OperationSimplifier<M>::visitTrunc(UnaryOp& op) {
+OpRef OperationSimplifier::visitTrunc(UnaryOp& op) {
   if (const auto* val = llvm::dyn_cast<ConstantInt>(op.operand().get()))
     return ConstantInt::Create(val->value().trunc(op.type().bitwidth()));
 
@@ -404,8 +381,7 @@ OpRef OperationSimplifier<M>::visitTrunc(UnaryOp& op) {
 
   return this->visitUnaryOp(op);
 }
-template <bool M>
-OpRef OperationSimplifier<M>::visitZExt(UnaryOp& op) {
+OpRef OperationSimplifier::visitZExt(UnaryOp& op) {
   namespace m = matching;
 
   if (const auto* val = llvm::dyn_cast<ConstantInt>(op.operand().get()))
@@ -430,8 +406,7 @@ OpRef OperationSimplifier<M>::visitZExt(UnaryOp& op) {
 
   return this->visitUnaryOp(op);
 }
-template <bool M>
-OpRef OperationSimplifier<M>::visitSExt(UnaryOp& op) {
+OpRef OperationSimplifier::visitSExt(UnaryOp& op) {
   if (const auto* val = llvm::dyn_cast<ConstantInt>(op.operand().get()))
     return ConstantInt::Create(val->value().sext(op.type().bitwidth()));
 
@@ -440,8 +415,7 @@ OpRef OperationSimplifier<M>::visitSExt(UnaryOp& op) {
 
   return this->visitUnaryOp(op);
 }
-template <bool M>
-OpRef OperationSimplifier<M>::visitBitcast(UnaryOp& op) {
+OpRef OperationSimplifier::visitBitcast(UnaryOp& op) {
   {
     OpRef value;
     if (matches(op.operand(), matching::Bitcast(value)) &&
@@ -453,8 +427,7 @@ OpRef OperationSimplifier<M>::visitBitcast(UnaryOp& op) {
   return BaseType::visitBitcast(op);
 }
 
-template <bool M>
-OpRef OperationSimplifier<M>::visitSelectOp(SelectOp& op) {
+OpRef OperationSimplifier::visitSelectOp(SelectOp& op) {
   if (const auto* vcond = llvm::dyn_cast<ConstantInt>(op.condition().get()))
     return vcond->value() == 1 ? op.true_value() : op.false_value();
   if (op.true_value() == op.false_value())
@@ -463,8 +436,7 @@ OpRef OperationSimplifier<M>::visitSelectOp(SelectOp& op) {
   return this->visitOperation(op);
 }
 
-template <bool M>
-OpRef OperationSimplifier<M>::visitICmp(ICmpOp& op) {
+OpRef OperationSimplifier::visitICmp(ICmpOp& op) {
   TRY_CONST_INT(ConstantInt::Create(
       constant_int_compare(op.comparison(), lhs.value(), rhs.value())));
 
@@ -490,8 +462,7 @@ OpRef OperationSimplifier<M>::visitICmp(ICmpOp& op) {
 
   return this->visitBinaryOp(op);
 }
-template <bool M>
-OpRef OperationSimplifier<M>::visitFCmp(FCmpOp& op) {
+OpRef OperationSimplifier::visitFCmp(FCmpOp& op) {
   TRY_CONST_FLOAT(ConstantInt::Create(
       constant_float_compare(op.comparison(), lhs.value(), rhs.value())));
 
@@ -511,8 +482,7 @@ OpRef OperationSimplifier<M>::visitFCmp(FCmpOp& op) {
   return this->visitBinaryOp(op);
 }
 
-template <bool M>
-OpRef OperationSimplifier<M>::visitAllocOp(AllocOp& op) {
+OpRef OperationSimplifier::visitAllocOp(AllocOp& op) {
   if (const auto* cnst = llvm::dyn_cast<ConstantInt>(op.size().get())) {
     if (cnst->value().getLimitedValue(SIZE_MAX) < SIZE_MAX) {
       return FixedArray::Create(cnst->type(), op.default_value(),
@@ -522,8 +492,7 @@ OpRef OperationSimplifier<M>::visitAllocOp(AllocOp& op) {
 
   return this->visitArrayBase(op);
 }
-template <bool M>
-OpRef OperationSimplifier<M>::visitLoadOp(LoadOp& op) {
+OpRef OperationSimplifier::visitLoadOp(LoadOp& op) {
   const auto* fixedarray = llvm::dyn_cast<FixedArray>(op.data().get());
   const auto* offset_int = llvm::dyn_cast<ConstantInt>(op.offset().get());
 
@@ -550,8 +519,7 @@ OpRef OperationSimplifier<M>::visitLoadOp(LoadOp& op) {
 
   return this->visitOperation(op);
 }
-template <bool M>
-OpRef OperationSimplifier<M>::visitStoreOp(StoreOp& op) {
+OpRef OperationSimplifier::visitStoreOp(StoreOp& op) {
   const auto* offset_cnst = llvm::dyn_cast<ConstantInt>(op.offset().get());
   const auto* fixedarray = llvm::dyn_cast<FixedArray>(op.data().get());
 
@@ -568,16 +536,11 @@ OpRef OperationSimplifier<M>::visitStoreOp(StoreOp& op) {
   return this->visitArrayBase(op);
 }
 
-template <bool M>
-OpRef OperationSimplifier<M>::visitFixedArray(FixedArray& op) {
+OpRef OperationSimplifier::visitFixedArray(FixedArray& op) {
   // Note: We don't cache FixedArray instances since the cost of hashing the
   //       whole array after every change causes quadratic blowups on just about
   //       every program that interacts with memory.
   return std::make_shared<FixedArray>(std::move(op));
 }
-
-// Note that these have to be after all the method definitions
-template class OperationSimplifier<true>;
-template class OperationSimplifier<false>;
 
 } // namespace caffeine


### PR DESCRIPTION
With the changes from #582 it's no longer necessary for `OperationSimplifier` to support both copies and moves. This PR converts it to only do moves and only take non-const `Operation` references.

/stack #582 