### PR TITLE
Implement `abort`

### DIFF
--- a/include/caffeine/Interpreter/ExternalFuncs/Abort.h
+++ b/include/caffeine/Interpreter/ExternalFuncs/Abort.h
@@ -2,7 +2,7 @@
 
 namespace caffeine {
 
-class CaffeineAssertFunction : public ExternalFunction {
+class AbortFunction : public ExternalFunction {
 public:
   void call(InterpreterContext& ctx, Span<LLVMValue> args) const override;
 };

--- a/include/caffeine/Interpreter/ExternalFunction.h
+++ b/include/caffeine/Interpreter/ExternalFunction.h
@@ -72,8 +72,9 @@ public:
   static std::unique_ptr<ExternalFunction> caffeine_calloc();
   static std::unique_ptr<ExternalFunction> caffeine_free();
 
-  static std::unique_ptr<ExternalFunction> setjmp();
+  static std::unique_ptr<ExternalFunction> abort();
   static std::unique_ptr<ExternalFunction> longjmp();
+  static std::unique_ptr<ExternalFunction> setjmp();
 
 private:
   ExternalFunctions() = delete;

--- a/src/Interpreter/CaffeineContext.cpp
+++ b/src/Interpreter/CaffeineContext.cpp
@@ -151,9 +151,13 @@ Builder& Builder::with_default_functions() {
                 ExternalFunctions::caffeine_builtin_resolve());
   with_function("caffeine_calloc", ExternalFunctions::caffeine_calloc());
   with_function("caffeine_free", ExternalFunctions::caffeine_free());
-  with_function("_setjmp", ExternalFunctions::setjmp());
-  with_function("setjmp", ExternalFunctions::setjmp());
+  with_function("caffeine_malloc_aligned",
+                ExternalFunctions::caffeine_malloc_aligned());
+
+  with_function("abort", ExternalFunctions::abort());
   with_function("longjmp", ExternalFunctions::longjmp());
+  with_function("setjmp", ExternalFunctions::setjmp());
+  with_function("_setjmp", ExternalFunctions::setjmp());
 
   return *this;
 }

--- a/src/Interpreter/Executor.cpp
+++ b/src/Interpreter/Executor.cpp
@@ -1,5 +1,6 @@
 #include "caffeine/Interpreter/Executor.h"
 #include "caffeine/Interpreter/CaffeineContext.h"
+#include "caffeine/Interpreter/ExprEval.h"
 #include "caffeine/Interpreter/Interpreter.h"
 #include "caffeine/Interpreter/Store.h"
 #include "caffeine/Support/UnsupportedOperation.h"
@@ -29,6 +30,10 @@ void Executor::run_worker() {
       try {
         Interpreter interp{&ictx};
         interp.execute();
+      } catch (ExprEvaluator::Unevaluatable& ex) {
+        logger->log_failure(nullptr, ctx.value(),
+                            Failure(Assertion(), ex.what()));
+        break;
       } catch (UnsupportedOperationException&) {
         // The assert that threw this already printed an error message
         // TODO: We should have a better way to indicate that this failed to the

--- a/src/Interpreter/ExternalFuncs/Abort.cpp
+++ b/src/Interpreter/ExternalFuncs/Abort.cpp
@@ -1,0 +1,20 @@
+#include "caffeine/Interpreter/ExternalFuncs/Abort.h"
+#include "caffeine/Interpreter/InterpreterContext.h"
+
+namespace caffeine {
+
+void AbortFunction::call(InterpreterContext& ctx, Span<LLVMValue> args) const {
+  if (args.size() != 0) {
+    ctx.fail("abort called with bad signature (wrong number of "
+             "arguments)");
+    return;
+  }
+
+  ctx.fail("program called abort");
+}
+
+std::unique_ptr<ExternalFunction> ExternalFunctions::abort() {
+  return std::make_unique<AbortFunction>();
+}
+
+} // namespace caffeine

--- a/test/run-fail/abort.c
+++ b/test/run-fail/abort.c
@@ -1,0 +1,5 @@
+#include <stdlib.h>
+
+void test() {
+  abort();
+}


### PR DESCRIPTION
This PR implements the C `abort` method. It's used by c++ in `std::terminate`

/stack #600