### PR TITLE
Fix `strlen` test

### DIFF
--- a/bazel/toolchain/bitcode.bzl
+++ b/bazel/toolchain/bitcode.bzl
@@ -1,5 +1,7 @@
 """
 """
+# Note, currently libc / muslc is downloaded from Github
+# via third_party/musl/setup.bzl
 
 load(
     "@rules_cc//cc:cc_toolchain_config_lib.bzl",
@@ -43,6 +45,7 @@ def _bitcode_toolchain_config(ctx):
                         flag_group(
                             flags = [
                                 "-emit-llvm",
+                                "-fgnuc-version=0",
                                 "-g",
                                 "-nostdinc",
                                 "-ffreestanding",

--- a/cmake/CaffeineTestUtils.cmake
+++ b/cmake/CaffeineTestUtils.cmake
@@ -107,6 +107,8 @@ function(declare_test TEST_NAME_OUT test EXPECTED)
   llvm_link_libraries     ("${test_target}" PRIVATE caffeine-builtins)
   if (CAFFEINE_ENABLE_LIBC AND "${test_ext}" STREQUAL ".cpp")
     llvm_link_libraries     ("${test_target}" PRIVATE libcxx)
+  elseif (CAFFEINE_ENABLE_LIBC)
+    llvm_link_libraries     ("${test_target}" PRIVATE libc)
   endif()
   llvm_compile_options    ("${test_target}" PRIVATE -O3)
 

--- a/cmake/LLVMIRUtils.cmake
+++ b/cmake/LLVMIRUtils.cmake
@@ -142,12 +142,12 @@ function(llvm_library TARGET_NAME)
       "$<TARGET_PROPERTY:${TARGET_NAME},INCLUDE_DIRECTORIES>"
       "-I"
     )
-    
+
     get_source_file_property(includes "${source}" INCLUDE_DIRECTORIES)
     get_source_file_property(options "${source}" LLVM_COMPILE_OPTIONS)
     file(RELATIVE_PATH object_rel "${CMAKE_BINARY_DIR}" "${object}")
 
-    string(CONCAT COMPILER 
+    string(CONCAT COMPILER
       "$<$<STREQUAL:${source_language},C>:${CLANG}>"
       "$<$<STREQUAL:${source_language},CXX>:${CLANGXX}>"
     )
@@ -177,7 +177,7 @@ function(llvm_library TARGET_NAME)
     add_custom_command(
       OUTPUT "${object}"
       COMMAND "${COMPILER}" ARGS
-        -emit-llvm -MMD -g -c
+        -emit-llvm -MMD -g -c -fgnuc-version=0 -Wno-literal-range
         "${sys_includes}"
         "${tgt_includes}"
         "${src_includes}"
@@ -253,7 +253,7 @@ function(llvm_compile_options TARGET_NAME VISIBILITY)
   if (VISIBILITY STREQUAL "PUBLIC" OR VISIBILITY STREQUAL "INTERFACE")
     set_property(
       TARGET ${TARGET_NAME} APPEND
-      PROPERTY LLVM_INTERFACE_COMPILE_OPTIONS ${options} 
+      PROPERTY LLVM_INTERFACE_COMPILE_OPTIONS ${options}
     )
   endif()
 endfunction()
@@ -289,22 +289,22 @@ function(llvm_link_libraries TARGET_NAME VISIBILITY)
       if (VISIBILITY STREQUAL "PRIVATE" OR VISIBILITY STREQUAL "PUBLIC")
         set_property(
           TARGET ${TARGET_NAME} APPEND
-          PROPERTY INCLUDE_DIRECTORIES 
+          PROPERTY INCLUDE_DIRECTORIES
           "$<GENEX_EVAL:$<TARGET_PROPERTY:${library},INTERFACE_INCLUDE_DIRECTORIES>>"
         )
         set_property(
           TARGET ${TARGET_NAME} APPEND
-          PROPERTY LLVM_COMPILE_OPTIONS 
+          PROPERTY LLVM_COMPILE_OPTIONS
           "$<GENEX_EVAL:$<TARGET_PROPERTY:${library},LLVM_INTERFACE_COMPILE_OPTIONS>>"
         )
         set_property(
           TARGET ${TARGET_NAME} APPEND
-          PROPERTY LLVM_LINK_OPTIONS 
+          PROPERTY LLVM_LINK_OPTIONS
           "$<GENEX_EVAL:$<TARGET_PROPERTY:${library},LLVM_INTERFACE_LINK_OPTIONS>>"
         )
         set_property(
           TARGET ${TARGET_NAME} APPEND
-          PROPERTY LLVM_LINK_LIBRARIES 
+          PROPERTY LLVM_LINK_LIBRARIES
           "$<GENEX_EVAL:$<TARGET_PROPERTY:${library},LLVM_INTERFACE_LINK_LIBRARIES>>"
           "$<TARGET_PROPERTY:${library},OUTPUT>"
         )
@@ -313,22 +313,22 @@ function(llvm_link_libraries TARGET_NAME VISIBILITY)
       if (VISIBILITY STREQUAL "INTERFACE" OR VISIBILITY STREQUAL "PUBLIC")
         set_property(
           TARGET ${TARGET_NAME} APPEND
-          PROPERTY INTERFACE_INCLUDE_DIRECTORIES 
+          PROPERTY INTERFACE_INCLUDE_DIRECTORIES
           "$<GENEX_EVAL:$<TARGET_PROPERTY:${library},INTERFACE_INCLUDE_DIRECTORIES>>"
         )
         set_property(
           TARGET ${TARGET_NAME} APPEND
-          PROPERTY LLVM_INTERFACE_COMPILE_OPTIONS 
+          PROPERTY LLVM_INTERFACE_COMPILE_OPTIONS
           "$<GENEX_EVAL:$<TARGET_PROPERTY:${library},LLVM_INTERFACE_COMPILE_OPTIONS>>"
         )
         set_property(
           TARGET ${TARGET_NAME} APPEND
-          PROPERTY LLVM_INTERFACE_LINK_OPTIONS 
+          PROPERTY LLVM_INTERFACE_LINK_OPTIONS
           "$<GENEX_EVAL:$<TARGET_PROPERTY:${library},LLVM_INTERFACE_LINK_OPTIONS>>"
         )
         set_property(
           TARGET ${TARGET_NAME} APPEND
-          PROPERTY LLVM_INTERFACE_LINK_LIBRARIES 
+          PROPERTY LLVM_INTERFACE_LINK_LIBRARIES
           "$<GENEX_EVAL:$<TARGET_PROPERTY:${library},LLVM_INTERFACE_LINK_LIBRARIES>>"
         )
       endif()
@@ -336,7 +336,7 @@ function(llvm_link_libraries TARGET_NAME VISIBILITY)
       if (VISIBILITY STREQUAL "PRIVATE" OR VISIBILITY STREQUAL "PUBLIC")
         set_property(
           TARGET ${TARGET_NAME} APPEND
-          PROPERTY LLVM_LINK_LIBRARIES 
+          PROPERTY LLVM_LINK_LIBRARIES
           "${library}"
         )
       endif()
@@ -344,11 +344,10 @@ function(llvm_link_libraries TARGET_NAME VISIBILITY)
       if (VISIBILITY STREQUAL "INTERFACE" OR VISIBILITY STREQUAL "PUBLIC")
         set_property(
           TARGET ${TARGET_NAME} APPEND
-          PROPERTY LLVM_INTERFACE_LINK_LIBRARIES 
+          PROPERTY LLVM_INTERFACE_LINK_LIBRARIES
           "${library}"
         )
       endif()
     endif()
   endforeach()
 endfunction()
-

--- a/libraries/libcxx/CMakeLists.txt
+++ b/libraries/libcxx/CMakeLists.txt
@@ -35,7 +35,7 @@ if(NOT ${STATUS_CODE} EQUAL 0)
 endif()
 
 llvm_library(libcxx ${CMAKE_CURRENT_BINARY_DIR}/libcxx.bc "${CMAKE_CURRENT_BINARY_DIR}/dummy.c")
-llvm_link_libraries(libcxx PRIVATE musl_libc)
+llvm_link_libraries(libcxx PRIVATE libc)
 
 endif()
 endfunction()

--- a/test/run-pass/strlen.c
+++ b/test/run-pass/strlen.c
@@ -1,0 +1,9 @@
+#include "caffeine.h"
+#include <stdio.h>
+#include <string.h>
+
+const char* thing = "";
+
+void test(int x) {
+  caffeine_assert(strlen(thing) < 5);
+}

--- a/third_party/musl/setup.bzl
+++ b/third_party/musl/setup.bzl
@@ -4,12 +4,12 @@
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 def setup_musl(name):
-    date = "2021-10-23-20-04"
+    date = "2021-12-29-03-25"
 
     http_archive(
         name = name,
         strip_prefix = "install",
         url = "https://github.com/insufficiently-caffeinated/caffeine-dependencies/releases/download/caffeine-deps-{}/musl.tar.xz".format(date),
         build_file = "@caffeine//third_party/musl:build.bzl",
-        sha256 = "5460c5b2bab85863aeb2c402adde0740cbe95564a747c5a2464eaf90e51c3c98",
+        sha256 = "d922f7093f20615293d5ab173651e15d202bc637ab947b12a18bf0ef6a7fd8da",
     )


### PR DESCRIPTION
This commit fixes the musl libc `strlen` implementation. The root cause
if that when `__GNUC__` is defined, the `strlen` implementation assumes
that it can read past the buffer by a bit. However, under caffeine's
memory model this is not true.
    
To prevent clang from defining the GNU C macro, we set
 -fgnuc-version=0` as a flag to clang.

/stack #595