### PR TITLE
Implement `FpToUI` and `FpToSI` within `Z3Solver`

### DIFF
--- a/src/Solver/Z3/Convert.cpp
+++ b/src/Solver/Z3/Convert.cpp
@@ -432,7 +432,13 @@ z3::expr Z3OpVisitor::visitUIToFp(const UnaryOp& op) {
   return expr;
 }
 z3::expr Z3OpVisitor::visitFpToSI(const UnaryOp& op) {
-  CAFFEINE_UNOP_UNIMPLEMENTED(op);
+  z3::expr src = visit(*op.operand());
+
+  z3::expr expr{src.ctx(),
+                Z3_mk_fpa_to_sbv(src.ctx(), src.ctx().fpa_rounding_mode(), src,
+                                 op.type().bitwidth())};
+  src.ctx().check_error();
+  return expr;
 }
 z3::expr Z3OpVisitor::visitFpToUI(const UnaryOp& op) {
   CAFFEINE_UNOP_UNIMPLEMENTED(op);

--- a/src/Solver/Z3/Convert.cpp
+++ b/src/Solver/Z3/Convert.cpp
@@ -441,7 +441,13 @@ z3::expr Z3OpVisitor::visitFpToSI(const UnaryOp& op) {
   return expr;
 }
 z3::expr Z3OpVisitor::visitFpToUI(const UnaryOp& op) {
-  CAFFEINE_UNOP_UNIMPLEMENTED(op);
+  z3::expr src = visit(*op.operand());
+
+  z3::expr expr{src.ctx(),
+                Z3_mk_fpa_to_ubv(src.ctx(), src.ctx().fpa_rounding_mode(), src,
+                                 op.type().bitwidth())};
+  src.ctx().check_error();
+  return expr;
 }
 z3::expr Z3OpVisitor::visitFpExt(const UnaryOp& op) {
   CAFFEINE_UNOP_UNIMPLEMENTED(op);

--- a/test/regression/issue-609.pass.requires-fptosi.c
+++ b/test/regression/issue-609.pass.requires-fptosi.c
@@ -1,0 +1,11 @@
+#include "caffeine.h"
+#include <stdint.h>
+
+void test(float f) {
+  caffeine_assume(f < 0.0f);
+  caffeine_assume(f > -20000000.0f);
+
+  // This is the smallest-magnitude integer not representable by a
+  // floating-point number.
+  caffeine_assert((int32_t)f != INT32_C(-16777217));
+}

--- a/test/regression/issue-609.pass.requires-fptoui.c
+++ b/test/regression/issue-609.pass.requires-fptoui.c
@@ -1,0 +1,11 @@
+#include "caffeine.h"
+#include <stdint.h>
+
+void test(float f) {
+  caffeine_assume(f > 0.0f);
+  caffeine_assume(f < 20000000.0f);
+
+  // This is the smallest-magnitude integer not representable by a
+  // floating-point number.
+  caffeine_assert((uint32_t)f != UINT32_C(16777217));
+}


### PR DESCRIPTION
As in title. The semantics aren't exactly consistent with those of LLVM IR (since these produce poison if the float cannot be converted) but they are close enough for some things to work.

Closes #609 