### PR TITLE
Convert `FixedArray` to use `OperationData`

### DIFF
--- a/include/caffeine/IR/Operation.def
+++ b/include/caffeine/IR/Operation.def
@@ -145,7 +145,7 @@ HANDLE_UNARY_OP_FIRST(Not)
 
 // Other instructions
 HANDLE_FULL_OP(Select,     Select,     SelectOp,   20, 3, 0)
-HANDLE_FULL_OP(FixedArray, FixedArray, FixedArray, 21, 0, 0)
+HANDLE_FULL_OP(FixedArray, FixedArray, FixedArray, 21, 4, 0)
 
 // Allocation instructions
 /**

--- a/include/caffeine/IR/Operation.h
+++ b/include/caffeine/IR/Operation.h
@@ -428,18 +428,12 @@ public:
  */
 class FixedArray final : public ArrayBase {
 private:
-  FixedArray(Type t, const PersistentArray<OpRef>& data);
+  FixedArray(Type t, llvm::ArrayRef<OpRef> data);
 
 public:
-  const PersistentArray<OpRef>& data() const;
+  llvm::ArrayRef<OpRef> data() const;
 
-  size_t num_operands() const override;
-
-  OpRef with_new_operands(llvm::ArrayRef<OpRef> operands) const override;
-
-  const OpRef& operand_at(size_t i) const override;
-
-  static OpRef Create(Type index_ty, const PersistentArray<OpRef>& data);
+  static OpRef Create(Type index_ty, llvm::ArrayRef<OpRef> data);
   static OpRef Create(Type index_ty, const OpRef& value, size_t size);
 
   static bool classof(const Operation* op);

--- a/include/caffeine/IR/Operation.inl
+++ b/include/caffeine/IR/Operation.inl
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <caffeine/ADT/PersistentArray.h>
 #ifndef CAFFEINE_IR_OPERATION_INL
 #define CAFFEINE_IR_OPERATION_INL
 
@@ -260,21 +261,6 @@ inline const OpRef& StoreOp::offset() const {
 
 inline const OpRef& StoreOp::value() const {
   return operand_at(2);
-}
-
-/***************************************************
- * FixedArray                                      *
- ***************************************************/
-inline const PersistentArray<OpRef>& FixedArray::data() const {
-  return std::get<PersistentArray<OpRef>>(inner_);
-}
-
-inline size_t FixedArray::num_operands() const {
-  return data().size();
-}
-
-inline const OpRef& FixedArray::operand_at(size_t i) const {
-  return data().get(i);
 }
 
 /***************************************************

--- a/include/caffeine/IR/OperationBuilder.h
+++ b/include/caffeine/IR/OperationBuilder.h
@@ -125,7 +125,7 @@ public:
   OpRef createStore(const OpRef& data, const OpRef& offset, const OpRef& value);
   OpRef createUndef(Type t);
 
-  OpRef createFixedArray(Type index_ty, const PersistentArray<OpRef>& data);
+  OpRef createFixedArray(Type index_ty, llvm::ArrayRef<OpRef> data);
   OpRef createFixedArray(Type index_ty, const OpRef& value, size_t size);
 
   OpRef createFunctionObject(llvm::Function* function);

--- a/src/IR/OperationBuilder.cpp
+++ b/src/IR/OperationBuilder.cpp
@@ -227,7 +227,7 @@ OpRef OperationBuilder::createUndef(Type t) {
 }
 
 OpRef OperationBuilder::createFixedArray(Type index_ty,
-                                         const PersistentArray<OpRef>& data) {
+                                         llvm::ArrayRef<OpRef> data) {
   return FixedArray::Create(index_ty, data);
 }
 OpRef OperationBuilder::createFixedArray(Type index_ty, const OpRef& value,

--- a/src/IR/OperationSimplifier.cpp
+++ b/src/IR/OperationSimplifier.cpp
@@ -519,8 +519,8 @@ OpRef OperationSimplifier::visitStoreOp(StoreOp& op) {
   const auto* fixedarray = llvm::dyn_cast<FixedArray>(op.data().get());
 
   if (offset_cnst && fixedarray) {
-    auto data = fixedarray->data();
-    data.set(offset_cnst->value().getLimitedValue(), op.value());
+    auto data = fixedarray->data().vec();
+    data[offset_cnst->value().getLimitedValue()] = op.value();
     return FixedArray::Create(op.offset()->type(), data);
   } else if (fixedarray) {
     auto cached = OperationCache::default_cache()->intern(op.data());

--- a/src/IR/Operations/ArrayBase.cpp
+++ b/src/IR/Operations/ArrayBase.cpp
@@ -12,8 +12,8 @@ OpRef ArrayBase::size() const {
   case Store:
     return llvm::cast<ArrayBase>(*operand_at(0)).size();
   case FixedArray:
-    return ConstantInt::Create(llvm::APInt(
-        type().bitwidth(), std::get<PersistentArray<OpRef>>(inner_).size()));
+    return ConstantInt::Create(
+        llvm::APInt(type().bitwidth(), operands_.size()));
   }
 
   CAFFEINE_UNIMPLEMENTED("unexpected ArrayBase opcode");

--- a/src/Interpreter/ExternalFuncs/CaffeineSymbolicAlloca.cpp
+++ b/src/Interpreter/ExternalFuncs/CaffeineSymbolicAlloca.cpp
@@ -154,7 +154,7 @@ namespace {
           constants.push_back(Constant::Create(
               Type::int_ty(8), Symbol(ctx.context().next_constant())));
         }
-        return FixedArray::Create(type, PersistentArray<OpRef>(constants));
+        return FixedArray::Create(type, constants);
       }
     }
   };


### PR DESCRIPTION
This one ended up being a bit more involved. In addition to directly converting `FixedArray` to use `OperationData`, it also ended up replacing every location in the code that actually used `PersistentArray`. This will likely result in some increase in memory usage but for now it should be a small issue.