### PR TITLE
Clear `Operation` fields upon move-out

### DIFF
--- a/include/caffeine/IR/OperationBase.h
+++ b/include/caffeine/IR/OperationBase.h
@@ -297,6 +297,9 @@ protected:
 public:
   // Utility during debugging - should never actually be called by the program.
   void DebugPrint() const;
+
+private:
+  void reset();
 };
 
 std::ostream& operator<<(std::ostream& os, const Operation& op);

--- a/src/IR/Operation.cpp
+++ b/src/IR/Operation.cpp
@@ -71,6 +71,7 @@ Operation::Operation(Operation&& op) noexcept
     : std::enable_shared_from_this<Operation>(), opcode_(op.opcode_),
       type_(op.type_), inner_(std::move(op.inner_)) {
   copy_vtable(op);
+  op.reset();
 }
 
 Operation& Operation::operator=(Operation&& op) noexcept {
@@ -79,8 +80,15 @@ Operation& Operation::operator=(Operation&& op) noexcept {
   opcode_ = op.opcode_;
 
   copy_vtable(op);
+  op.reset();
 
   return *this;
+}
+
+void Operation::reset() {
+  opcode_ = Invalid;
+  type_ = Type::void_ty();
+  inner_ = std::monostate{};
 }
 
 bool Operation::operator==(const Operation& op) const {


### PR DESCRIPTION
Right now, `Operation`'s move constructor is basically a copy constructor. This has the potential to hide a number of bugs in how `Operation` instances are used. Currently, there are no issues that this exposes but I'm including it as a safeguard for when I start mucking around in the `Operation` internals.

/stack #583 