### PR TITLE
Expose `Operation::data_` via a public accessor

### DIFF
--- a/include/caffeine/IR/OperationBase.h
+++ b/include/caffeine/IR/OperationBase.h
@@ -153,16 +153,16 @@ public:
 protected:
   Type type_;
 
-  std::unique_ptr<OperationData> data_;
+  std::shared_ptr<OperationData> data_;
   llvm::SmallVector<OpRef, 4> operands_;
 
   friend llvm::hash_code hash_value(const Operation& op);
 
 protected:
   Operation(std::unique_ptr<OperationData>&& data,
-            std::initializer_list<OpRef> operands = {});
-  Operation(std::unique_ptr<OperationData>&& data,
             llvm::ArrayRef<OpRef> operands);
+  Operation(const std::shared_ptr<OperationData>& data,
+            llvm::SmallVector<OpRef, 4>&& operands);
 
   Operation();
 
@@ -224,10 +224,21 @@ public:
    */
   const OpRef& operand_at(size_t idx) const;
 
+  const std::shared_ptr<OperationData>& data() const;
+
   Operation(Operation&& op) = default;
   Operation& operator=(Operation&& op) = default;
 
   ~Operation() = default;
+
+  /**
+   * Create an operation instance directly from an OperationData instance and an
+   * array of operands.
+   */
+  static OpRef CreateRaw(const std::shared_ptr<OperationData>& data,
+                         llvm::ArrayRef<OpRef> operands = {});
+  static OpRef CreateRaw(const std::shared_ptr<OperationData>& data,
+                         llvm::SmallVector<OpRef, 4>&& operands);
 
 protected:
   /**

--- a/include/caffeine/IR/OperationBase.h
+++ b/include/caffeine/IR/OperationBase.h
@@ -7,6 +7,7 @@
 #include "caffeine/Support/CopyVTable.h"
 #include <boost/container/static_vector.hpp>
 #include <cstdint>
+#include <initializer_list>
 #include <llvm/ADT/APFloat.h>
 #include <llvm/ADT/APInt.h>
 #include <llvm/Support/Casting.h>
@@ -159,6 +160,8 @@ protected:
   friend llvm::hash_code hash_value(const Operation& op);
 
 protected:
+  Operation(std::unique_ptr<OperationData>&& data,
+            std::initializer_list<OpRef> operands = {});
   Operation(std::unique_ptr<OperationData>&& data,
             llvm::ArrayRef<OpRef> operands);
   Operation(const std::shared_ptr<OperationData>& data,

--- a/src/IR/OperationBase.cpp
+++ b/src/IR/OperationBase.cpp
@@ -12,6 +12,10 @@ namespace caffeine {
 Operation::Operation() : type_(Type::void_ty()) {}
 
 Operation::Operation(std::unique_ptr<OperationData>&& data,
+                     std::initializer_list<OpRef> operands)
+    : Operation(std::move(data),
+                llvm::ArrayRef<OpRef>(operands.begin(), operands.end())) {}
+Operation::Operation(std::unique_ptr<OperationData>&& data,
                      llvm::ArrayRef<OpRef> operands)
     : type_(data->type()), data_(std::move(data)),
       operands_(operands.begin(), operands.end()) {


### PR DESCRIPTION
The egraph implementation will be using `OperationData` as part of its internal representation of operations. However, in order to make that work it needs to be able to access the data pointer of the operation. This PR adds a read-only accessor for `Operation::data_` as well as some constructors to create an operation from its data pointer + a list of operands.

/stack #674 