### PR TITLE
Implement support for evaluating `GlobalAlias`'

### DIFF
--- a/include/caffeine/Interpreter/ExprEval.h
+++ b/include/caffeine/Interpreter/ExprEval.h
@@ -82,6 +82,7 @@ public:
   // Subclasses of GlobalValue
   LLVMValue visitGlobalVariable(llvm::GlobalVariable& global);
   LLVMValue visitFunction(llvm::Function& func);
+  LLVMValue visitGlobalAlias(llvm::GlobalAlias& alias);
 
   // Extras
   void visitGlobalData(llvm::Constant& cnst, Allocation& alloc, unsigned AS,

--- a/src/Interpreter/Executor.cpp
+++ b/src/Interpreter/Executor.cpp
@@ -1,5 +1,6 @@
 #include "caffeine/Interpreter/Executor.h"
 #include "caffeine/Interpreter/CaffeineContext.h"
+#include "caffeine/Interpreter/ExprEval.h"
 #include "caffeine/Interpreter/Interpreter.h"
 #include "caffeine/Interpreter/Store.h"
 #include "caffeine/Support/UnsupportedOperation.h"
@@ -29,6 +30,10 @@ void Executor::run_worker() {
       try {
         Interpreter interp{&ictx};
         interp.execute();
+      } catch (ExprEvaluator::Unevaluatable& ex) {
+        logger->log_failure(nullptr, ctx.value(),
+                            Failure(Assertion(), ex.what()));
+        break;
       } catch (UnsupportedOperationException&) {
         // The assert that threw this already printed an error message
         // TODO: We should have a better way to indicate that this failed to the

--- a/src/Interpreter/ExprEval.cpp
+++ b/src/Interpreter/ExprEval.cpp
@@ -95,6 +95,8 @@ LLVMValue ExprEvaluator::evaluate(llvm::Value* val) {
     return visitGlobalVariable(*cnst);
   if (auto* cnst = llvm::dyn_cast<llvm::Function>(val))
     return visitFunction(*cnst);
+  if (auto* cnst = llvm::dyn_cast<llvm::GlobalAlias>(val))
+    return visitGlobalAlias(*cnst);
 
   CAFFEINE_UNSUPPORTED(fmt::format(
       "Unsupported expression ({}): {}",
@@ -374,6 +376,12 @@ LLVMValue ExprEvaluator::visitFunction(llvm::Function& func) {
 
   interp->context().globals.emplace(&func, pointer);
   return pointer;
+}
+
+LLVMValue ExprEvaluator::visitGlobalAlias(llvm::GlobalAlias& alias) {
+  auto res = visit(alias.getAliasee());
+  interp->context().globals.emplace(&alias, res);
+  return res;
 }
 
 void ExprEvaluator::visitGlobalData(llvm::Constant& constant, Allocation& alloc,

--- a/src/Interpreter/ExternalFuncs/LongJmp.cpp
+++ b/src/Interpreter/ExternalFuncs/LongJmp.cpp
@@ -33,8 +33,8 @@ namespace {
         auto jmpbuf_size = layout.getTypeStoreSize(jmpbuf_ty);
 
         auto unresolved = args[0].scalar().pointer();
-        auto resolved =
-            ctx.resolve_ptr(unresolved, jmpbuf_size, "invalid pointer read");
+        auto resolved = ctx.resolve_ptr(unresolved, jmpbuf_size,
+                                        "invalid pointer read in LongJmp");
 
         ctx.fork_external<LongJmpFrame>(resolved, [=](InterpreterContext& ctx,
                                                       LongJmpFrame* frame,


### PR DESCRIPTION
While working on c++ support I ran into this issue. This adds the fix

/stack #600