### PR TITLE
Silence unused parameter warnings under GCC

### DIFF
--- a/bazel/warnings.bzl
+++ b/bazel/warnings.bzl
@@ -19,6 +19,9 @@ WARNING_FLAGS = select({
         "-Wall",
         "-Wextra",
         "-Wno-unknown-pragmas",
+        # Immer has some code that triggers this and gcc doesn't seem to have the
+        # required options to silence warnings under certain prefixes.
+        "-Wno-unused-parameter",
     ],
     "//bazel:msvc": [
         "/experimental:external",


### PR DESCRIPTION
There's a couple of unused arguments in dependencies. GCC doesn't seem to have a way to silence warnings for dependency headers so I've just gone and disabled the warning instead.