### PR TITLE
Also build with clang in bazel CI

### DIFF
--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -17,6 +17,7 @@ jobs:
     strategy:
       matrix:
         mode: [opt, fastbuild]
+        compiler: [gcc, clang]
       fail-fast: false
 
     steps:
@@ -40,6 +41,7 @@ jobs:
         run: |
           cat >> local.bazelrc <<- EOF
           build --compilation_mode=${{ matrix.mode }}
+          build --config=${{ matrix.compiler }}
           EOF
 
       - name: Avoid uploading if we don't have credentials

--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -27,7 +27,6 @@ jobs:
         id: bazel_info
         shell: bash
         run: |
-          echo last_downstream_green > .bazelversion 
           echo "::set-output name=output_base::$(bazel info output_base)"
 
       - uses: actions/cache@v2

--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -113,3 +113,12 @@ jobs:
       - name: Check formatting of all targets
         run: bazelisk run --config=ci -- //:check-format
 
+  all-test-pass:
+    needs: [build, format]
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: No-op
+        run: |
+          echo "All checks passed!""
+

--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -114,6 +114,7 @@ jobs:
         run: bazelisk run --config=ci -- //:check-format
 
   all-test-pass:
+    name: Verify all tests pass
     needs: [build, format]
     runs-on: ubuntu-latest
 

--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -120,5 +120,5 @@ jobs:
     steps:
       - name: No-op
         run: |
-          echo "All checks passed!""
+          echo "All checks passed!"
 

--- a/bazel/ci.bazelrc
+++ b/bazel/ci.bazelrc
@@ -13,3 +13,10 @@ build:ci --experimental_remote_cache_async
 
 # Avoid downloading artifacts that aren't needed.
 build:ci --remote_download_toplevel
+
+build:clang --action_env=CC=clang-12
+build:clang --action_env=CXX=clang++-12
+build:clang --linkopt=-fuse-ld=lld-12
+
+build:gcc --action_env=CC=gcc-11
+build:gcc --action_env=CXX=g++-11

--- a/bazel/ci.bazelrc
+++ b/bazel/ci.bazelrc
@@ -18,5 +18,5 @@ build:clang --action_env=CC=clang-12
 build:clang --action_env=CXX=clang++-12
 build:clang --linkopt=-fuse-ld=lld-12
 
-build:gcc --action_env=CC=gcc-11
-build:gcc --action_env=CXX=g++-11
+build:gcc --action_env=CC=gcc-10
+build:gcc --action_env=CXX=g++-10


### PR DESCRIPTION
Clang tends to give better error messages than gcc. Beyond that, we want to support both so we should really be testing with all compilers we support.