### PR TITLE
Allow `Operation::with_new_operands` and `Operation::operand_at` to work with `OperationData`

### DIFF
--- a/include/caffeine/IR/OperationBase.h
+++ b/include/caffeine/IR/OperationBase.h
@@ -311,6 +311,8 @@ public:
   bool operator==(const OperationData& op) const;
   bool operator!=(const OperationData& op) const;
 
+  std::unique_ptr<OperationData> clone() const;
+
   static bool classof(const Operation*) {
     return true;
   }


### PR DESCRIPTION
As in title. This avoids having to implement these for every derived type while I'm converting them.

/stack #654 