### PR TITLE
Add testcase for `strlen` and unbust `libc`

### DIFF
--- a/cmake/CaffeineTestUtils.cmake
+++ b/cmake/CaffeineTestUtils.cmake
@@ -107,6 +107,8 @@ function(declare_test TEST_NAME_OUT test EXPECTED)
   llvm_link_libraries     ("${test_target}" PRIVATE caffeine-builtins)
   if (CAFFEINE_ENABLE_LIBC AND "${test_ext}" STREQUAL ".cpp")
     llvm_link_libraries     ("${test_target}" PRIVATE libcxx)
+  elseif (CAFFEINE_ENABLE_LIBC)
+    llvm_link_libraries     ("${test_target}" PRIVATE libc)
   endif()
   llvm_compile_options    ("${test_target}" PRIVATE -O3)
 

--- a/include/caffeine/Interpreter/ExprEval.h
+++ b/include/caffeine/Interpreter/ExprEval.h
@@ -84,7 +84,8 @@ public:
   LLVMValue visitFunction(llvm::Function& func);
 
   // Extras
-  void visitGlobalData(llvm::Constant& cnst, Allocation& alloc, unsigned AS);
+  void visitGlobalData(llvm::Constant& cnst, Allocation& alloc, unsigned AS,
+                       AllocationPermissions perms);
   LLVMValue visitConstantExpr(llvm::ConstantExpr& expr);
 
   /*********************************************

--- a/include/caffeine/Memory/MemHeap.h
+++ b/include/caffeine/Memory/MemHeap.h
@@ -9,6 +9,7 @@
 #include <llvm/ADT/APInt.h>
 #include <llvm/ADT/DenseMap.h>
 #include <llvm/IR/DataLayout.h>
+#include <stdexcept>
 #include <vector>
 
 namespace caffeine {
@@ -44,6 +45,12 @@ enum class AllocationPermissions {
   Write = 0x2,
   Execute = 0x4,
   ReadWrite = Read | Write,
+};
+
+class AllocationException : public std::runtime_error {
+public:
+  AllocationException(const std::string& what_arg)
+      : std::runtime_error(what_arg) {}
 };
 
 /**
@@ -84,6 +91,7 @@ public:
   AllocationKind kind() const;
 
   AllocationPermissions permissions() const;
+  void permissions(AllocationPermissions& new_perm);
 
   const OpRef& data() const;
   OpRef& data();

--- a/include/caffeine/Memory/MemHeap.inl
+++ b/include/caffeine/Memory/MemHeap.inl
@@ -40,6 +40,10 @@ inline AllocationPermissions Allocation::permissions() const {
   return perms_;
 }
 
+inline void Allocation::permissions(AllocationPermissions& p) {
+  perms_ = p;
+}
+
 /***************************************************
  * Pointer                                         *
  ***************************************************/

--- a/libraries/libcxx/CMakeLists.txt
+++ b/libraries/libcxx/CMakeLists.txt
@@ -35,7 +35,7 @@ if(NOT ${STATUS_CODE} EQUAL 0)
 endif()
 
 llvm_library(libcxx ${CMAKE_CURRENT_BINARY_DIR}/libcxx.bc "${CMAKE_CURRENT_BINARY_DIR}/dummy.c")
-llvm_link_libraries(libcxx PRIVATE musl_libc)
+llvm_link_libraries(libcxx PRIVATE libc)
 
 endif()
 endfunction()

--- a/src/Interpreter/ExprEval.cpp
+++ b/src/Interpreter/ExprEval.cpp
@@ -1,4 +1,5 @@
 #include "caffeine/Interpreter/ExprEval.h"
+#include "caffeine/ADT/Guard.h"
 #include "caffeine/Interpreter/Context.h"
 #include "caffeine/Interpreter/InterpreterContext.h"
 #include "caffeine/Memory/MemHeap.h"
@@ -332,22 +333,30 @@ LLVMValue ExprEvaluator::visitGlobalVariable(llvm::GlobalVariable& global) {
   llvm::Type* type = global.getInitializer()->getType();
   OpRef size = ConstantInt::Create(
       llvm::APInt(bitwidth, layout.getTypeAllocSize(type).getFixedSize()));
-  OpRef alloc_data = AllocOp::Create(size, ConstantInt::CreateZero(8));
 
-  auto perms = global.isConstant() ? AllocationPermissions::Write
+  // Don't want to be too nice to the end user code, make the default
+  // initialization something that the end user doesn't expect
+  OpRef alloc_data =
+      AllocOp::Create(size, ConstantInt::Create(llvm::APInt(8, 0xFF)));
+
+  auto perms = global.isConstant() ? AllocationPermissions::Read
                                    : AllocationPermissions::ReadWrite;
 
   unsigned alignment = global.getAlignment();
 
+  // Initially we create the allocation with a ReadWrite permission so that
+  // we can write the constant data into it via visitGlobalData. Then in
+  // visitGlobalData we set the permissions to the correct thing
   auto ptr = interp->allocate(
       size, interp->createConstantInt(bitwidth, alignment), alloc_data,
-      global.getAddressSpace(), AllocationKind::Global, perms);
+      global.getAddressSpace(), AllocationKind::Global,
+      AllocationPermissions::ReadWrite);
   auto res = LLVMValue(ptr);
 
   interp->context().globals.emplace(&global, res);
 
   visitGlobalData(*global.getInitializer(), *interp->ptr_allocation(ptr),
-                  global.getAddressSpace());
+                  global.getAddressSpace(), perms);
 
   return res;
 }
@@ -372,15 +381,12 @@ LLVMValue ExprEvaluator::visitFunction(llvm::Function& func) {
 }
 
 void ExprEvaluator::visitGlobalData(llvm::Constant& constant, Allocation& alloc,
-                                    unsigned AS) {
+                                    unsigned AS, AllocationPermissions perms) {
+  auto guard = make_guard([&] { alloc.permissions(perms); });
+
   llvm::Type* type = constant.getType();
   const llvm::DataLayout& layout = interp->getModule()->getDataLayout();
   unsigned bitwidth = layout.getPointerSizeInBits(AS);
-
-  // Don't bother to evaluate the rest of the initializer if we already know
-  // that we're going to get all zeros.
-  if (llvm::isa<llvm::ConstantAggregateZero>(constant))
-    return;
 
   LLVMValue value = visit(&constant);
 

--- a/src/Interpreter/ExternalFuncs/LongJmp.cpp
+++ b/src/Interpreter/ExternalFuncs/LongJmp.cpp
@@ -33,8 +33,8 @@ namespace {
         auto jmpbuf_size = layout.getTypeStoreSize(jmpbuf_ty);
 
         auto unresolved = args[0].scalar().pointer();
-        auto resolved =
-            ctx.resolve_ptr(unresolved, jmpbuf_size, "invalid pointer read");
+        auto resolved = ctx.resolve_ptr(unresolved, jmpbuf_size,
+                                        "invalid pointer read during longjmp");
 
         ctx.fork_external<LongJmpFrame>(resolved, [=](InterpreterContext& ctx,
                                                       LongJmpFrame* frame,

--- a/src/Interpreter/Interpreter.cpp
+++ b/src/Interpreter/Interpreter.cpp
@@ -373,8 +373,10 @@ void Interpreter::visitStoreInst(llvm::StoreInst& inst) {
 
     Allocation* alloc = fork.ptr_allocation(ptr);
     CAFFEINE_ASSERT(alloc);
-    alloc->write(ptr.offset(), inst.getValueOperand()->getType(), value,
-                 fork.context().heaps, layout);
+    try {
+      alloc->write(ptr.offset(), inst.getValueOperand()->getType(), value,
+                   fork.context().heaps, layout);
+    } catch (AllocationException& ex) { fork.fail(ex.what()); }
   }
 }
 void Interpreter::visitAllocaInst(llvm::AllocaInst& inst) {

--- a/src/Interpreter/Interpreter.cpp
+++ b/src/Interpreter/Interpreter.cpp
@@ -343,8 +343,8 @@ void Interpreter::visitLoadInst(llvm::LoadInst& inst) {
   //       revisited.
 
   auto unresolved = interp->load(inst.getOperand(0)).scalar().pointer();
-  auto resolved =
-      interp->resolve_ptr(unresolved, inst.getType(), "invalid pointer read");
+  auto resolved = interp->resolve_ptr(unresolved, inst.getType(),
+                                      "invalid pointer read during load");
   interp->kill();
 
   for (const Pointer& ptr : resolved) {

--- a/src/Interpreter/PrintingFailureLogger.cpp
+++ b/src/Interpreter/PrintingFailureLogger.cpp
@@ -75,6 +75,7 @@ void PrintingFailureLogger::log_failure(const Model* model, const Context& ctx,
 
   if (!failure.message.empty())
     ss << "Reason:\n  " << failure.message << '\n';
+  ss << "Assertion:\n" << failure.check << '\n';
 
   std::unique_lock lock(mtx);
   *os << ss.str() << std::flush;

--- a/test/run-fail/mem/global-mem-readwrite.c
+++ b/test/run-fail/mem/global-mem-readwrite.c
@@ -1,5 +1,3 @@
-#include "caffeine.h"
-
 const char data[] = "abcdef";
 
 __attribute__((noinline)) void write_to_data(char* mem) {

--- a/test/run-pass/strlen.c
+++ b/test/run-pass/strlen.c
@@ -1,8 +1,8 @@
-#include <string.h>
-#include <stdio.h>
 #include "caffeine.h"
+#include <stdio.h>
+#include <string.h>
 
-const char * thing = "";
+const char* thing = "";
 
 void test(int x) {
   caffeine_assert(strlen(thing) < 5);

--- a/test/run-pass/strlen.c
+++ b/test/run-pass/strlen.c
@@ -5,5 +5,5 @@
 const char * thing = "";
 
 void test(int x) {
-  caffeine_assert(strlen(thing) == 5);
+  caffeine_assert(strlen(thing) < 5);
 }

--- a/test/run-pass/strlen.c
+++ b/test/run-pass/strlen.c
@@ -1,0 +1,9 @@
+#include <string.h>
+#include <stdio.h>
+#include "caffeine.h"
+
+const char * thing = "";
+
+void test(int x) {
+  caffeine_assert(strlen(thing) == 5);
+}


### PR DESCRIPTION
Previously, `libc` wouldn't link for non c++ files (this might be something I broke in the past while linking in `libcxx`). Additionally I might have found a bug with our memory allocation stuff because a really simple `strlen` testcase fails.