### PR TITLE
Replace all uses of `InternedString` with `std::string`

### DIFF
--- a/include/caffeine/IR/Operation.h
+++ b/include/caffeine/IR/Operation.h
@@ -18,7 +18,6 @@
 #include "caffeine/ADT/PersistentArray.h"
 #include "caffeine/ADT/Ref.h"
 #include "caffeine/ADT/SharedArray.h"
-#include "caffeine/ADT/StringInterner.h"
 #include "caffeine/IR/Type.h"
 #include "caffeine/Support/Assert.h"
 #include "caffeine/Support/CopyVTable.h"
@@ -61,7 +60,7 @@ private:
 
 public:
   const Symbol& symbol() const;
-  InternedString name() const;
+  std::string_view name() const;
   uint64_t number() const;
 
   bool is_numbered() const;

--- a/include/caffeine/IR/Operation.inl
+++ b/include/caffeine/IR/Operation.inl
@@ -139,7 +139,7 @@ inline const Symbol& Constant::symbol() const {
   return llvm::cast<caffeine::ConstantData>(data_.get())->symbol();
 }
 
-inline InternedString Constant::name() const {
+inline std::string_view Constant::name() const {
   CAFFEINE_ASSERT(is_named(), "tried to access name of unnamed constant");
   return symbol().name();
 }

--- a/include/caffeine/IR/OperationBase.h
+++ b/include/caffeine/IR/OperationBase.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include "caffeine/ADT/PersistentArray.h"
-#include "caffeine/ADT/StringInterner.h"
 #include "caffeine/IR/Symbol.h"
 #include "caffeine/IR/Type.h"
 #include "caffeine/Support/Assert.h"

--- a/include/caffeine/IR/Symbol.h
+++ b/include/caffeine/IR/Symbol.h
@@ -1,7 +1,7 @@
 #pragma once
 
-#include "caffeine/ADT/StringInterner.h"
 #include <iosfwd>
+#include <llvm/ADT/Hashing.h>
 #include <string>
 #include <string_view>
 #include <variant>
@@ -22,7 +22,7 @@ private:
     Numbered = 1,
   };
 
-  std::variant<InternedString, uint64_t> value_;
+  std::variant<std::string, uint64_t> value_;
 
 public:
   Symbol(const std::string& name);
@@ -36,7 +36,7 @@ public:
   bool is_named() const;
   bool is_numbered() const;
 
-  InternedString name() const;
+  std::string_view name() const;
   uint64_t number() const;
 
   bool operator==(const Symbol& symbol) const;

--- a/src/IR/Symbol.cpp
+++ b/src/IR/Symbol.cpp
@@ -2,12 +2,9 @@
 
 namespace caffeine {
 
-Symbol::Symbol(const std::string& name)
-    : value_(StringInterner::default_interner().intern(name)) {}
-Symbol::Symbol(std::string&& name)
-    : value_(StringInterner::default_interner().intern(std::move(name))) {}
-Symbol::Symbol(std::string_view name)
-    : value_(StringInterner::default_interner().intern(name)) {}
+Symbol::Symbol(const std::string& name) : value_(name) {}
+Symbol::Symbol(std::string&& name) : value_(std::move(name)) {}
+Symbol::Symbol(std::string_view name) : Symbol(std::string(name)) {}
 Symbol::Symbol(uint64_t number) : value_(number) {}
 
 std::ostream& operator<<(std::ostream& os, const Symbol& symbol) {
@@ -23,7 +20,7 @@ bool Symbol::is_numbered() const {
   return value_.index() == Numbered;
 }
 
-InternedString Symbol::name() const {
+std::string_view Symbol::name() const {
   return std::get<Named>(value_);
 }
 uint64_t Symbol::number() const {


### PR DESCRIPTION
We don't have enough copies of strings for this to even be remotely near worth it.

/stack #653 