### PR TITLE
Add an implementation of a union-find datastructure

### DIFF
--- a/include/caffeine/ADT/UnionFind.h
+++ b/include/caffeine/ADT/UnionFind.h
@@ -1,0 +1,70 @@
+#pragma once
+
+#include <cstdint>
+#include <type_traits>
+#include <vector>
+
+namespace caffeine {
+
+template<typename T = size_t>
+class UnionFind {
+public:
+  UnionFind() = default;
+
+  T make_set() {
+    T id = parents.size();
+    parents.push_back(id);
+    return id;
+  }
+
+  size_t size() const {
+    return parents.size();
+  }
+
+  const T& parent(T query) const {
+    return parents.at(static_cast<size_t>(query));
+  }
+  T& parent(T query) {
+    return parents.at(static_cast<size_t>(query));
+  }
+
+  T update(T current) {
+    while (true) {
+      T p = parent(current);
+
+      if (current == p)
+        break;
+
+      auto gp = parent(p);
+      parent(current) = gp;
+      current = gp;
+    }
+
+    return current;
+  }
+
+  T find(T current) const {
+    while (current != parent(current)) {
+      current = parent(current);
+    }
+
+    return current;
+  }
+  T find(T current) {
+    return update(current);
+  }
+
+  T do_union(T root1, T root2) {
+    parent(root2) = root1;
+    return root1;
+  }
+
+#ifdef CAFFEINE_EXPOSE_FOR_TESTING
+public:
+#else
+private:
+#endif
+  std::vector<T> parents;
+};
+
+} // namespace caffeine

--- a/include/caffeine/ADT/UnionFind.h
+++ b/include/caffeine/ADT/UnionFind.h
@@ -6,7 +6,7 @@
 
 namespace caffeine {
 
-template<typename T = size_t>
+template <typename T = size_t>
 class UnionFind {
 public:
   UnionFind() = default;

--- a/test/unit/ADT/UnionFind.cpp
+++ b/test/unit/ADT/UnionFind.cpp
@@ -27,7 +27,7 @@ TEST(UnionFindTest, union_find) {
   for (size_t i = 0; i < 10; ++i) {
     uf.find(i);
   }
-  
+
   std::vector<size_t> expected = {0, 0, 0, 0, 4, 5, 6, 6, 6, 6};
   ASSERT_EQ(uf.parents, expected);
 }

--- a/test/unit/ADT/UnionFind.cpp
+++ b/test/unit/ADT/UnionFind.cpp
@@ -1,0 +1,33 @@
+#include "caffeine/ADT/UnionFind.h"
+#include <gtest/gtest.h>
+
+using namespace caffeine;
+
+TEST(UnionFindTest, union_find) {
+  UnionFind<> uf;
+  std::vector<size_t> linear;
+
+  for (size_t i = 0; i < 10; ++i) {
+    linear.push_back(uf.make_set());
+  }
+
+  ASSERT_EQ(uf.parents, linear);
+
+  // build up one set
+  uf.do_union(0, 1);
+  uf.do_union(0, 2);
+  uf.do_union(0, 3);
+
+  // build up another set
+  uf.do_union(6, 7);
+  uf.do_union(6, 8);
+  uf.do_union(6, 9);
+
+  // this should compress all paths
+  for (size_t i = 0; i < 10; ++i) {
+    uf.find(i);
+  }
+  
+  std::vector<size_t> expected = {0, 0, 0, 0, 4, 5, 6, 6, 6, 6};
+  ASSERT_EQ(uf.parents, expected);
+}

--- a/test/unit/BUILD
+++ b/test/unit/BUILD
@@ -9,7 +9,10 @@ cc_library(
     hdrs = glob(["**/*.h"]),
     copts = WARNING_FLAGS,
     data = ["Interpreter/ir-with-global.ll"],
-    local_defines = ["CAFFEINE_BAZEL"],
+    local_defines = [
+        "CAFFEINE_BAZEL",
+        "CAFFEINE_EXPOSE_FOR_TESTING",
+    ],
     strip_include_prefix = "/test/unit",
     visibility = ["//:__pkg__"],
     deps = [

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -18,6 +18,7 @@ target_include_directories(caffeine-unittest PRIVATE "${CMAKE_SOURCE_DIR}/includ
 target_include_directories(caffeine-unittest PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}")
 target_include_directories(caffeine-unittest PRIVATE "${CMAKE_SOURCE_DIR}")
 target_include_directories(caffeine-unittest PRIVATE "${CMAKE_BINARY_DIR}/gen/")
+target_compile_definitions(caffeine-unittest PRIVATE CAFFEINE_EXPOSE_FOR_TEST)
 
 if (CAFFEINE_ENABLE_COVERAGE)
   add_test(

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -18,7 +18,7 @@ target_include_directories(caffeine-unittest PRIVATE "${CMAKE_SOURCE_DIR}/includ
 target_include_directories(caffeine-unittest PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}")
 target_include_directories(caffeine-unittest PRIVATE "${CMAKE_SOURCE_DIR}")
 target_include_directories(caffeine-unittest PRIVATE "${CMAKE_BINARY_DIR}/gen/")
-target_compile_definitions(caffeine-unittest PRIVATE CAFFEINE_EXPOSE_FOR_TEST)
+target_compile_definitions(caffeine-unittest PRIVATE CAFFEINE_EXPOSE_FOR_TESTING)
 
 if (CAFFEINE_ENABLE_COVERAGE)
   add_test(


### PR DESCRIPTION
Pretty much as in the title. This PR adds an implementation of a union-find datastructure as well as a test that exercises it. Currently, it is unused but I will be using it in follow-up PRs to actually add e-graphs to caffeine.