### PR TITLE
Add time-limited and count-limited execution context stores

### DIFF
--- a/include/caffeine/Interpreter/Store.h
+++ b/include/caffeine/Interpreter/Store.h
@@ -35,6 +35,10 @@ public:
   // By default this will just call add_context in a loop.
   virtual void add_context_multi(Span<Context> contexts);
 
+  // Indicate that the current context should shut down. By default this is a
+  // no-op but some derived contexts may need it.
+  virtual void shutdown() {}
+
 protected:
   ExecutionContextStore(ExecutionContextStore&&) = default;
   ExecutionContextStore(const ExecutionContextStore&) = default;
@@ -60,7 +64,7 @@ public:
   void add_context(Context&& ctx) override;
   void add_context_multi(Span<Context> contexts) override;
 
-  void shutdown();
+  void shutdown() override;
 
 private:
   Context dequeue();

--- a/include/caffeine/Interpreter/Store/CountLimitedStore.h
+++ b/include/caffeine/Interpreter/Store/CountLimitedStore.h
@@ -1,0 +1,29 @@
+#pragma once
+
+#include "caffeine/Interpreter/Store.h"
+#include <atomic>
+
+namespace caffeine {
+
+// An execution context store that will only return at most a limited number of
+// contexts.
+//
+// This is useful for limiting the runtime of caffeine. Note that the limit
+// figure here is the number of contexts that have been removed from the store
+// and will not match the progress bar displayed in the terminal.
+class CountLimitedStore : public ExecutionContextStore {
+public:
+  CountLimitedStore(uint64_t context_limit,
+                    std::unique_ptr<ExecutionContextStore>&& store);
+
+  std::optional<Context> next_context() override;
+  void add_context(Context&& ctx) override;
+  void add_context_multi(Span<Context> contexts) override;
+
+private:
+  std::unique_ptr<ExecutionContextStore>&& store;
+  std::atomic<uint64_t> count{0};
+  uint64_t limit;
+};
+
+} // namespace caffeine

--- a/include/caffeine/Interpreter/Store/CountLimitedStore.h
+++ b/include/caffeine/Interpreter/Store/CountLimitedStore.h
@@ -21,7 +21,7 @@ public:
   void add_context_multi(Span<Context> contexts) override;
 
 private:
-  std::unique_ptr<ExecutionContextStore>&& store;
+  std::unique_ptr<ExecutionContextStore> store;
   std::atomic<uint64_t> count{0};
   uint64_t limit;
 };

--- a/include/caffeine/Interpreter/Store/CountLimitedStore.h
+++ b/include/caffeine/Interpreter/Store/CountLimitedStore.h
@@ -20,6 +20,8 @@ public:
   void add_context(Context&& ctx) override;
   void add_context_multi(Span<Context> contexts) override;
 
+  void shutdown() override;
+
 private:
   std::unique_ptr<ExecutionContextStore> store;
   std::atomic<uint64_t> count{0};

--- a/include/caffeine/Interpreter/Store/TimeLimitedStore.h
+++ b/include/caffeine/Interpreter/Store/TimeLimitedStore.h
@@ -1,11 +1,13 @@
 #pragma once
 
 #include "caffeine/Interpreter/Store.h"
-#include <chrono>
 #include <atomic>
+#include <chrono>
 
 namespace caffeine {
 
+// A store that keeps returning new contexts until the provided end time has
+// passed.
 class TimeLimitedStore : public ExecutionContextStore {
 public:
   TimeLimitedStore(std::chrono::time_point<std::chrono::steady_clock> endpoint,

--- a/include/caffeine/Interpreter/Store/TimeLimitedStore.h
+++ b/include/caffeine/Interpreter/Store/TimeLimitedStore.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include "caffeine/Interpreter/Store.h"
+#include <chrono>
+
+namespace caffeine {
+
+class TimeLimitedStore : public ExecutionContextStore {
+public:
+  TimeLimitedStore(std::chrono::time_point<std::chrono::steady_clock> endpoint,
+                   std::unique_ptr<ExecutionContextStore>&& store);
+
+  std::optional<Context> next_context() override;
+  void add_context(Context&& ctx) override;
+  void add_context_multi(Span<Context> contexts) override;
+
+private:
+  std::unique_ptr<ExecutionContextStore> store;
+  std::chrono::time_point<std::chrono::steady_clock> endpoint;
+};
+
+} // namespace caffeine

--- a/include/caffeine/Interpreter/Store/TimeLimitedStore.h
+++ b/include/caffeine/Interpreter/Store/TimeLimitedStore.h
@@ -2,6 +2,7 @@
 
 #include "caffeine/Interpreter/Store.h"
 #include <chrono>
+#include <atomic>
 
 namespace caffeine {
 
@@ -14,9 +15,12 @@ public:
   void add_context(Context&& ctx) override;
   void add_context_multi(Span<Context> contexts) override;
 
+  void shutdown() override;
+
 private:
   std::unique_ptr<ExecutionContextStore> store;
   std::chrono::time_point<std::chrono::steady_clock> endpoint;
+  std::atomic<bool> shutdown_started{false};
 };
 
 } // namespace caffeine

--- a/include/caffeine/Interpreter/ThreadQueueStore.h
+++ b/include/caffeine/Interpreter/ThreadQueueStore.h
@@ -64,7 +64,7 @@ public:
   void add_context(Context&& ctx) override;
   void add_context_multi(Span<Context> ctxs) override;
 
-  void shutdown();
+  void shutdown() override;
 
 private:
   // Lock the store, doesn't ever create a new queue

--- a/src/Interpreter/Store/CountLimitedStore.cpp
+++ b/src/Interpreter/Store/CountLimitedStore.cpp
@@ -10,6 +10,8 @@ CountLimitedStore::CountLimitedStore(
 
 std::optional<Context> CountLimitedStore::next_context() {
   uint64_t current = count.fetch_add(1, std::memory_order_relaxed);
+  if (current == limit)
+    shutdown();
   if (current > limit)
     return std::nullopt;
 
@@ -21,6 +23,10 @@ void CountLimitedStore::add_context(Context&& ctx) {
 }
 void CountLimitedStore::add_context_multi(Span<Context> contexts) {
   store->add_context_multi(contexts);
+}
+
+void CountLimitedStore::shutdown() {
+  store->shutdown();
 }
 
 } // namespace caffeine

--- a/src/Interpreter/Store/CountLimitedStore.cpp
+++ b/src/Interpreter/Store/CountLimitedStore.cpp
@@ -1,0 +1,26 @@
+#include "caffeine/Interpreter/Store/CountLimitedStore.h"
+#include <atomic>
+#include <memory>
+
+namespace caffeine {
+
+CountLimitedStore::CountLimitedStore(
+    uint64_t context_limit, std::unique_ptr<ExecutionContextStore>&& store)
+    : store(std::move(store)), limit(context_limit) {}
+
+std::optional<Context> CountLimitedStore::next_context() {
+  uint64_t current = count.fetch_add(1, std::memory_order_relaxed);
+  if (current > limit)
+    return std::nullopt;
+
+  return store->next_context();
+}
+
+void CountLimitedStore::add_context(Context&& ctx) {
+  store->add_context(std::move(ctx));
+}
+void CountLimitedStore::add_context_multi(Span<Context> contexts) {
+  store->add_context_multi(contexts);
+}
+
+} // namespace caffeine

--- a/src/Interpreter/Store/ThreadQueueStore.cpp
+++ b/src/Interpreter/Store/ThreadQueueStore.cpp
@@ -72,13 +72,6 @@ ThreadQueueContextStore::ThreadQueueContextStore(unsigned numthreads)
 ThreadQueueContextStore::~ThreadQueueContextStore() {
   if (explicit_shutdown)
     return;
-
-  for (auto& [id, tqueue] : queues) {
-    auto& queue = tqueue->queue;
-    CAFFEINE_ASSERT(
-        queue.empty(),
-        "ThreadQueueContextStore shut down with elments still in queues.");
-  }
 }
 
 std::optional<Context> ThreadQueueContextStore::next_context() {

--- a/src/Interpreter/Store/TimeLimitedStore.cpp
+++ b/src/Interpreter/Store/TimeLimitedStore.cpp
@@ -1,0 +1,29 @@
+#include "caffeine/Interpreter/Store/TimeLimitedStore.h"
+#include "caffeine/Interpreter/Context.h"
+#include <chrono>
+#include <tuple>
+
+namespace caffeine {
+
+TimeLimitedStore::TimeLimitedStore(
+    std::chrono::time_point<std::chrono::steady_clock> endpoint,
+    std::unique_ptr<ExecutionContextStore>&& store)
+    : store(std::move(store)), endpoint(endpoint) {}
+
+std::optional<Context> TimeLimitedStore::next_context() {
+  auto now = std::chrono::steady_clock::now();
+
+  if (now > endpoint)
+    return std::nullopt;
+
+  return store->next_context();
+}
+
+void TimeLimitedStore::add_context(Context&& ctx) {
+  store->add_context(std::move(ctx));
+}
+void TimeLimitedStore::add_context_multi(Span<Context> contexts) {
+  store->add_context_multi(contexts);
+}
+
+} // namespace caffeine

--- a/src/Interpreter/Store/TimeLimitedStore.cpp
+++ b/src/Interpreter/Store/TimeLimitedStore.cpp
@@ -13,8 +13,10 @@ TimeLimitedStore::TimeLimitedStore(
 std::optional<Context> TimeLimitedStore::next_context() {
   auto now = std::chrono::steady_clock::now();
 
-  if (now > endpoint)
+  if (now > endpoint) {
+    shutdown();
     return std::nullopt;
+  }
 
   return store->next_context();
 }
@@ -24,6 +26,11 @@ void TimeLimitedStore::add_context(Context&& ctx) {
 }
 void TimeLimitedStore::add_context_multi(Span<Context> contexts) {
   store->add_context_multi(contexts);
+}
+
+void TimeLimitedStore::shutdown() {
+  if (!shutdown_started.exchange(true))
+    store->shutdown();
 }
 
 } // namespace caffeine

--- a/tools/caffeine/main.cpp
+++ b/tools/caffeine/main.cpp
@@ -108,6 +108,11 @@ cl::opt<uint64_t> limit_contexts{
              "caffeine ends up splitting a context into multiple and then "
              "executing both."),
     cl::cat(caffeine_options), cl::init(0)};
+cl::opt<uint64_t> limit_time_seconds{
+    "limit-time-seconds",
+    cl::desc("Instructs caffeine to stop symbolic execution after the given "
+             "number of seconds have elapsed."),
+    cl::value_desc("seconds"), cl::cat(caffeine_options), cl::init(0)};
 
 static ExitOnError exit_on_err;
 
@@ -184,6 +189,13 @@ int main(int argc, char** argv) {
   if (limit_contexts != 0) {
     store =
         std::make_unique<CountLimitedStore>(limit_contexts, std::move(store));
+  }
+
+  if (limit_time_seconds != 0) {
+    store = std::make_unique<TimeLimitedStore>(
+        std::chrono::steady_clock::now() +
+            std::chrono::seconds(limit_time_seconds),
+        std::move(store));
   }
 
   std::unique_ptr<CoverageTracker> cov = nullptr;


### PR DESCRIPTION
This PR adds two different execution context stores:
- one that only returns at most a certain number of contexts before shutting down
- one that only returns contexts for a certain amount of time before shutting down

It then adds command line options for enabling either or both of these solvers on top of the normal one.

Closes #628