### PR TITLE
Delete the internal variant within `Operation`

### DIFF
--- a/include/caffeine/IR/Operation.h
+++ b/include/caffeine/IR/Operation.h
@@ -136,10 +136,6 @@ public:
   static OpRef Create(const Symbol& symbol, const OpRef& size);
   static OpRef Create(Symbol&& symbol, const OpRef& size);
 
-  OpRef with_new_operands(llvm::ArrayRef<OpRef> operands) const override;
-
-  const OpRef& operand_at(size_t idx) const override;
-
   static bool classof(const Operation* op);
 };
 

--- a/include/caffeine/IR/OperationBase.h
+++ b/include/caffeine/IR/OperationBase.h
@@ -152,17 +152,10 @@ public:
   };
 
 protected:
-  using ConstantData = std::pair<Symbol, OpRef>;
-  using FixedData = PersistentArray<OpRef>;
-  using OpVec = boost::container::static_vector<OpRef, 3>;
-  using Inner = std::variant<std::monostate, OpVec, llvm::APInt, llvm::APFloat,
-                             FixedData, ConstantData, llvm::Function*>;
-
   uint16_t opcode_;
   uint16_t dummy_ = 0; // Unused, used for padding
 
   Type type_;
-  Inner inner_;
 
   std::unique_ptr<OperationData> data_;
   llvm::SmallVector<OpRef, 4> operands_;
@@ -174,18 +167,8 @@ protected:
             std::initializer_list<OpRef> operands = {});
   Operation(std::unique_ptr<OperationData>&& data,
             llvm::ArrayRef<OpRef> operands);
-  Operation(Opcode op, Type t, const Inner& inner);
-  Operation(Opcode op, Type t, Inner&& inner);
-
-  Operation(Opcode op, Type t, const OpRef* operands);
-
-  Operation(Opcode op, Type t, const OpRef& op0);
-  Operation(Opcode op, Type t, const OpRef& op0, const OpRef& op1);
-  Operation(Opcode op, Type t, const OpRef& op0, const OpRef& op1,
-            const OpRef& op2);
 
   Operation();
-  Operation(Opcode op, Type t);
 
   using CopyVTable::copy_vtable;
 

--- a/include/caffeine/IR/OperationBase.h
+++ b/include/caffeine/IR/OperationBase.h
@@ -117,8 +117,7 @@ enum class FCmpOpcode : uint8_t {
  *    Visitor.cpp. This may also require adding new built-in methods to the
  *    Value type.
  */
-class Operation : private CopyVTable,
-                  public std::enable_shared_from_this<Operation> {
+class Operation : public std::enable_shared_from_this<Operation> {
 protected:
   // Base opcode used for FCmp opcodes
   static constexpr uint16_t fcmp_base = CAFFEINE_FCMP_BASE;
@@ -152,9 +151,6 @@ public:
   };
 
 protected:
-  uint16_t opcode_;
-  uint16_t dummy_ = 0; // Unused, used for padding
-
   Type type_;
 
   std::unique_ptr<OperationData> data_;
@@ -169,8 +165,6 @@ protected:
             llvm::ArrayRef<OpRef> operands);
 
   Operation();
-
-  using CopyVTable::copy_vtable;
 
 public:
   /**
@@ -230,9 +224,8 @@ public:
    */
   const OpRef& operand_at(size_t idx) const;
 
-  // Need to define this since refcount shouldn't be copied/moved.
-  Operation(Operation&& op) noexcept;
-  Operation& operator=(Operation&& op) noexcept;
+  Operation(Operation&& op) noexcept = default;
+  Operation& operator=(Operation&& op) noexcept = default;
 
   // Need to force operation to have a vtable
   virtual ~Operation() = default;

--- a/include/caffeine/IR/OperationBase.h
+++ b/include/caffeine/IR/OperationBase.h
@@ -227,8 +227,7 @@ public:
   Operation(Operation&& op) = default;
   Operation& operator=(Operation&& op) = default;
 
-  // Need to force operation to have a vtable
-  virtual ~Operation() = default;
+  ~Operation() = default;
 
 protected:
   /**

--- a/include/caffeine/IR/OperationBase.h
+++ b/include/caffeine/IR/OperationBase.h
@@ -224,8 +224,8 @@ public:
    */
   const OpRef& operand_at(size_t idx) const;
 
-  Operation(Operation&& op) noexcept = default;
-  Operation& operator=(Operation&& op) noexcept = default;
+  Operation(Operation&& op) = default;
+  Operation& operator=(Operation&& op) = default;
 
   // Need to force operation to have a vtable
   virtual ~Operation() = default;

--- a/include/caffeine/IR/OperationBase.h
+++ b/include/caffeine/IR/OperationBase.h
@@ -204,8 +204,8 @@ public:
   typedef detail::operand_iterator operand_iterator;
   typedef detail::operand_iterator const_operand_iterator;
 
-  virtual size_t num_operands() const;
-  virtual llvm::iterator_range<const_operand_iterator> operands() const;
+  size_t num_operands() const;
+  llvm::iterator_range<const_operand_iterator> operands() const;
 
   const Operation& operator[](size_t idx) const;
 
@@ -223,12 +223,12 @@ public:
    * Create a new operation using the same opcode as the current one but with
    * new operands.
    */
-  virtual OpRef with_new_operands(llvm::ArrayRef<OpRef> operands) const;
+  OpRef with_new_operands(llvm::ArrayRef<OpRef> operands) const;
 
   /**
    * Accessors to operand references.
    */
-  virtual const OpRef& operand_at(size_t idx) const;
+  const OpRef& operand_at(size_t idx) const;
 
   // Need to define this since refcount shouldn't be copied/moved.
   Operation(Operation&& op) noexcept;

--- a/src/IR/Operation.cpp
+++ b/src/IR/Operation.cpp
@@ -113,22 +113,8 @@ OpRef ConstantArray::Create(Symbol&& symbol, const OpRef& size) {
   return constant_fold(ConstantArray(std::move(symbol), size));
 }
 
-OpRef ConstantArray::with_new_operands(llvm::ArrayRef<OpRef> operands) const {
-  CAFFEINE_ASSERT(operands.size() == 1);
-
-  if (size() == operands[0])
-    return shared_from_this();
-
-  return Create(symbol(), operands[0]);
-}
-
 const Symbol& ConstantArray::symbol() const {
   return llvm::cast<caffeine::ConstantData>(data_.get())->symbol();
-}
-
-const OpRef& ConstantArray::operand_at(size_t idx) const {
-  CAFFEINE_ASSERT(idx == 0, "Accessed out of bounds operand index");
-  return operands_[idx];
 }
 
 /***************************************************

--- a/src/IR/Operation.cpp
+++ b/src/IR/Operation.cpp
@@ -630,7 +630,7 @@ OpRef FunctionObject::Create(llvm::Function* function) {
 /***************************************************
  * hashing implementations                         *
  ***************************************************/
-static llvm::hash_code hash_value(const OpRef& op) {
+llvm::hash_code hash_value(const OpRef& op) {
   return std::hash<OpRef>()(op);
 }
 
@@ -641,20 +641,7 @@ llvm::hash_code hash_value(const Operation& op) {
   if (op.data_)
     hash = llvm::hash_combine(*op.data_);
 
-  return std::visit(
-      [&](const auto& v) {
-        using type = std::decay_t<decltype(v)>;
-
-        if constexpr (std::is_same_v<type, Operation::OpVec>) {
-          return llvm::hash_combine(
-              hash, llvm::hash_combine_range(v.begin(), v.end()));
-        } else if constexpr (std::is_same_v<type, std::monostate>) {
-          return llvm::hash_combine(hash, std::hash<type>()(v));
-        } else {
-          return llvm::hash_combine(hash, v);
-        }
-      },
-      op.inner_);
+  return hash;
 }
 llvm::hash_code hash_value(const Symbol& symbol) {
   return std::visit(

--- a/src/IR/OperationBase.cpp
+++ b/src/IR/OperationBase.cpp
@@ -35,57 +35,15 @@ Operation::Operation(std::unique_ptr<OperationData>&& data,
   }
 }
 
-Operation::Operation(Opcode op, Type t, const Inner& inner)
-    : opcode_(static_cast<uint16_t>(op)), type_(t), inner_(inner) {}
-Operation::Operation(Opcode op, Type t, Inner&& inner)
-    : opcode_(static_cast<uint16_t>(op)), type_(t), inner_(std::move(inner)) {}
-
-Operation::Operation(Opcode op, Type t)
-    : opcode_(static_cast<uint16_t>(op)), type_(t), inner_(std::monostate()) {}
-
-Operation::Operation(Opcode op, Type t, const OpRef* operands)
-    : opcode_(static_cast<uint16_t>(op)), type_(t),
-      inner_(OpVec(operands, operands + detail::opcode_nargs(opcode_))) {
-  CAFFEINE_ASSERT(detail::opcode_base(opcode_) != 1,
-                  "Tried to create a constant with operands");
-  // Don't use this constructor to create an invalid opcode.
-  // It'll mess up constructors and destructors.
-  CAFFEINE_ASSERT(op != Invalid);
-  // No opcodes have > 3 operands
-  CAFFEINE_ASSERT(detail::opcode_nargs(opcode_) <= 3, "Invalid opcode");
-}
-
-Operation::Operation(Opcode op, Type t, const OpRef& op0)
-    : opcode_(static_cast<uint16_t>(op)), type_(t), inner_(OpVec{op0}) {
-  CAFFEINE_ASSERT(detail::opcode_base(opcode_) != 1,
-                  "Tried to create a constant with operands");
-  CAFFEINE_ASSERT(detail::opcode_nargs(opcode_) == 1);
-}
-Operation::Operation(Opcode op, Type t, const OpRef& op0, const OpRef& op1)
-    : opcode_(static_cast<uint16_t>(op)), type_(t), inner_(OpVec{op0, op1}) {
-  CAFFEINE_ASSERT(detail::opcode_base(opcode_) != 1,
-                  "Tried to create a constant with operands");
-  CAFFEINE_ASSERT(detail::opcode_nargs(opcode_) == 2);
-}
-Operation::Operation(Opcode op, Type t, const OpRef& op0, const OpRef& op1,
-                     const OpRef& op2)
-    : opcode_(static_cast<uint16_t>(op)), type_(t),
-      inner_(OpVec{op0, op1, op2}) {
-  CAFFEINE_ASSERT(detail::opcode_base(opcode_) != 1,
-                  "Tried to create a constant with operands");
-  CAFFEINE_ASSERT(detail::opcode_nargs(opcode_) == 3);
-}
-
 Operation::Operation(Operation&& op) noexcept
     : std::enable_shared_from_this<Operation>(), opcode_(op.opcode_),
-      type_(op.type_), inner_(std::move(op.inner_)), data_(std::move(op.data_)),
+      type_(op.type_), data_(std::move(op.data_)),
       operands_(std::move(op.operands_)) {
   copy_vtable(op);
   op.reset();
 }
 
 Operation& Operation::operator=(Operation&& op) noexcept {
-  inner_ = std::move(op.inner_);
   data_ = std::move(op.data_);
   operands_ = std::move(op.operands_);
   type_ = op.type_;
@@ -102,7 +60,6 @@ void Operation::reset() {
   type_ = Type::void_ty();
   operands_.clear();
   data_ = nullptr;
-  inner_ = std::monostate{};
 }
 
 bool Operation::operator==(const Operation& op) const {
@@ -119,19 +76,7 @@ bool Operation::operator==(const Operation& op) const {
       return false;
   }
 
-  return std::visit(
-      [](const auto& a, const auto& b) {
-        if constexpr (!std::is_same_v<std::decay_t<decltype(a)>,
-                                      std::decay_t<decltype(b)>>) {
-          return false;
-        } else if constexpr (std::is_same_v<std::decay_t<decltype(a)>,
-                                            llvm::APFloat>) {
-          return a.bitwiseIsEqual(b);
-        } else {
-          return a == b;
-        }
-      },
-      inner_, op.inner_);
+  return true;
 }
 bool Operation::operator!=(const Operation& op) const {
   return !(*this == op);
@@ -143,25 +88,12 @@ OpRef Operation::with_new_operands(llvm::ArrayRef<OpRef> operands) const {
   if (num_operands() == 0)
     return shared_from_this();
 
-  if (!data_) {
-    auto my_operands = std::get<OpVec>(inner_);
-    bool equal = std::equal(std::begin(my_operands), std::end(my_operands),
-                            std::begin(operands), std::end(operands));
+  if ((llvm::ArrayRef<OpRef>)operands_ == operands)
+    return shared_from_this();
 
-    if (equal)
-      return shared_from_this();
-
-    Operation next{(Opcode)opcode(), type(), operands.data()};
-    next.copy_vtable(*this);
-    return constant_fold(std::move(next));
-  } else {
-    if ((llvm::ArrayRef<OpRef>)operands_ == operands)
-      return shared_from_this();
-
-    Operation next{data_->clone(), operands};
-    next.copy_vtable(*this);
-    return constant_fold(std::move(next));
-  }
+  Operation next{data_->clone(), operands};
+  next.copy_vtable(*this);
+  return constant_fold(std::move(next));
 }
 
 std::string_view Operation::opcode_name() const {
@@ -231,9 +163,7 @@ const Operation& Operation::operator[](size_t idx) const {
 }
 
 const OpRef& Operation::operand_at(size_t idx) const {
-  if (data_)
-    return operands_[idx];
-  return std::get<OpVec>(inner_)[idx];
+  return operands_[idx];
 }
 
 template <typename T, typename... Ts>

--- a/src/IR/OperationBase.cpp
+++ b/src/IR/OperationBase.cpp
@@ -116,7 +116,7 @@ uint16_t Operation::aux_data() const {
   return detail::opcode_aux(opcode());
 }
 Type Operation::type() const {
-  return type_;
+  return data_ ? type_ : Type::void_ty();
 }
 
 bool Operation::is_constant() const {

--- a/src/IR/OperationSimplifier.cpp
+++ b/src/IR/OperationSimplifier.cpp
@@ -92,6 +92,7 @@ namespace {
   } while (false)
 
 OpRef OperationSimplifier::visit(Operation& op) {
+  CAFFEINE_ASSERT(op.valid());
 #ifdef CAFFEINE_ENABLE_IMPLICIT_CONSTANT_FOLDING
   return BaseType::visit(op);
 #else


### PR DESCRIPTION
This PR completes the refactoring of the `Operation` internals. After this PR `Operation` only has two main fields
- an `OperationData` pointer that stores any non-operand data, and,
- a list of operands

I've also kept the type field but it will always be the same as the one stored within `OperationData`. This is mainly to avoid a pointer dereference since the type is used everywhere within caffeine.