### PR TITLE
Build Z3 via cmake within bazel

### DIFF
--- a/third_party/BUILD
+++ b/third_party/BUILD
@@ -12,11 +12,12 @@ alias(
 
 alias(
     name = "z3",
-    actual = select({
-        "@bazel_tools//src/conditions:windows": "@z3-windows//:z3",
-        "@bazel_tools//src/conditions:darwin": "@z3-darwin//:z3",
-        "//conditions:default": "@z3-linux//:z3",
-    }),
+    # actual = select({
+    #     "@bazel_tools//src/conditions:windows": "@z3-windows//:z3",
+    #     "@bazel_tools//src/conditions:darwin": "@z3-darwin//:z3",
+    #     "//conditions:default": "@z3-linux//:z3",
+    # }),
+    actual = "//third_party/z3",
 )
 
 alias(

--- a/third_party/BUILD
+++ b/third_party/BUILD
@@ -12,11 +12,6 @@ alias(
 
 alias(
     name = "z3",
-    # actual = select({
-    #     "@bazel_tools//src/conditions:windows": "@z3-windows//:z3",
-    #     "@bazel_tools//src/conditions:darwin": "@z3-darwin//:z3",
-    #     "//conditions:default": "@z3-linux//:z3",
-    # }),
     actual = "//third_party/z3",
 )
 

--- a/third_party/z3/BUILD
+++ b/third_party/z3/BUILD
@@ -1,0 +1,15 @@
+load("@rules_foreign_cc//foreign_cc:defs.bzl", "cmake")
+
+cmake(
+    name = "z3",
+    build_args = ["-j $(nproc)"],
+    generate_args = [
+        "-DZ3_BUILD_LIBZ3_SHARED=OFF",
+    ],
+    lib_source = "@z3-cmake//:srcs",
+    out_static_libs = select({
+        "@bazel_tools//src/conditions:windows": ["z3.lib"],
+        "//conditions:default": ["libz3.a"],
+    }),
+    visibility = ["//visibility:public"],
+)

--- a/third_party/z3/setup.bzl
+++ b/third_party/z3/setup.bzl
@@ -3,50 +3,19 @@
 
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
-BUILD_FILE_CONTENT = """
-cc_import(
-    name = "z3-raw",
-    static_library = "bin/libz3.a",
-    shared_library = "bin/libz3.so",
-)
-
-cc_library(
-    name = "z3",
-    hdrs = glob(["include/**/*"]),
-    deps = [":z3-raw"],
-    strip_include_prefix = "include",
-    visibility = ["//visibility:public"],
-)
-"""
-
 def setup_z3(name):
     version = "4.8.14"
-    matrix = [
-        (
-            "windows",
-            "https://github.com/Z3Prover/z3/releases/download/z3-{0}/z3-{0}-x64-win.zip",
-            "a3fa1edc62d66403008ae01efec2d3499c8f4b730382acbfb3564f82f3ead7a9",
-            "z3-{0}-x64-win",
-        ),
-        (
-            "linux",
-            "https://github.com/Z3Prover/z3/releases/download/z3-{0}/z3-{0}-x64-glibc-2.31.zip",
-            "5ffa4b8b2e04309560d78ef88779bd8353f64248129ca24f6d9e7eb9fdb0af6c",
-            "z3-{0}-x64-glibc-2.31",
-        ),
-        (
-            "darwin",
-            "https://github.com/Z3Prover/z3/releases/download/z3-{0}/z3-{0}-x64-osx-10.16.zip",
-            "",
-            "z3-{0}-x64-osx-10.16",
-        ),
-    ]
 
-    for plat, url, sha256, prefix in matrix:
-        http_archive(
-            name = "{}-{}".format(name, plat),
-            url = url.format(version),
-            sha256 = sha256,
-            strip_prefix = prefix.format(version),
-            build_file_content = BUILD_FILE_CONTENT,
-        )
+    http_archive(
+        name = "{}-cmake".format(name),
+        url = "https://github.com/Z3Prover/z3/archive/refs/tags/z3-{}.tar.gz".format(version),
+        sha256 = "96a1f49a7701120cc38bfa63c02ff93be4d64c7926cea41977dedec7d87a1364",
+        strip_prefix = "z3-z3-{}".format(version),
+        build_file_content = """
+filegroup(
+    name = "srcs",
+    srcs = glob(["**"]),
+    visibility = ["//visibility:public"]
+)
+"""
+    )

--- a/third_party/z3/setup.bzl
+++ b/third_party/z3/setup.bzl
@@ -20,25 +20,25 @@ cc_library(
 """
 
 def setup_z3(name):
-    version = "4.8.12"
+    version = "4.8.14"
     matrix = [
         (
             "windows",
             "https://github.com/Z3Prover/z3/releases/download/z3-{0}/z3-{0}-x64-win.zip",
-            "de12fb2160798a464244954236b28da597e79289f33955b170853b8bf0d1f078",
+            "a3fa1edc62d66403008ae01efec2d3499c8f4b730382acbfb3564f82f3ead7a9",
             "z3-{0}-x64-win",
         ),
         (
             "linux",
             "https://github.com/Z3Prover/z3/releases/download/z3-{0}/z3-{0}-x64-glibc-2.31.zip",
-            "648e8a7afb57445440ad711b733bd675e3888da2767c14ae5122582c924d8d52",
+            "5ffa4b8b2e04309560d78ef88779bd8353f64248129ca24f6d9e7eb9fdb0af6c",
             "z3-{0}-x64-glibc-2.31",
         ),
         (
             "darwin",
-            "https://github.com/Z3Prover/z3/releases/download/z3-{0}/z3-{0}-x64-osx-10.15.7.zip",
-            "a1f6ef3c99456147c4d3f2652dc6bc90951c4ab3fe7741a255eb794f0ab8938c",
-            "z3-{0}-x64-osx-10.15.7",
+            "https://github.com/Z3Prover/z3/releases/download/z3-{0}/z3-{0}-x64-osx-10.16.zip",
+            "",
+            "z3-{0}-x64-osx-10.16",
         ),
     ]
 


### PR DESCRIPTION
This PR updates Z3 to version 4.8.14 and swaps it to be built using the cmake build system.