### PR TITLE
Convert `ConstantArray` to use `OperationData` internally

### DIFF
--- a/include/caffeine/IR/Operation.inl
+++ b/include/caffeine/IR/Operation.inl
@@ -170,18 +170,6 @@ inline const llvm::APFloat& ConstantFloat::value() const {
 }
 
 /***************************************************
- * ConstantArray                                   *
- ***************************************************/
-inline const Symbol& ConstantArray::symbol() const {
-  return std::get<ConstantData>(inner_).first;
-}
-
-inline const OpRef& ConstantArray::operand_at(size_t idx) const {
-  CAFFEINE_ASSERT(idx == 0, "Accessed out of bounds operand index");
-  return std::get<ConstantData>(inner_).second;
-}
-
-/***************************************************
  * BinaryOp                                        *
  ***************************************************/
 inline const OpRef& BinaryOp::lhs() const {

--- a/src/IR/Operation.cpp
+++ b/src/IR/Operation.cpp
@@ -100,9 +100,9 @@ OpRef ConstantFloat::Create(double value) {
  * ConstantArray                                   *
  ***************************************************/
 ConstantArray::ConstantArray(Symbol&& symbol, const OpRef& size)
-    : ArrayBase(Operation::ConstantArray,
-                Type::array_ty(size->type().bitwidth()),
-                ConstantData(std::move(symbol), size)) {}
+    : ArrayBase(std::make_unique<caffeine::ConstantData>(
+                    Type::array_ty(size->type().bitwidth()), std::move(symbol)),
+                {size}) {}
 
 OpRef ConstantArray::Create(const Symbol& symbol, const OpRef& size) {
   return Create(Symbol(symbol), size);
@@ -120,6 +120,15 @@ OpRef ConstantArray::with_new_operands(llvm::ArrayRef<OpRef> operands) const {
     return shared_from_this();
 
   return Create(symbol(), operands[0]);
+}
+
+const Symbol& ConstantArray::symbol() const {
+  return llvm::cast<caffeine::ConstantData>(data_.get())->symbol();
+}
+
+const OpRef& ConstantArray::operand_at(size_t idx) const {
+  CAFFEINE_ASSERT(idx == 0, "Accessed out of bounds operand index");
+  return operands_[idx];
 }
 
 /***************************************************


### PR DESCRIPTION
As in title. My ultimate goal with this patch series is to get all the operation classes using `OperationData`.

/stack #660 