### PR TITLE
Introduce alternative data representation for operation data

### DIFF
--- a/include/caffeine/IR/OperationBase.h
+++ b/include/caffeine/IR/OperationBase.h
@@ -203,9 +203,15 @@ protected:
   Type type_;
   Inner inner_;
 
+  std::unique_ptr<OperationData> data_;
+  llvm::SmallVector<OpRef, 4> operands_;
+
   friend llvm::hash_code hash_value(const Operation& op);
 
 protected:
+  Operation(
+    std::unique_ptr<OperationData>&& data,
+    std::initializer_list<OpRef> operands = {});
   Operation(Opcode op, Type t, const Inner& inner);
   Operation(Opcode op, Type t, Inner&& inner);
 

--- a/include/caffeine/IR/OperationBase.h
+++ b/include/caffeine/IR/OperationBase.h
@@ -309,10 +309,6 @@ private:
 };
 
 class OperationData {
-private:
-  Type type_;
-  uint16_t opcode_;
-
 public:
   using Opcode = Operation::Opcode;
 
@@ -353,6 +349,23 @@ public:
   static bool classof(const Operation*) {
     return true;
   }
+
+  OperationData(OperationData&&) = delete;
+  OperationData(const OperationData&) = delete;
+  OperationData& operator=(OperationData&&) = delete;
+  OperationData& operator=(const OperationData&) = delete;
+
+  friend llvm::hash_code hash_value(const OperationData& op);
+
+protected:
+  // Hash any data stored in the derived members of this class.
+  virtual llvm::hash_code hash() const {
+    return 0;
+  }
+
+private:
+  Type type_;
+  Opcode opcode_;
 };
 
 /**
@@ -372,6 +385,8 @@ public:
            op->opcode() == Opcode::ConstantArray;
   }
 
+  llvm::hash_code hash() const override;
+
 private:
   Symbol symbol_;
 };
@@ -388,6 +403,8 @@ public:
   static bool classof(const OperationData* op) {
     return op->opcode() == Opcode::ConstantInt;
   }
+
+  llvm::hash_code hash() const override;
 
 private:
   llvm::APInt value_;
@@ -406,6 +423,8 @@ public:
     return op->opcode() == Opcode::ConstantFloat;
   }
 
+  llvm::hash_code hash() const override;
+
 private:
   llvm::APFloat value_;
 };
@@ -421,6 +440,8 @@ public:
   static bool classof(const OperationData* op) {
     return op->opcode() == Opcode::FunctionObject;
   }
+
+  llvm::hash_code hash() const override;
 
 private:
   llvm::Function* func_;

--- a/include/caffeine/IR/OperationBase.h
+++ b/include/caffeine/IR/OperationBase.h
@@ -209,9 +209,8 @@ protected:
   friend llvm::hash_code hash_value(const Operation& op);
 
 protected:
-  Operation(
-    std::unique_ptr<OperationData>&& data,
-    std::initializer_list<OpRef> operands = {});
+  Operation(std::unique_ptr<OperationData>&& data,
+            std::initializer_list<OpRef> operands = {});
   Operation(Opcode op, Type t, const Inner& inner);
   Operation(Opcode op, Type t, Inner&& inner);
 

--- a/src/IR/Operation.cpp
+++ b/src/IR/Operation.cpp
@@ -26,6 +26,19 @@ namespace caffeine {
 
 Operation::Operation() : opcode_(Invalid), type_(Type::void_ty()) {}
 
+Operation::Operation(std::unique_ptr<OperationData>&& data,
+                     std::initializer_list<OpRef> operands)
+    : opcode_(data->opcode()), type_(data->type()), data_(std::move(data)),
+      operands_(operands) {
+  size_t nargs = detail::opcode_nargs(opcode());
+
+  if (nargs != 4) {
+    CAFFEINE_ASSERT(nargs == operands.size(),
+                    fmt::format("invalid number of arguments: {} != {}", nargs,
+                                operands.size()));
+  }
+}
+
 Operation::Operation(Opcode op, Type t, const Inner& inner)
     : opcode_(static_cast<uint16_t>(op)), type_(t), inner_(inner) {}
 Operation::Operation(Opcode op, Type t, Inner&& inner)

--- a/src/IR/OperationBase.cpp
+++ b/src/IR/OperationBase.cpp
@@ -1,5 +1,6 @@
 #include "caffeine/IR/OperationBase.h"
 #include <fmt/format.h>
+#include <llvm/IR/Function.h>
 
 namespace caffeine {
 
@@ -39,6 +40,7 @@ ConstantFloatData::ConstantFloatData(llvm::APFloat&& val)
       value_(std::move(val)) {}
 
 FunctionObjectData::FunctionObjectData(llvm::Function* func)
-    : OperationData(Opcode::FunctionObject, Type::function_ty()), func_(func) {}
+    : OperationData(Opcode::FunctionObject, Type::from_llvm(func->getType())),
+      func_(func) {}
 
 } // namespace caffeine

--- a/src/IR/OperationBase.cpp
+++ b/src/IR/OperationBase.cpp
@@ -1,13 +1,11 @@
 #include "caffeine/IR/OperationBase.h"
-#include <fmt/format.h>
 #include <llvm/IR/Function.h>
 
 namespace caffeine {
 
 OperationData::OperationData()
     : type_(Type::void_ty()), opcode_(Opcode::Invalid) {}
-OperationData::OperationData(Opcode op, Type t)
-    : type_(t), opcode_(static_cast<uint16_t>(op)) {}
+OperationData::OperationData(Opcode op, Type t) : type_(t), opcode_(op) {}
 
 std::string_view OperationData::opcode_name() const {
   return opcode_name(opcode());
@@ -42,5 +40,27 @@ ConstantFloatData::ConstantFloatData(llvm::APFloat&& val)
 FunctionObjectData::FunctionObjectData(llvm::Function* func)
     : OperationData(Opcode::FunctionObject, Type::from_llvm(func->getType())),
       func_(func) {}
+
+llvm::hash_code hash_value(const OperationData& op) {
+  return llvm::hash_combine(op.hash(), op.type(), op.opcode());
+}
+
+using llvm::hash_value;
+
+llvm::hash_code ConstantData::hash() const {
+  return hash_value(symbol_);
+}
+
+llvm::hash_code ConstantIntData::hash() const {
+  return hash_value(value_);
+}
+
+llvm::hash_code ConstantFloatData::hash() const {
+  return hash_value(value_);
+}
+
+llvm::hash_code FunctionObjectData::hash() const {
+  return hash_value(func_);
+}
 
 } // namespace caffeine

--- a/src/IR/OperationBase.cpp
+++ b/src/IR/OperationBase.cpp
@@ -1,0 +1,44 @@
+#include "caffeine/IR/OperationBase.h"
+#include <fmt/format.h>
+
+namespace caffeine {
+
+OperationData::OperationData()
+    : type_(Type::void_ty()), opcode_(Opcode::Invalid) {}
+OperationData::OperationData(Opcode op, Type t)
+    : type_(t), opcode_(static_cast<uint16_t>(op)) {}
+
+std::string_view OperationData::opcode_name() const {
+  return opcode_name(opcode());
+}
+std::string_view OperationData::opcode_name(Opcode op) {
+  return Operation::opcode_name(op);
+}
+
+ConstantData::ConstantData(Type t, const Symbol& symbol)
+    : OperationData(([&] {
+                      if (t.is_array())
+                        return Opcode::ConstantArray;
+                      if (symbol.is_named())
+                        return Opcode::ConstantNamed;
+                      return Opcode::ConstantNumbered;
+                    })(),
+                    t),
+      symbol_(symbol) {}
+
+ConstantIntData::ConstantIntData(const llvm::APInt& val)
+    : OperationData(Opcode::ConstantInt, Type::type_of(val)), value_(val) {}
+ConstantIntData::ConstantIntData(llvm::APInt&& val)
+    : OperationData(Opcode::ConstantInt, Type::type_of(val)),
+      value_(std::move(val)) {}
+
+ConstantFloatData::ConstantFloatData(const llvm::APFloat& val)
+    : OperationData(Opcode::ConstantFloat, Type::type_of(val)), value_(val) {}
+ConstantFloatData::ConstantFloatData(llvm::APFloat&& val)
+    : OperationData(Opcode::ConstantFloat, Type::type_of(val)),
+      value_(std::move(val)) {}
+
+FunctionObjectData::FunctionObjectData(llvm::Function* func)
+    : OperationData(Opcode::FunctionObject, Type::function_ty()), func_(func) {}
+
+} // namespace caffeine

--- a/src/IR/OperationBase.cpp
+++ b/src/IR/OperationBase.cpp
@@ -1,4 +1,5 @@
 #include "caffeine/IR/OperationBase.h"
+#include "caffeine/IR/Operation.h"
 #include <llvm/IR/Function.h>
 
 namespace caffeine {


### PR DESCRIPTION
This PR introduces a new class hierarchy for storing the non-operand data of an `Operation`. It's not currently used anywhere but follow-on commits will use it as I convert more operation types to use `OperationData` to store non-operand data.

/stack #584 