### PR TITLE
Handle `llvm.global_ctors`

### DIFF
--- a/include/caffeine/Interpreter/Context.h
+++ b/include/caffeine/Interpreter/Context.h
@@ -30,6 +30,7 @@ public:
   immer::map<std::string, OpRef> constants;
 
   llvm::Module* mod;
+  bool global_ctors_ran = false;
 
 private:
   uint64_t constant_num_ = 0;

--- a/include/caffeine/Interpreter/ExternalFuncs/ChainCall.h
+++ b/include/caffeine/Interpreter/ExternalFuncs/ChainCall.h
@@ -1,0 +1,29 @@
+#include "caffeine/Interpreter/ExternalFunction.h"
+#include "caffeine/Interpreter/InterpreterContext.h"
+#include "caffeine/Support/LLVMFmt.h"
+#include <boost/range/algorithm/find_if.hpp>
+#include <fmt/format.h>
+#include <iterator>
+#include <llvm/IR/InstrTypes.h>
+#include <llvm/IR/Instructions.h>
+#include <llvm/IR/Module.h>
+
+#include <iostream>
+
+#include "unwind.h"
+
+namespace caffeine {
+
+class ChainCall final : public ExternalStackFrameMixin<ChainCall> {
+public:
+  using ExternalStackFrameMixin<ChainCall>::ExternalStackFrameMixin;
+
+  ChainCall(std::vector<llvm::Function*>&& funcs);
+  void step(InterpreterContext& ctx) override;
+
+private:
+  size_t currFunction = 0;
+  std::vector<llvm::Function*> funcs;
+};
+
+} // namespace caffeine

--- a/include/caffeine/Interpreter/Interpreter.h
+++ b/include/caffeine/Interpreter/Interpreter.h
@@ -73,6 +73,8 @@ public:
 
   void visitDbgInfoIntrinsic(llvm::DbgInfoIntrinsic&);
 
+  void visitGlobalCtors();
+
 private:
   void getInstLine(llvm::Instruction& inst);
   void visitExternFunc(llvm::CallBase& inst);

--- a/libraries/libcxx/CMakeLists.txt
+++ b/libraries/libcxx/CMakeLists.txt
@@ -8,7 +8,7 @@ set_directory_properties(PROPERTIES COMPILE_OPTIONS "-w")
 find_program(JQ jq REQUIRED)
 
 file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/dummy.c" "")
-set(CAFFEINE_LIBCXX_VERSION "v0.0.34")
+set(CAFFEINE_LIBCXX_VERSION "v0.0.39")
 set(RELEASE_URL "https://github.com/insufficiently-caffeinated/libcxx/releases/download/${CAFFEINE_LIBCXX_VERSION}/libcxx.bc")
 
 message("Downloading libcxx.bc from ${RELEASE_URL}")

--- a/src/Interpreter/ContextBacktrace.cpp
+++ b/src/Interpreter/ContextBacktrace.cpp
@@ -43,20 +43,7 @@ void Context::print_backtrace(std::ostream& OS) const {
 
     if (frame_.is_regular()) {
       const auto& frame = frame_.get_regular();
-      if (!frame.current_block || frame.current == frame.current_block->end()) {
-        // We don't have a valid iterator.
-        current = nullptr;
-      } else if (frame.current == frame.current_block->begin()) {
-        // This case probably shouldn't happen but this method gets called when
-        // things are going wrong so we need to handle all possibilities.
-        if (frame.prev_block) {
-          current = &frame.prev_block->back();
-        } else {
-          current = &*frame.current;
-        }
-      } else {
-        current = &*std::prev(frame.current);
-      }
+      current = frame.get_current_instruction();
 
       if (frame.current_block) {
         if (llvm::Function* func = frame.current_block->getParent()) {

--- a/src/Interpreter/ExternalFuncs/ChainCall.cpp
+++ b/src/Interpreter/ExternalFuncs/ChainCall.cpp
@@ -1,0 +1,34 @@
+#include "caffeine/Interpreter/ExternalFuncs/ChainCall.h"
+#include "caffeine/Interpreter/ExternalFunction.h"
+#include "caffeine/Interpreter/InterpreterContext.h"
+#include "caffeine/Support/LLVMFmt.h"
+#include <boost/range/algorithm/find_if.hpp>
+#include <fmt/format.h>
+#include <iterator>
+#include <llvm/IR/InstrTypes.h>
+#include <llvm/IR/Instructions.h>
+#include <llvm/IR/Module.h>
+
+#include <iostream>
+
+#include "unwind.h"
+
+namespace caffeine {
+
+ChainCall::ChainCall(std::vector<llvm::Function*>&& funcs)
+    : ExternalStackFrameMixin({}, nullptr), funcs(std::move(funcs)) {}
+void ChainCall::step(InterpreterContext& ctx) {
+  if (currFunction >= funcs.size()) {
+    ctx.context().stack.pop_back();
+    return;
+  }
+  CAFFEINE_ASSERT(funcs.at(currFunction)->getFunctionType()->getNumParams() ==
+                      0,
+                  "function in chaincall needs operands");
+
+  ctx.context().stack.push_back(
+      StackFrame::RegularFrame(funcs.at(currFunction)));
+  currFunction++;
+}
+
+} // namespace caffeine

--- a/test/run-pass/cpp/global-ctors.cpp
+++ b/test/run-pass/cpp/global-ctors.cpp
@@ -1,0 +1,16 @@
+#include "caffeine.h"
+
+bool initialized = false;
+
+class GlobalInit {
+public:
+  GlobalInit() {
+    initialized = true;
+  }
+};
+
+GlobalInit initializer{};
+
+extern "C" void test() {
+  caffeine_assert(initialized);
+}

--- a/third_party/libcxx/setup.bzl
+++ b/third_party/libcxx/setup.bzl
@@ -4,12 +4,12 @@
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 def setup_libcxx(name):
-    version = "v0.0.34"
+    version = "v0.0.39"
 
     http_archive(
         name = name,
         strip_prefix = "build/libcxx",
         url = "https://github.com/insufficiently-caffeinated/libcxx/releases/download/{}/libcxx.tar.gz".format(version),
         build_file = "@caffeine//third_party/libcxx:build.bzl",
-        sha256 = "3df931bc57e52a6a76d203406b581403dcc1324dac70f7af45a65f463f520ace",
+        sha256 = "566979f706e309c8af7b948eaad1974668cea2754fa0b6ab3cb65474bd25553a",
     )


### PR DESCRIPTION
This PR adds handling for `llvm.global_ctors` which is required for c++ support

Closes #631 