### PR TITLE
Implement `llvm.abs.*` intrinsic and fix `ICmpOp`

### DIFF
--- a/include/caffeine/Interpreter/ExternalFunction.h
+++ b/include/caffeine/Interpreter/ExternalFunction.h
@@ -96,6 +96,7 @@ private:
  */
 class Intrinsics {
 public:
+  static std::unique_ptr<ExternalFunction> abs();
   static std::unique_ptr<ExternalFunction> smul_with_overflow();
   static std::unique_ptr<ExternalFunction> umul_with_overflow();
 

--- a/src/IR/Operation.cpp
+++ b/src/IR/Operation.cpp
@@ -741,7 +741,14 @@ OpRef ICmpOp::CreateICmp(ICmpOpcode cmp, int64_t lhs, const OpRef& rhs) {
       rhs);
 }
 OpRef ICmpOp::CreateICmp(ICmpOpcode cmp, const OpRef& lhs, int64_t rhs) {
-  return ICmpOp::CreateICmp(cmp, rhs, lhs);
+  CAFFEINE_ASSERT(lhs, "rhs was null");
+  CAFFEINE_ASSERT(lhs->type().is_int(),
+                  "icmp can only be created with integer operands");
+
+  auto literal = llvm::APInt(64, static_cast<uint64_t>(rhs));
+  return ICmpOp::CreateICmp(
+      cmp, lhs,
+      ConstantInt::Create(literal.sextOrTrunc(lhs->type().bitwidth())));
 }
 
 /***************************************************

--- a/src/Interpreter/CaffeineContext.cpp
+++ b/src/Interpreter/CaffeineContext.cpp
@@ -163,6 +163,7 @@ Builder& Builder::with_default_functions() {
 }
 
 Builder& Builder::with_default_intrinsics() {
+  with_intrinsic(llvm::Intrinsic::abs, Intrinsics::abs());
   with_intrinsic(llvm::Intrinsic::umul_with_overflow,
                  Intrinsics::umul_with_overflow());
   with_intrinsic(llvm::Intrinsic::smul_with_overflow,

--- a/src/Interpreter/Intrinsics/llvm.abs.cpp
+++ b/src/Interpreter/Intrinsics/llvm.abs.cpp
@@ -1,0 +1,44 @@
+#include "caffeine/IR/Value.h"
+#include "caffeine/Interpreter/ExternalFunction.h"
+#include "caffeine/Interpreter/Interpreter.h"
+
+namespace caffeine {
+
+namespace {
+  class AbsIntrinsic : public ExternalFunction {
+  public:
+    void call(llvm::Function* func, InterpreterContext& ctx,
+              Span<LLVMValue> args) const {
+      CAFFEINE_ASSERT(args.size() == 2);
+      CAFFEINE_ASSERT(args[0].is_scalar(),
+                      "Vector operation not supported yet");
+
+      auto should_poison = args[1].scalar().expr();
+      auto val_to_abs = args[0].scalar().expr();
+      auto ret_ty = func->getReturnType();
+
+      auto min_val = ConstantInt::Create(
+          llvm::APInt::getSignedMinValue(ret_ty->getIntegerBitWidth()));
+      auto is_min = ICmpOp::CreateICmpEQ(val_to_abs, min_val);
+
+      Assertion will_succeed = Assertion(BinaryOp::CreateOr(
+          ctx.createNot(should_poison), UnaryOp::CreateNot(is_min)));
+
+      ctx.assert_or_fail(will_succeed,
+                         "Taking absolute number of minimum value");
+
+      auto result = SelectOp::Create(
+          is_min, min_val,
+          SelectOp::Create(ICmpOp::CreateICmpSLT(val_to_abs, 0),
+                           BinaryOp::CreateMul(-1, val_to_abs), val_to_abs));
+
+      ctx.jump_return(LLVMValue(result));
+    }
+  };
+} // namespace
+
+std::unique_ptr<ExternalFunction> Intrinsics::abs() {
+  return std::make_unique<AbsIntrinsic>();
+}
+
+} // namespace caffeine

--- a/test/run-fail/abs/basic-abs.c
+++ b/test/run-fail/abs/basic-abs.c
@@ -1,0 +1,9 @@
+
+#include "caffeine.h"
+#include <stdint.h>
+#include <stdlib.h>
+
+void test(int32_t x) {
+  caffeine_assume(x < 0);
+  caffeine_assert(abs(x) == -x);
+}

--- a/test/run-pass/abs/basic-abs.c
+++ b/test/run-pass/abs/basic-abs.c
@@ -1,0 +1,9 @@
+
+#include "caffeine.h"
+#include <stdint.h>
+#include <stdlib.h>
+
+void test(int32_t x) {
+  caffeine_assume(x < 0 && x != INT32_MIN);
+  caffeine_assert(abs(x) == -x);
+}


### PR DESCRIPTION
This PR fixes a bug in `ICmpOp` where a constructor assumed that the operands are interchangeable and also implements the `llvm.abs.*` intrinsic