### PR TITLE
Clean up unused bazel dependencies

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -105,10 +105,9 @@ cc_library(
         "//third_party:magic-enum",
         "//third_party:z3",
         "//third_party/capnp",
-        "//third_party/divine",
         "@boost//:thread",
         "@llvm//llvm:Core",
-        "@llvm//llvm:Passes",
+        "@llvm//llvm:Support",
     ],
 )
 

--- a/test/unit/BUILD
+++ b/test/unit/BUILD
@@ -15,6 +15,7 @@ cc_library(
     deps = [
         "//:caffeine",
         "//third_party:gtest",
+        "@llvm//llvm:IRReader",
     ],
     alwayslink = 1,
 )

--- a/third_party/divine/BUILD
+++ b/third_party/divine/BUILD
@@ -3,6 +3,7 @@ cc_library(
     srcs = glob(["src/**/*.cpp"]),
     hdrs = glob(["include/**/*"]),
     strip_include_prefix = "/third_party/divine/include",
+    tags = ["manual"],
     visibility = ["//visibility:public"],
     deps = [
         "//third_party:fmt",

--- a/tools/caffeine/BUILD
+++ b/tools/caffeine/BUILD
@@ -4,5 +4,7 @@ cc_binary(
     visibility = ["//visibility:public"],
     deps = [
         "//:caffeine",
+        "@llvm//llvm:IRReader",
+        "@llvm//llvm:Support",
     ],
 )

--- a/tools/caffeine/main.cpp
+++ b/tools/caffeine/main.cpp
@@ -14,23 +14,21 @@
 #include "caffeine/Support/Signal.h"
 #include "caffeine/Support/Tracing.h"
 #include <atomic>
+#include <csignal>
 #include <cstdlib>
-#include <divine/Passes/CppLsda.h>
 #include <exception>
 #include <iostream>
 #include <llvm/IR/Module.h>
 #include <llvm/IR/PassManager.h>
 #include <llvm/IRReader/IRReader.h>
-#include <llvm/Passes/PassBuilder.h>
 #include <llvm/Support/CommandLine.h>
 #include <llvm/Support/InitLLVM.h>
+#include <llvm/Support/SourceMgr.h>
 #include <llvm/Support/WithColor.h>
 #include <llvm/Support/raw_os_ostream.h>
 #include <memory>
-#include <signal.h>
 #include <string>
 #include <thread>
-#include <z3++.h>
 
 using namespace llvm;
 using namespace caffeine;
@@ -157,14 +155,6 @@ int main(int argc, char** argv) {
                        << "'\n";
     return 2;
   }
-
-  llvm::ModulePassManager mpm;
-  llvm::ModuleAnalysisManager mam;
-  mpm.addPass(divine::AddCppLSDA());
-
-  llvm::PassBuilder passBuilder;
-  passBuilder.registerModuleAnalyses(mam);
-  mpm.run(*module, mam);
 
   auto function = module->getFunction(entry.getValue());
   if (!function) {

--- a/tools/guided-fuzzing/BUILD
+++ b/tools/guided-fuzzing/BUILD
@@ -8,9 +8,7 @@ cc_library(
         "//:caffeine",
         "//third_party:fmt",
         "@afl//:afl-hdrs",
-        "@llvm//llvm:BitWriter",
         "@llvm//llvm:Core",
         "@llvm//llvm:IRReader",
-        "@llvm//llvm:TransformUtils",
     ],
 )


### PR DESCRIPTION
This is a bit of an attempt to reduce some the build times for caffeine. Currently, in order to build caffeine we link in a large part of LLVM. This is slow so, naturally, we would like to avoid that.

This PR does the following:
- Remove divine as a dependency from caffeine. Last time I tried to do this we weren't sure whether it would still be needed so I haven't actually gone and deleted it from the repo just yet. However, it is now dead code.
- Remove dependencies on llvm components that aren't actually needed within the `//:caffeine` target.
- The same goes for all the tools targets as well.
- Re-add all the dependencies that weren't required for `//:caffeine` but were needed by downstream targets (e.g. `//test/unit`) as dependencies for the downstream targets.

The end result of this is that it should no longer be necessary to build all the LLVM passes in order to build caffeine. It will still be necessary to build them in the host configuration but that is a one-time that doesn't need to be redone for every configuration.