### PR TITLE
Add a new `Operation` to represent an e-graph node

### DIFF
--- a/include/caffeine/IR/Operation.def
+++ b/include/caffeine/IR/Operation.def
@@ -68,6 +68,7 @@ HANDLE_FULL_OP(ConstantInt,       ConstantInt,    ConstantInt,    1, 0, 5)
 HANDLE_FULL_OP(ConstantFloat,     ConstantFloat,  ConstantFloat,  1, 0, 6)
 HANDLE_FULL_OP(ConstantArray,     ConstantArray,  ConstantArray,  1, 1, 7)
 HANDLE_FULL_OP(FunctionObject,    FunctionObject, FunctionObject, 1, 0, 8)
+HANDLE_FULL_OP(EGraphNode,        EGraphNode,     EGraphNode,     1, 0, 9)
 
 /**
  * An unnamed symbolic constant that can have any value whenever it is

--- a/include/caffeine/IR/Operation.h
+++ b/include/caffeine/IR/Operation.h
@@ -447,6 +447,22 @@ public:
   static bool classof(const Operation* op);
 };
 
+/**
+ * Represents a node within the E-Graph. The rest of the expression can then be
+ * retrieved by querying the E-Graph.
+ */
+class EGraphNode final : public Operation {
+private:
+  EGraphNode(Type t, size_t id);
+
+public:
+  size_t id() const;
+
+  static OpRef Create(Type t, size_t id);
+
+  static bool classof(const Operation* op);
+};
+
 } // namespace caffeine
 
 #include "caffeine/IR/Operation.inl"

--- a/include/caffeine/IR/Operation.inl
+++ b/include/caffeine/IR/Operation.inl
@@ -282,6 +282,7 @@ CAFFEINE_OP_DECL_CLASSOF(StoreOp, Store);
 CAFFEINE_OP_DECL_CLASSOF(Undef, Undef);
 CAFFEINE_OP_DECL_CLASSOF(FixedArray, FixedArray);
 CAFFEINE_OP_DECL_CLASSOF(FunctionObject, FunctionObject);
+CAFFEINE_OP_DECL_CLASSOF(EGraphNode, EGraphNode);
 
 inline bool Constant::classof(const Operation* op) {
   return op->opcode() == ConstantNamed || op->opcode() == ConstantNumbered;

--- a/include/caffeine/IR/OperationData.h
+++ b/include/caffeine/IR/OperationData.h
@@ -83,4 +83,22 @@ private:
   llvm::Function* func_;
 };
 
+class EGraphNodeData : public OperationData {
+public:
+  EGraphNodeData(Type t, size_t id);
+
+  size_t id() const {
+    return id_;
+  }
+
+  static bool classof(const OperationData* op) {
+    return op->opcode() == Opcode::EGraphNode;
+  }
+
+  llvm::hash_code hash() const override;
+
+private:
+  size_t id_;
+};
+
 } // namespace caffeine

--- a/src/IR/OperationData.cpp
+++ b/src/IR/OperationData.cpp
@@ -116,4 +116,8 @@ llvm::hash_code FunctionObjectData::hash() const {
   return hash_value(func_);
 }
 
+llvm::hash_code EGraphNodeData::hash() const {
+  return hash_value(id_);
+}
+
 } // namespace caffeine

--- a/src/IR/Operations/EGraphNode.cpp
+++ b/src/IR/Operations/EGraphNode.cpp
@@ -1,6 +1,6 @@
+#include "../Operation.h"
 #include "caffeine/IR/Operation.h"
 #include "caffeine/IR/OperationData.h"
-#include "../Operation.h"
 
 namespace caffeine {
 

--- a/src/IR/Operations/EGraphNode.cpp
+++ b/src/IR/Operations/EGraphNode.cpp
@@ -8,7 +8,7 @@ EGraphNode::EGraphNode(Type t, size_t id)
     : Operation(std::make_unique<EGraphNodeData>(t, id)) {}
 
 size_t EGraphNode::id() const {
-  return llvm::cast<EGraphNodeData>(data().get())->id();
+  return llvm::cast<EGraphNodeData>(data_.get())->id();
 }
 
 OpRef EGraphNode::Create(Type t, size_t id) {

--- a/src/IR/Operations/EGraphNode.cpp
+++ b/src/IR/Operations/EGraphNode.cpp
@@ -1,0 +1,18 @@
+#include "caffeine/IR/Operation.h"
+#include "caffeine/IR/OperationData.h"
+#include "src/IR/Operation.h"
+
+namespace caffeine {
+
+EGraphNode::EGraphNode(Type t, size_t id)
+    : Operation(std::make_unique<EGraphNodeData>(t, id)) {}
+
+size_t EGraphNode::id() const {
+  return llvm::cast<EGraphNodeData>(data().get())->id();
+}
+
+OpRef EGraphNode::Create(Type t, size_t id) {
+  return constant_fold(EGraphNode(t, id));
+}
+
+} // namespace caffeine

--- a/src/IR/Operations/EGraphNode.cpp
+++ b/src/IR/Operations/EGraphNode.cpp
@@ -1,6 +1,6 @@
 #include "caffeine/IR/Operation.h"
 #include "caffeine/IR/OperationData.h"
-#include "src/IR/Operation.h"
+#include "../Operation.h"
 
 namespace caffeine {
 

--- a/src/Solver/ModelEval.cpp
+++ b/src/Solver/ModelEval.cpp
@@ -146,7 +146,7 @@ Value ModelEvaluator::visitSIToFp(const UnaryOp&) {
   CAFFEINE_UNIMPLEMENTED();
 }
 
-Value ModelEvaluator::visitEGraphNode(const EGraphNode& O) {
+Value ModelEvaluator::visitEGraphNode(const EGraphNode&) {
   CAFFEINE_ABORT("Attempted to evaluate EGraphNode");
 }
 

--- a/src/Solver/ModelEval.cpp
+++ b/src/Solver/ModelEval.cpp
@@ -146,6 +146,10 @@ Value ModelEvaluator::visitSIToFp(const UnaryOp&) {
   CAFFEINE_UNIMPLEMENTED();
 }
 
+Value ModelEvaluator::visitEGraphNode(const EGraphNode& O) {
+  CAFFEINE_ABORT("Attempted to evaluate EGraphNode");
+}
+
 Value ModelEvaluator::visitAlloc(const AllocOp& op) {
   auto size = visit(*op.size()).apint().getLimitedValue();
   CAFFEINE_ASSERT(size <= (uint64_t)SIZE_MAX);

--- a/src/Solver/Z3/Convert.cpp
+++ b/src/Solver/Z3/Convert.cpp
@@ -489,4 +489,8 @@ z3::expr Z3OpVisitor::visitFunctionObject(const FunctionObject&) {
   CAFFEINE_ABORT("Encountered a symbolic FunctionObject instance");
 }
 
+z3::expr Z3OpVisitor::visitEGraphNode(const EGraphNode& op) {
+  CAFFEINE_ABORT("Z3OpVisitor got an incomplete expression");
+}
+
 } // namespace caffeine

--- a/src/Solver/Z3/Convert.cpp
+++ b/src/Solver/Z3/Convert.cpp
@@ -489,7 +489,7 @@ z3::expr Z3OpVisitor::visitFunctionObject(const FunctionObject&) {
   CAFFEINE_ABORT("Encountered a symbolic FunctionObject instance");
 }
 
-z3::expr Z3OpVisitor::visitEGraphNode(const EGraphNode& op) {
+z3::expr Z3OpVisitor::visitEGraphNode(const EGraphNode&) {
   CAFFEINE_ABORT("Z3OpVisitor got an incomplete expression");
 }
 


### PR DESCRIPTION
This PR adds a new operation type that just refers to an e-class id within the e-graph. It will be used by the e-graph class introduced in future PRs.

/stack #673 