### PR TITLE
Fix progress message within BitcodeBinaryOpt step

### DIFF
--- a/bazel/bitcode.bzl
+++ b/bazel/bitcode.bzl
@@ -323,7 +323,7 @@ def _bitcode_optimize(ctx):
         executable = ctx.executable._opt,
         arguments = [args],
         mnemonic = "BitcodeLink",
-        progress_message = "Optimizing %{input}",
+        progress_message = "Optimizing {}".format(output),
     )
 
     return [DefaultInfo(files = depset([output]))]


### PR DESCRIPTION
Bazel docs say to use template strings for the progress message. However, in practice this don't actually seem to be expanded by bazel. This change replaces the template string with an expanded one.