### PR TITLE
Make warning flags work within bazel

### DIFF
--- a/bazel/BUILD
+++ b/bazel/BUILD
@@ -1,1 +1,24 @@
 exports_files(["run_command.sh"])
+
+config_setting(
+    name = "clang",
+    flag_values = {
+        "@bazel_tools//tools/cpp:compiler": "clang",
+    },
+)
+
+config_setting(
+    name = "msvc",
+    flag_values = {
+        "@bazel_tools//tools/cpp:compiler": "msvc",
+    },
+)
+
+config_setting(
+    name = "gcc",
+    flag_values = {
+        "@bazel_tools//tools/cpp:compiler": "compiler",
+    },
+)
+
+

--- a/bazel/warnings.bzl
+++ b/bazel/warnings.bzl
@@ -1,24 +1,26 @@
 """
 """
 
-load("@bazel_skylib//lib:selects.bzl", "selects")
-
-WARNING_FLAGS = selects.with_or({
-    ("@bazel_tools//tools/cpp:clang", "@bazel_tools//tools/cpp:clang-cl"): [
+WARNING_FLAGS = select({
+    "//bazel:clang": [
+        # If a warning pops up in a external library then add an entry here
+        # for it to silence the warning.
         "--system-header-prefix=llvm/",
         "--system-header-prefix=fmt/",
+        "--system-header-prefix=immer/",
+        "--system-header-prefix=capnp/",
         "-fcolor-diagnostics",
         "-Wall",
         "-Wextra",
         "-Wno-unknown-pragmas",
     ],
-    "@bazel_tools//tools/cpp:gcc": [
+    "//bazel:gcc": [
         "-fdiagnostics-color=always",
         "-Wall",
         "-Wextra",
         "-Wno-unknown-pragmas",
     ],
-    "@bazel_tools//tools/cpp:msvc": [
+    "//bazel:msvc": [
         "/experimental:external",
         "/external:anglebrackets",
         "/external:W0",

--- a/tools/caffeine/BUILD
+++ b/tools/caffeine/BUILD
@@ -1,6 +1,9 @@
+load("//bazel:warnings.bzl", "WARNING_FLAGS")
+
 cc_binary(
     name = "caffeine",
     srcs = ["main.cpp"],
+    copts = WARNING_FLAGS,
     visibility = ["//visibility:public"],
     deps = [
         "//:caffeine",

--- a/tools/guided-fuzzing/BUILD
+++ b/tools/guided-fuzzing/BUILD
@@ -1,7 +1,10 @@
+load("//bazel:warnings.bzl", "WARNING_FLAGS")
+
 cc_library(
     name = "guided-fuzzing",
     srcs = glob(["src/*.cpp"]),
     hdrs = glob(["include/*.h"]),
+    copts = WARNING_FLAGS,
     strip_include_prefix = "/tools/guided-fuzzing/include",
     visibility = ["//visibility:public"],
     deps = [


### PR DESCRIPTION
I've recently noticed that warning flags were not being passed to bazel. This PR changes that so that the compiler is properly detected and warning flags are passed appropriately.