### PR TITLE
Don't force divine to be a shared library

### DIFF
--- a/third_party/divine/CMakeLists.txt
+++ b/third_party/divine/CMakeLists.txt
@@ -11,7 +11,7 @@ file(
   "${CMAKE_CURRENT_SOURCE_DIR}/include/*.h"
 )
 
-add_library(divine SHARED
+add_library(divine
   ${sources} ${headers}
 )
 


### PR DESCRIPTION
This makes it difficult to use caffeine unless it's in a global location.