### PR TITLE
Unbust `libc` linking

### DIFF
--- a/cmake/CaffeineTestUtils.cmake
+++ b/cmake/CaffeineTestUtils.cmake
@@ -107,6 +107,8 @@ function(declare_test TEST_NAME_OUT test EXPECTED)
   llvm_link_libraries     ("${test_target}" PRIVATE caffeine-builtins)
   if (CAFFEINE_ENABLE_LIBC AND "${test_ext}" STREQUAL ".cpp")
     llvm_link_libraries     ("${test_target}" PRIVATE libcxx)
+  elseif (CAFFEINE_ENABLE_LIBC)
+    llvm_link_libraries     ("${test_target}" PRIVATE libc)
   endif()
   llvm_compile_options    ("${test_target}" PRIVATE -O3)
 

--- a/libraries/libcxx/CMakeLists.txt
+++ b/libraries/libcxx/CMakeLists.txt
@@ -35,7 +35,7 @@ if(NOT ${STATUS_CODE} EQUAL 0)
 endif()
 
 llvm_library(libcxx ${CMAKE_CURRENT_BINARY_DIR}/libcxx.bc "${CMAKE_CURRENT_BINARY_DIR}/dummy.c")
-llvm_link_libraries(libcxx PRIVATE musl_libc)
+llvm_link_libraries(libcxx PRIVATE libc)
 
 endif()
 endfunction()


### PR DESCRIPTION
Previously `libc` would not be linked to `c` files, only `c++` files.
This PR fixes that