### PR TITLE
Convert `Constant`, `ConstantInt`, `ConstantFloat`, and `FunctionObject` to use `OperationData`

### DIFF
--- a/include/caffeine/IR/Operation.inl
+++ b/include/caffeine/IR/Operation.inl
@@ -210,7 +210,7 @@ inline bool Symbol::operator!=(const Symbol& symbol) const {
  * Constant                                        *
  ***************************************************/
 inline const Symbol& Constant::symbol() const {
-  return std::get<ConstantData>(inner_).first;
+  return llvm::cast<caffeine::ConstantData>(data_.get())->symbol();
 }
 
 inline InternedString Constant::name() const {

--- a/include/caffeine/IR/Operation.inl
+++ b/include/caffeine/IR/Operation.inl
@@ -233,7 +233,7 @@ inline bool Constant::is_named() const {
  * ConstantInt                                     *
  ***************************************************/
 inline const llvm::APInt& ConstantInt::value() const {
-  return std::get<llvm::APInt>(inner_);
+  return llvm::cast<ConstantIntData>(data_.get())->value();
 }
 
 /***************************************************

--- a/include/caffeine/IR/Operation.inl
+++ b/include/caffeine/IR/Operation.inl
@@ -240,7 +240,7 @@ inline const llvm::APInt& ConstantInt::value() const {
  * ConstantFloat                                   *
  ***************************************************/
 inline const llvm::APFloat& ConstantFloat::value() const {
-  return std::get<llvm::APFloat>(inner_);
+  return llvm::cast<ConstantFloatData>(data_.get())->value();
 }
 
 /***************************************************

--- a/include/caffeine/IR/OperationBase.h
+++ b/include/caffeine/IR/OperationBase.h
@@ -345,6 +345,9 @@ public:
     return detail::opcode_aux(opcode());
   }
 
+  bool operator==(const OperationData& op) const;
+  bool operator!=(const OperationData& op) const;
+
   static bool classof(const Operation*) {
     return true;
   }

--- a/src/IR/Operation.cpp
+++ b/src/IR/Operation.cpp
@@ -312,10 +312,9 @@ Operation::Opcode Constant::op_for_symbol(const Symbol& symbol) {
  * ConstantInt                                     *
  ***************************************************/
 ConstantInt::ConstantInt(const llvm::APInt& iconst)
-    : Operation(Opcode::ConstantInt, Type::type_of(iconst), iconst) {}
+    : Operation(std::make_unique<ConstantIntData>(iconst)) {}
 ConstantInt::ConstantInt(llvm::APInt&& iconst)
-    : Operation(Opcode::ConstantInt, Type::type_of(iconst), std::move(iconst)) {
-}
+    : Operation(std::make_unique<ConstantIntData>(std::move(iconst))) {}
 
 Value ConstantInt::as_value() const {
   return Value(value());

--- a/src/IR/Operation.cpp
+++ b/src/IR/Operation.cpp
@@ -112,6 +112,16 @@ void Operation::reset() {
 bool Operation::operator==(const Operation& op) const {
   if (opcode_ != op.opcode_ || type_ != op.type_)
     return false;
+  if (operands_ != op.operands_)
+    return false;
+
+  if (data_ != op.data_) {
+    if ((bool)data_ != (bool)op.data_)
+      return false;
+
+    if (*data_ != *op.data_)
+      return false;
+  }
 
   return std::visit(
       [](const auto& a, const auto& b) {

--- a/src/IR/Operation.cpp
+++ b/src/IR/Operation.cpp
@@ -871,11 +871,10 @@ OpRef FixedArray::Create(Type index_ty, const OpRef& value, size_t size) {
  * FunctionObject                                  *
  ***************************************************/
 FunctionObject::FunctionObject(llvm::Function* function)
-    : Operation(Operation::FunctionObject, Type::from_llvm(function->getType()),
-                function) {}
+    : Operation(std::make_unique<FunctionObjectData>(function)) {}
 
 llvm::Function* FunctionObject::function() const {
-  return std::get<llvm::Function*>(inner_);
+  return llvm::cast<FunctionObjectData>(data_.get())->function();
 }
 
 OpRef FunctionObject::Create(llvm::Function* function) {

--- a/src/IR/Operation.cpp
+++ b/src/IR/Operation.cpp
@@ -341,10 +341,9 @@ OpRef ConstantInt::CreateZero(unsigned bitwidth) {
  * ConstantFloat                                   *
  ***************************************************/
 ConstantFloat::ConstantFloat(const llvm::APFloat& fconst)
-    : Operation(Operation::ConstantFloat, Type::type_of(fconst), fconst) {}
+    : Operation(std::make_unique<ConstantFloatData>(fconst)) {}
 ConstantFloat::ConstantFloat(llvm::APFloat&& fconst)
-    : Operation(Operation::ConstantFloat, Type::type_of(fconst),
-                std::move(fconst)) {}
+    : Operation(std::make_unique<ConstantFloatData>(std::move(fconst))) {}
 
 OpRef ConstantFloat::Create(const llvm::APFloat& fconst) {
   return Create(llvm::APFloat(fconst));

--- a/src/IR/Operation.cpp
+++ b/src/IR/Operation.cpp
@@ -290,10 +290,10 @@ std::ostream& operator<<(std::ostream& os, const Symbol& symbol) {
  * Constant                                        *
  ***************************************************/
 Constant::Constant(Type t, const Symbol& symbol)
-    : Operation(op_for_symbol(symbol), t, ConstantData(symbol, nullptr)) {}
+    : Operation(std::make_unique<caffeine::ConstantData>(t, symbol)) {}
 Constant::Constant(Type t, Symbol&& symbol)
-    : Operation(op_for_symbol(symbol), t,
-                ConstantData(std::move(symbol), nullptr)) {}
+    : Operation(
+          std::make_unique<caffeine::ConstantData>(t, std::move(symbol))) {}
 
 OpRef Constant::Create(Type t, const Symbol& symbol) {
   return Constant::Create(t, Symbol(symbol));

--- a/src/IR/OperationBase.cpp
+++ b/src/IR/OperationBase.cpp
@@ -15,6 +15,24 @@ std::string_view OperationData::opcode_name(Opcode op) {
   return Operation::opcode_name(op);
 }
 
+bool OperationData::operator==(const OperationData& op) const {
+  if (type_ != op.type_ || opcode_ != op.opcode_)
+    return false;
+
+  if (auto data = llvm::dyn_cast<ConstantData>(this))
+    return data->symbol() == llvm::cast<ConstantData>(op).symbol();
+  if (auto data = llvm::dyn_cast<ConstantIntData>(this))
+    return data->value() == llvm::cast<ConstantIntData>(op).value();
+  if (auto data = llvm::dyn_cast<ConstantFloatData>(this))
+    return data->value() == llvm::cast<ConstantFloatData>(op).value();
+  if (auto data = llvm::dyn_cast<FunctionObjectData>(this))
+    return data->function() == llvm::cast<FunctionObjectData>(op).function();
+  return true;
+}
+bool OperationData::operator!=(const OperationData& op) const {
+  return !(*this == op);
+}
+
 ConstantData::ConstantData(Type t, const Symbol& symbol)
     : OperationData(([&] {
                       if (t.is_array())

--- a/src/IR/OperationBase.cpp
+++ b/src/IR/OperationBase.cpp
@@ -1,5 +1,6 @@
 #include "caffeine/IR/OperationBase.h"
 #include "caffeine/IR/Operation.h"
+#include <boost/config.hpp>
 #include <llvm/IR/Function.h>
 
 namespace caffeine {
@@ -28,10 +29,13 @@ bool OperationData::operator==(const OperationData& op) const {
   if (auto data = llvm::dyn_cast<FunctionObjectData>(this))
     return data->function() == llvm::cast<FunctionObjectData>(op).function();
 
+#if !defined(BOOST_NO_RTTI)
   // If this assertion triggers then you have added a new derived class for
   // OperationData without adding the corresponding equality check to this
   // method.
   CAFFEINE_ASSERT(typeid(*this) == typeid(OperationData));
+#endif
+
   return true;
 }
 bool OperationData::operator!=(const OperationData& op) const {

--- a/src/IR/OperationBase.cpp
+++ b/src/IR/OperationBase.cpp
@@ -27,6 +27,11 @@ bool OperationData::operator==(const OperationData& op) const {
     return data->value() == llvm::cast<ConstantFloatData>(op).value();
   if (auto data = llvm::dyn_cast<FunctionObjectData>(this))
     return data->function() == llvm::cast<FunctionObjectData>(op).function();
+
+  // If this assertion triggers then you have added a new derived class for
+  // OperationData without adding the corresponding equality check to this
+  // method.
+  CAFFEINE_ASSERT(typeid(*this) == typeid(OperationData));
   return true;
 }
 bool OperationData::operator!=(const OperationData& op) const {

--- a/test/unit/IR/Operation.cpp
+++ b/test/unit/IR/Operation.cpp
@@ -166,3 +166,12 @@ TEST(OperationTests, float_load_store_simplify_to_noop) {
   ASSERT_EQ((Operation::Opcode)read->opcode(), Operation::ConstantNumbered);
   ASSERT_EQ(value, read) << read;
 }
+
+TEST(OperationTests, constant_int_has_correct_value) {
+  auto v1 = ConstantInt::Create(llvm::APInt(37, 0));
+  auto v2 = ConstantInt::Create(llvm::APInt(37, 14));
+  uint64_t extracted =
+      llvm::cast<ConstantInt>(v2.get())->value().getLimitedValue();
+
+  ASSERT_EQ(extracted, 14);
+}


### PR DESCRIPTION
This is all the easy ones that don't have any operands. The conversion was fairly straightforward. The one exception is that I needed to fix up the comparison operator for `Operation` so that caching and hashmaps worked as expected.