### PR TITLE
Add `llvm::CallBase` to `ExternalFunction` class

### DIFF
--- a/include/caffeine/Interpreter/ExternalFuncs/Abort.h
+++ b/include/caffeine/Interpreter/ExternalFuncs/Abort.h
@@ -4,7 +4,8 @@ namespace caffeine {
 
 class AbortFunction : public ExternalFunction {
 public:
-  void call(InterpreterContext& ctx, Span<LLVMValue> args) const override;
+  void call(llvm::CallBase* cb, InterpreterContext& ctx,
+            Span<LLVMValue> args) const override;
 };
 
 } // namespace caffeine

--- a/include/caffeine/Interpreter/ExternalFuncs/CaffeineAssert.h
+++ b/include/caffeine/Interpreter/ExternalFuncs/CaffeineAssert.h
@@ -4,7 +4,8 @@ namespace caffeine {
 
 class CaffeineAssertFunction : public ExternalFunction {
 public:
-  void call(InterpreterContext& ctx, Span<LLVMValue> args) const override;
+  void call(llvm::CallBase* cb, InterpreterContext& ctx,
+            Span<LLVMValue> args) const override;
 };
 
 } // namespace caffeine

--- a/include/caffeine/Interpreter/ExternalFuncs/CaffeineAssume.h
+++ b/include/caffeine/Interpreter/ExternalFuncs/CaffeineAssume.h
@@ -6,7 +6,8 @@ namespace caffeine {
 
 class CaffeineAssumeFunction : public ExternalFunction {
 public:
-  void call(InterpreterContext& ctx, Span<LLVMValue> args) const override;
+  void call(llvm::CallBase* cb, InterpreterContext& ctx,
+            Span<LLVMValue> args) const override;
 };
 
 } // namespace caffeine

--- a/include/caffeine/Interpreter/ExternalFuncs/MallocAlign.h
+++ b/include/caffeine/Interpreter/ExternalFuncs/MallocAlign.h
@@ -6,7 +6,8 @@ namespace caffeine {
 
 class MallocAlignFunction : public ExternalFunction {
 public:
-  void call(InterpreterContext& ctx, Span<LLVMValue> args) const override;
+  void call(llvm::CallBase*, InterpreterContext& ctx,
+            Span<LLVMValue> args) const override;
 };
 
 } // namespace caffeine

--- a/include/caffeine/Interpreter/ExternalFunction.h
+++ b/include/caffeine/Interpreter/ExternalFunction.h
@@ -2,6 +2,8 @@
 
 #include "caffeine/ADT/Span.h"
 
+#include <llvm/IR/InstrTypes.h>
+
 namespace caffeine {
 class InterpreterContext;
 class LLVMValue;
@@ -39,7 +41,8 @@ public:
    *            execution.
    * @param args The arguments to the current function.
    */
-  virtual void call(InterpreterContext& ctx, Span<LLVMValue> args) const = 0;
+  virtual void call(llvm::CallBase* cb, InterpreterContext& ctx,
+                    Span<LLVMValue> args) const = 0;
 
   ExternalFunction() = default;
   virtual ~ExternalFunction() = default;

--- a/src/Interpreter/ExternalFuncs/Abort.cpp
+++ b/src/Interpreter/ExternalFuncs/Abort.cpp
@@ -1,9 +1,12 @@
 #include "caffeine/Interpreter/ExternalFuncs/Abort.h"
 #include "caffeine/Interpreter/InterpreterContext.h"
 
+#include <llvm/IR/InstrTypes.h>
+
 namespace caffeine {
 
-void AbortFunction::call(InterpreterContext& ctx, Span<LLVMValue> args) const {
+void AbortFunction::call(llvm::CallBase*, InterpreterContext& ctx,
+                         Span<LLVMValue> args) const {
   if (args.size() != 0) {
     ctx.fail("abort called with bad signature (wrong number of "
              "arguments)");

--- a/src/Interpreter/ExternalFuncs/CaffeineAssert.cpp
+++ b/src/Interpreter/ExternalFuncs/CaffeineAssert.cpp
@@ -1,9 +1,11 @@
 #include "caffeine/Interpreter/ExternalFuncs/CaffeineAssert.h"
 #include "caffeine/Interpreter/InterpreterContext.h"
 
+#include <llvm/IR/InstrTypes.h>
+
 namespace caffeine {
 
-void CaffeineAssertFunction::call(InterpreterContext& ctx,
+void CaffeineAssertFunction::call(llvm::CallBase*, InterpreterContext& ctx,
                                   Span<LLVMValue> args) const {
   if (args.size() != 1) {
     ctx.fail("caffeine_assert called with bad signature (wrong number of "

--- a/src/Interpreter/ExternalFuncs/CaffeineAssume.cpp
+++ b/src/Interpreter/ExternalFuncs/CaffeineAssume.cpp
@@ -1,9 +1,11 @@
 #include "caffeine/Interpreter/ExternalFuncs/CaffeineAssume.h"
 #include "caffeine/Interpreter/InterpreterContext.h"
 
+#include <llvm/IR/InstrTypes.h>
+
 namespace caffeine {
 
-void CaffeineAssumeFunction::call(InterpreterContext& ctx,
+void CaffeineAssumeFunction::call(llvm::CallBase*, InterpreterContext& ctx,
                                   Span<LLVMValue> args) const {
   if (args.size() != 1) {
     ctx.fail("caffeine_assume called with bad signature (wrong number of "

--- a/src/Interpreter/ExternalFuncs/CaffeineBuiltinResolve.cpp
+++ b/src/Interpreter/ExternalFuncs/CaffeineBuiltinResolve.cpp
@@ -9,7 +9,8 @@ namespace {
 
   class CaffeineBuiltinResolveFunction : public ExternalFunction {
   public:
-    void call(InterpreterContext& ctx, Span<LLVMValue> args) const override {
+    void call(llvm::CallBase*, InterpreterContext& ctx,
+              Span<LLVMValue> args) const override {
       if (args.size() != 2) {
         ctx.fail("invalid caffeine_builtin_resolve signature (invalid number "
                  "of arguments)");

--- a/src/Interpreter/ExternalFuncs/CaffeineSymbolicAlloca.cpp
+++ b/src/Interpreter/ExternalFuncs/CaffeineSymbolicAlloca.cpp
@@ -17,7 +17,8 @@ namespace {
 
   class CaffeineSymbolicAlloca : public ExternalFunction {
   public:
-    void call(InterpreterContext& ctx, Span<LLVMValue> args) const override {
+    void call(llvm::CallBase*, InterpreterContext& ctx,
+              Span<LLVMValue> args) const override {
       if (args.size() != 2) {
         ctx.fail("invalid caffeine_symbolic_alloca signature (invalid number "
                  "of arguments)");

--- a/src/Interpreter/ExternalFuncs/Calloc.cpp
+++ b/src/Interpreter/ExternalFuncs/Calloc.cpp
@@ -9,7 +9,8 @@ namespace {
 
   class CallocFunction : public ExternalFunction {
   public:
-    void call(InterpreterContext& ctx, Span<LLVMValue> args) const {
+    void call(llvm::CallBase*, InterpreterContext& ctx,
+              Span<LLVMValue> args) const {
       if (args.size() != 1) {
         ctx.fail(
             "invalid caffeine_calloc signature (invalid number of arguments)");

--- a/src/Interpreter/ExternalFuncs/Free.cpp
+++ b/src/Interpreter/ExternalFuncs/Free.cpp
@@ -8,7 +8,8 @@ namespace {
 
   class CaffeineFreeFunction : public ExternalFunction {
   public:
-    void call(InterpreterContext& ctx, Span<LLVMValue> args) const override {
+    void call(llvm::CallBase*, InterpreterContext& ctx,
+              Span<LLVMValue> args) const override {
       if (args.size() != 1) {
         ctx.fail(
             "invalid caffeine_free signature (invalid number of arguments)");

--- a/src/Interpreter/ExternalFuncs/LongJmp.cpp
+++ b/src/Interpreter/ExternalFuncs/LongJmp.cpp
@@ -143,7 +143,8 @@ namespace {
 
   class LongJmpFunction : public ExternalFunction {
   public:
-    void call(InterpreterContext& ctx, Span<LLVMValue> args) const override {
+    void call(llvm::CallBase*, InterpreterContext& ctx,
+              Span<LLVMValue> args) const override {
       if (args.size() != 2) {
         ctx.fail("invalid longjmp signature (invalid number of arguments)");
         return;

--- a/src/Interpreter/ExternalFuncs/MallocAlign.cpp
+++ b/src/Interpreter/ExternalFuncs/MallocAlign.cpp
@@ -6,7 +6,7 @@
 
 namespace caffeine {
 
-void MallocAlignFunction::call(InterpreterContext& ctx,
+void MallocAlignFunction::call(llvm::CallBase*, InterpreterContext& ctx,
                                Span<LLVMValue> args) const {
   if (args.size() != 2) {
     ctx.fail("invalid malloc_align signature (invalid number of arguments)");

--- a/src/Interpreter/ExternalFuncs/SetJmp.cpp
+++ b/src/Interpreter/ExternalFuncs/SetJmp.cpp
@@ -22,7 +22,8 @@ namespace {
 
   class SetJmpFunction : public ExternalFunction {
   public:
-    void call(InterpreterContext& ctx, Span<LLVMValue> args) const override {
+    void call(llvm::CallBase*, InterpreterContext& ctx,
+              Span<LLVMValue> args) const override {
       if (args.size() != 1) {
         ctx.fail("invalid number of arguments for setjmp");
         return;

--- a/src/Interpreter/Interpreter.cpp
+++ b/src/Interpreter/Interpreter.cpp
@@ -305,7 +305,7 @@ void Interpreter::visitIntrinsicInst(llvm::IntrinsicInst& intrin) {
   for (auto& arg : intrin.args())
     args.push_back(interp->load(arg.get()));
 
-  func->call(*interp, args);
+  func->call(&intrin, *interp, args);
 }
 void Interpreter::visitIndirectCall(llvm::CallBase& call) {
   CAFFEINE_ASSERT(
@@ -440,7 +440,7 @@ void Interpreter::visitExternFunc(llvm::CallBase& call) {
       args.push_back(interp->load(call.getArgOperand(i)));
     }
 
-    extern_func->call(*interp, args);
+    extern_func->call(&call, *interp, args);
     return;
   }
 

--- a/src/Interpreter/Intrinsics/llvm.smul.with.overflow.cpp
+++ b/src/Interpreter/Intrinsics/llvm.smul.with.overflow.cpp
@@ -7,7 +7,8 @@ namespace caffeine {
 namespace {
   class SMulWithOverflowIntrinsic : public ExternalFunction {
   public:
-    void call(InterpreterContext& ctx, Span<LLVMValue> args) const {
+    void call(llvm::CallBase*, InterpreterContext& ctx,
+              Span<LLVMValue> args) const {
       CAFFEINE_ASSERT(args.size() == 2);
 
       auto values = transform_exprs(

--- a/src/Interpreter/Intrinsics/llvm.umul.with.overflow.cpp
+++ b/src/Interpreter/Intrinsics/llvm.umul.with.overflow.cpp
@@ -7,7 +7,8 @@ namespace caffeine {
 namespace {
   class UMulWithOverflowIntrinsic : public ExternalFunction {
   public:
-    void call(InterpreterContext& ctx, Span<LLVMValue> args) const {
+    void call(llvm::CallBase*, InterpreterContext& ctx,
+              Span<LLVMValue> args) const {
       CAFFEINE_ASSERT(args.size() == 2);
 
       auto values = transform_exprs(


### PR DESCRIPTION
This commit adds a `llvm::CallBase` to the `call` method because the
`abs` intrinsic needs to inspect the return type. Currently it's not
possible to do this with the current `ExternalFunction` class.