### PR TITLE
Fix conversion of `ConstantFloat` to `z3::expr`

### DIFF
--- a/src/Interpreter/ExternalFuncs/CaffeineBuiltinResolve.cpp
+++ b/src/Interpreter/ExternalFuncs/CaffeineBuiltinResolve.cpp
@@ -19,8 +19,6 @@ namespace {
         return;
       }
 
-      fmt::print("{}\n", *func);
-
       if (func->getReturnType() != func->getArg(0)->getType() ||
           !func->getReturnType()->isPointerTy()) {
         ctx.fail("invalid caffeine_builtin_resolve signature (invalid first "

--- a/test/unit/Solver/Z3Solver.cpp
+++ b/test/unit/Solver/Z3Solver.cpp
@@ -1,9 +1,14 @@
 
 #include "src/Solver/Z3Solver.h"
+#include "caffeine/IR/Operation.h"
+#include "caffeine/Solver/Z3/Convert.h"
+#include "caffeine/Support/LLVMFmt.h"
+#include <fmt/format.h>
+#include <fmt/ostream.h>
 
 #include <gtest/gtest.h>
 
-using caffeine::z3_to_apfloat;
+using namespace caffeine;
 
 class Z3ConversionTests : public ::testing::Test {
 public:
@@ -66,4 +71,16 @@ TEST_F(Z3ConversionTests, dbl_max_to_apfloat) {
 
   ASSERT_TRUE(val.isFiniteNonZero());
   ASSERT_EQ(val.convertToDouble(), DBL_MAX);
+}
+
+TEST_F(Z3ConversionTests, apfloat_f32_to_z3_roundtrip) {
+  Z3ConstMap map;
+  z3::solver solver{ctx};
+
+  auto flt = llvm::APFloat(4.0f);
+  auto val = ConstantFloat::Create(flt);
+  auto fpa = Z3OpVisitor(&solver, map).visit(*val);
+  auto res = z3_to_apfloat(fpa);
+
+  ASSERT_TRUE(flt == res) << fmt::format("{} != {}", flt, res);
 }

--- a/test/unit/Solver/Z3Solver.cpp
+++ b/test/unit/Solver/Z3Solver.cpp
@@ -80,7 +80,10 @@ TEST_F(Z3ConversionTests, apfloat_f32_to_z3_roundtrip) {
   auto flt = llvm::APFloat(4.0f);
   auto val = ConstantFloat::Create(flt);
   auto fpa = Z3OpVisitor(&solver, map).visit(*val);
-  auto res = z3_to_apfloat(fpa);
+
+  solver.check();
+  auto model = solver.get_model();
+  auto res = z3_to_apfloat(model.eval(fpa));
 
   ASSERT_TRUE(flt == res) << fmt::format("{} != {}", flt, res);
 }


### PR DESCRIPTION
See the text of issue #629 for a more detailed explanation of the underlying bug. This fixes #629 by first converting the `APFloat` to an `APFloat` containing its bit-representation and then reusing the bitcast logic to convert that back to a floating-point `z3::expr`.