### PR TITLE
Convert `BinaryOp` to use `OperationData`

### DIFF
--- a/src/IR/Operation.cpp
+++ b/src/IR/Operation.cpp
@@ -126,7 +126,7 @@ OpRef ConstantArray::with_new_operands(llvm::ArrayRef<OpRef> operands) const {
  * BinaryOp                                        *
  ***************************************************/
 BinaryOp::BinaryOp(Opcode op, Type t, const OpRef& lhs, const OpRef& rhs)
-    : Operation(op, t, lhs, rhs) {}
+    : Operation(std::make_unique<OperationData>(op, t), {lhs, rhs}) {}
 
 OpRef BinaryOp::Create(Opcode op, const OpRef& lhs, const OpRef& rhs) {
   CAFFEINE_ASSERT((op & 0x3) == 2, "Opcode doesn't have 2 operands");


### PR DESCRIPTION
As in title. It turns out that these conversions will always require defining overrides of `operand_at` and `with_new_operands` until I flip the default in `Operation`. This will be fixed once the conversion work is complete.

/stack #660 