### PR TITLE
Implement `FpExt` and `FpTrunc` within `Z3Solver`

### DIFF
--- a/src/IR/Operation.cpp
+++ b/src/IR/Operation.cpp
@@ -2,6 +2,7 @@
 #include "Operation.h"
 #include "caffeine/IR/Type.h"
 #include "caffeine/IR/Value.h"
+#include "caffeine/Support/LLVMFmt.h"
 #include "caffeine/Support/Macros.h"
 
 #include <boost/algorithm/string.hpp>
@@ -202,9 +203,11 @@ static std::ostream& print_cons(std::ostream& os, const Ts&... values) {
 
 std::ostream& operator<<(std::ostream& os, const Operation& op) {
   if (const auto* constant = llvm::dyn_cast<Constant>(&op)) {
+    std::string label = fmt::format("const.{}", op.type().bitwidth());
+
     if (constant->is_named())
-      return print_cons(os, "const", constant->name());
-    return print_cons(os, "const", constant->number());
+      return print_cons(os, label, constant->name());
+    return print_cons(os, label, constant->number());
   }
 
   if (const auto* constant = llvm::dyn_cast<ConstantInt>(&op)) {
@@ -216,10 +219,7 @@ std::ostream& operator<<(std::ostream& os, const Operation& op) {
   }
 
   if (const auto* constant = llvm::dyn_cast<ConstantFloat>(&op)) {
-    std::string s;
-    llvm::raw_string_ostream o(s);
-    constant->value().print(o);
-    return print_cons(os, op.type(), s);
+    return print_cons(os, op.type(), fmt::format("{}", constant->value()));
   }
 
   if (const auto* function = llvm::dyn_cast<FunctionObject>(&op)) {

--- a/src/Interpreter/ExternalFuncs/CaffeineBuiltinResolve.cpp
+++ b/src/Interpreter/ExternalFuncs/CaffeineBuiltinResolve.cpp
@@ -19,8 +19,6 @@ namespace {
         return;
       }
 
-      fmt::print("{}\n", *func);
-
       if (func->getReturnType() != func->getArg(0)->getType() ||
           !func->getReturnType()->isPointerTy()) {
         ctx.fail("invalid caffeine_builtin_resolve signature (invalid first "

--- a/src/Solver/Z3/Convert.cpp
+++ b/src/Solver/Z3/Convert.cpp
@@ -462,7 +462,14 @@ z3::expr Z3OpVisitor::visitFpExt(const UnaryOp& op) {
   return expr;
 }
 z3::expr Z3OpVisitor::visitFpTrunc(const UnaryOp& op) {
-  CAFFEINE_UNOP_UNIMPLEMENTED(op);
+  z3::expr src = visit(*op.operand());
+  z3::sort tgt = type_to_sort(src.ctx(), op.type());
+
+  z3::expr expr{src.ctx(),
+                Z3_mk_fpa_to_fp_float(src.ctx(), src.ctx().fpa_rounding_mode(),
+                                      src, tgt)};
+  src.ctx().check_error();
+  return expr;
 }
 
 z3::expr Z3OpVisitor::visitLoad(const LoadOp& op) {

--- a/src/Solver/Z3/Convert.cpp
+++ b/src/Solver/Z3/Convert.cpp
@@ -452,7 +452,14 @@ z3::expr Z3OpVisitor::visitFpToUI(const UnaryOp& op) {
   return expr;
 }
 z3::expr Z3OpVisitor::visitFpExt(const UnaryOp& op) {
-  CAFFEINE_UNOP_UNIMPLEMENTED(op);
+  z3::expr src = visit(*op.operand());
+  z3::sort tgt = type_to_sort(src.ctx(), op.type());
+
+  z3::expr expr{src.ctx(),
+                Z3_mk_fpa_to_fp_float(src.ctx(), src.ctx().fpa_rounding_mode(),
+                                      src, tgt)};
+  src.ctx().check_error();
+  return expr;
 }
 z3::expr Z3OpVisitor::visitFpTrunc(const UnaryOp& op) {
   CAFFEINE_UNOP_UNIMPLEMENTED(op);

--- a/test/regression/issue-618.pass.requires-fpext.c
+++ b/test/regression/issue-618.pass.requires-fpext.c
@@ -1,0 +1,7 @@
+#include "caffeine.h"
+#include <float.h>
+#include <limits.h>
+
+void test(float x) {
+  caffeine_assert((double)x != DBL_MIN);
+}

--- a/test/regression/issue-619.pass.requires-fptrunc.c
+++ b/test/regression/issue-619.pass.requires-fptrunc.c
@@ -1,0 +1,8 @@
+#include "caffeine.h"
+#include <float.h>
+#include <limits.h>
+
+void test(double x) {
+  caffeine_assume(x < 2.0);
+  caffeine_assert((float)x != 4.0f);
+}

--- a/test/unit/Solver/Z3Solver.cpp
+++ b/test/unit/Solver/Z3Solver.cpp
@@ -1,9 +1,14 @@
 
 #include "src/Solver/Z3Solver.h"
+#include "caffeine/IR/Operation.h"
+#include "caffeine/Solver/Z3/Convert.h"
+#include "caffeine/Support/LLVMFmt.h"
+#include <fmt/format.h>
+#include <fmt/ostream.h>
 
 #include <gtest/gtest.h>
 
-using caffeine::z3_to_apfloat;
+using namespace caffeine;
 
 class Z3ConversionTests : public ::testing::Test {
 public:
@@ -66,4 +71,16 @@ TEST_F(Z3ConversionTests, dbl_max_to_apfloat) {
 
   ASSERT_TRUE(val.isFiniteNonZero());
   ASSERT_EQ(val.convertToDouble(), DBL_MAX);
+}
+
+TEST_F(Z3ConversionTests, apfloat_f32_to_z3_roundtrip) {
+  Z3ConstMap map;
+  z3::solver solver{ctx};
+
+  auto flt = llvm::APFloat(4.0f);
+  auto val = ConstantFloat::Create(flt);
+  auto fpa = Z3OpVisitor(&solver, map).visit(*val);
+  auto res = z3_to_apfloat(fpa);
+
+  ASSERT_TRUE(flt == res) << fmt::format("{} != {}", flt, res);
 }

--- a/test/unit/Solver/Z3Solver.cpp
+++ b/test/unit/Solver/Z3Solver.cpp
@@ -80,7 +80,10 @@ TEST_F(Z3ConversionTests, apfloat_f32_to_z3_roundtrip) {
   auto flt = llvm::APFloat(4.0f);
   auto val = ConstantFloat::Create(flt);
   auto fpa = Z3OpVisitor(&solver, map).visit(*val);
-  auto res = z3_to_apfloat(fpa);
+
+  solver.check();
+  auto model = solver.get_model();
+  auto res = z3_to_apfloat(model.eval(fpa));
 
   ASSERT_TRUE(flt == res) << fmt::format("{} != {}", flt, res);
 }


### PR DESCRIPTION
As in title. I've added some test cases that are pretty basic but do fail without this change. Stacked on top of #630 since that issue fixes the underlying issue causing the newly-added tests to fail.

Closes #618
Closes #619 
Closes #605 

/stack #630 