### PR TITLE
Implement basic constant propagation with E-Graphs

### DIFF
--- a/include/caffeine/IR/EGraph.h
+++ b/include/caffeine/IR/EGraph.h
@@ -25,6 +25,8 @@ public:
   bool operator==(const ENode& node) const;
   bool operator!=(const ENode& node) const;
 
+  Type type() const;
+
   friend llvm::hash_code hash_value(const ENode& node);
 };
 
@@ -122,6 +124,7 @@ private:
   std::vector<size_t> worklist;
 
   friend class EGraphExtractor;
+  friend class EGraphConstantPropagator;
 };
 
 /**

--- a/include/caffeine/IR/EGraph.h
+++ b/include/caffeine/IR/EGraph.h
@@ -39,6 +39,7 @@ public:
   void merge(EClass& eclass);
 
   bool is_constant() const;
+  Type type() const;
 
   friend llvm::hash_code hash_value(const EClass& node);
 };

--- a/include/caffeine/IR/EGraph.h
+++ b/include/caffeine/IR/EGraph.h
@@ -97,7 +97,7 @@ public:
                     llvm::SmallVectorImpl<OpRef>* exprs);
   void bulk_extract(llvm::ArrayRef<size_t> ids,
                     llvm::SmallVectorImpl<OpRef>* exprs) const;
-  
+
   void constprop();
 
 private:

--- a/include/caffeine/IR/EGraph.h
+++ b/include/caffeine/IR/EGraph.h
@@ -72,6 +72,7 @@ public:
   size_t find(size_t id) const;
   size_t find(size_t id);
 
+  EClass* get(size_t id);
   const EClass* get(size_t id) const;
 
   // Merge two e-classes into one. This makes them equivalent and returns the

--- a/include/caffeine/IR/EGraph.h
+++ b/include/caffeine/IR/EGraph.h
@@ -38,6 +38,8 @@ public:
 
   void merge(EClass& eclass);
 
+  bool is_constant() const;
+
   friend llvm::hash_code hash_value(const EClass& node);
 };
 
@@ -95,6 +97,8 @@ public:
                     llvm::SmallVectorImpl<OpRef>* exprs);
   void bulk_extract(llvm::ArrayRef<size_t> ids,
                     llvm::SmallVectorImpl<OpRef>* exprs) const;
+  
+  void constprop();
 
 private:
   // Add without first doing a rebuild.

--- a/src/IR/EGraph.cpp
+++ b/src/IR/EGraph.cpp
@@ -50,15 +50,9 @@ void EClass::merge(EClass& eclass) {
 
   nodes.insert(nodes.end(), std::move_iterator(eclass.nodes.begin()),
                std::move_iterator(eclass.nodes.end()));
-
-  // This e-class will not be used again, free all its memory
-  eclass.nodes.clear();
-  eclass.nodes.shrink_to_fit();
-
   for (auto it = eclass.parents.begin(); it != eclass.parents.end(); ++it) {
     parents.emplace(it.key(), it.value());
   }
-  eclass.parents = decltype(eclass.parents)();
 }
 
 size_t EGraph::find(size_t id) const {
@@ -85,6 +79,7 @@ size_t EGraph::merge(size_t id1, size_t id2) {
   auto new_id = union_find.do_union(id1, id2);
 
   classes.at(new_id).merge(classes.at(id2));
+  classes.erase(id2);
 
   worklist.push_back(new_id);
   return new_id;

--- a/src/IR/EGraph.cpp
+++ b/src/IR/EGraph.cpp
@@ -78,6 +78,10 @@ bool EClass::is_constant() const {
   }
 }
 
+Type EClass::type() const {
+  return nodes.front().data->type();
+}
+
 size_t EGraph::find(size_t id) const {
   return union_find.find(id);
 }

--- a/src/IR/EGraph.cpp
+++ b/src/IR/EGraph.cpp
@@ -1,10 +1,6 @@
 #include "caffeine/IR/EGraph.h"
 #include "caffeine/IR/Operation.h"
-#include <algorithm>
 #include <cstdint>
-#include <deque>
-#include <fmt/format.h>
-#include <iterator>
 #include <limits>
 
 namespace caffeine {

--- a/src/IR/EGraph.cpp
+++ b/src/IR/EGraph.cpp
@@ -89,6 +89,12 @@ size_t EGraph::find(size_t id) {
   return union_find.find(id);
 }
 
+EClass* EGraph::get(size_t id) {
+  auto it = classes.find(find(id));
+  if (it != classes.end())
+    return &it.value();
+  return nullptr;
+}
 const EClass* EGraph::get(size_t id) const {
   auto it = classes.find(id);
   if (it != classes.end())

--- a/src/IR/EGraph.cpp
+++ b/src/IR/EGraph.cpp
@@ -114,6 +114,9 @@ size_t EGraph::merge(size_t id1, size_t id2) {
   classes.at(new_id).merge(classes.at(id2));
   classes.erase(id2);
 
+  if (classes.at(new_id).is_constant())
+    unparent(new_id);
+
   worklist.push_back(new_id);
   return new_id;
 }

--- a/src/IR/EGraph.cpp
+++ b/src/IR/EGraph.cpp
@@ -205,14 +205,18 @@ void EGraph::repair(size_t eclass_id) {
 }
 
 void EGraph::unparent(size_t eclass_id) {
-  const EClass& eclass = classes.at(eclass_id);
+  EClass& eclass = classes.at(eclass_id);
+  CAFFEINE_ASSERT(eclass.is_constant());
+
+  if (eclass.nodes.size() == 1)
+    return;
 
   for (const ENode& node : eclass.nodes) {
     for (size_t operand : node.operands) {
-      EClass& child = classes.at(operand);
-      child.parents.erase(node);
+      get(operand)->parents.erase(node);
     }
   }
+  eclass.nodes.resize(1);
 }
 
 #define CONST_INT_FOLD(expr)                                                   \

--- a/src/IR/EGraphConstprop.cpp
+++ b/src/IR/EGraphConstprop.cpp
@@ -39,7 +39,7 @@ private:
                     [&](llvm::ArrayRef<llvm::APInt> args) { return (expr); })
 
     switch (node.data->opcode()) {
-    // clang-format off
+      // clang-format off
       case Operation::Add:  INT_FOLD(args[0] + args[1]);
       case Operation::Sub:  INT_FOLD(args[0] - args[1]);
       case Operation::Mul:  INT_FOLD(args[0] * args[1]);

--- a/src/IR/EGraphConstprop.cpp
+++ b/src/IR/EGraphConstprop.cpp
@@ -38,8 +38,8 @@ private:
   return foldBoolOp(node,                                                      \
                     [&](llvm::ArrayRef<llvm::APInt> args) { return (expr); })
 
+    // clang-format off
     switch (node.data->opcode()) {
-      // clang-format off
       case Operation::Add:  INT_FOLD(args[0] + args[1]);
       case Operation::Sub:  INT_FOLD(args[0] - args[1]);
       case Operation::Mul:  INT_FOLD(args[0] * args[1]);

--- a/src/IR/EGraphConstprop.cpp
+++ b/src/IR/EGraphConstprop.cpp
@@ -1,0 +1,165 @@
+#include "caffeine/IR/EGraph.h"
+#include "caffeine/IR/OperationData.h"
+#include <optional>
+#include <queue>
+#include <type_traits>
+
+namespace caffeine {
+
+class EGraphConstantPropagator {
+public:
+  EGraphConstantPropagator(EGraph* egraph) : egraph(egraph) {}
+
+  void visit(size_t id) {
+    if (id != egraph->find(id))
+      return;
+
+    if (constants.contains(id))
+      return;
+
+    EClass& eclass = *egraph->get(id);
+
+    for (ENode& node : eclass.nodes) {
+      if (auto merged = tryFoldNode(node)) {
+        id = egraph->merge(*merged, id);
+        constants.insert(id);
+        egraph->worklist.push_back(id);
+        break;
+      }
+    }
+  }
+
+private:
+  std::optional<size_t> tryFoldNode(const ENode& node) {
+#define INT_FOLD(expr)                                                         \
+  return foldIntOp(node,                                                       \
+                   [&](llvm::ArrayRef<llvm::APInt> args) { return (expr); })
+#define BOOL_FOLD(expr)                                                        \
+  return foldBoolOp(node,                                                      \
+                    [&](llvm::ArrayRef<llvm::APInt> args) { return (expr); })
+
+    switch (node.data->opcode()) {
+      // clang-format off
+      case Operation::Add:  INT_FOLD(args[0] + args[1]);
+      case Operation::Sub:  INT_FOLD(args[0] - args[1]);
+      case Operation::Mul:  INT_FOLD(args[0] * args[1]);
+      case Operation::UDiv: INT_FOLD(args[1] == 0 ? args[0].udiv(args[1]) : args[1]);
+      case Operation::SDiv: INT_FOLD(args[1] == 0 ? args[0].sdiv(args[1]) : args[1]);
+      case Operation::URem: INT_FOLD(args[1] == 0 ? args[0].urem(args[1]) : args[1]);
+      case Operation::SRem: INT_FOLD(args[1] == 0 ? args[0].srem(args[1]) : args[1]);
+
+      case Operation::And:  INT_FOLD(args[0] & args[1]);
+      case Operation::Or:   INT_FOLD(args[0] | args[1]);
+      case Operation::Xor:  INT_FOLD(args[0] ^ args[1]);
+      case Operation::Shl:  INT_FOLD(args[0].shl(args[1]));
+      case Operation::LShr: INT_FOLD(args[0].lshr(args[1]));
+      case Operation::AShr: INT_FOLD(args[0].ashr(args[1]));
+
+      case Operation::ICmpEq:  BOOL_FOLD(args[0] == args[1]);
+      case Operation::ICmpNe:  BOOL_FOLD(args[0] != args[1]);
+      case Operation::ICmpUgt: BOOL_FOLD(args[0].ugt(args[1]));
+      case Operation::ICmpUge: BOOL_FOLD(args[0].uge(args[1]));
+      case Operation::ICmpUlt: BOOL_FOLD(args[0].ult(args[1]));
+      case Operation::ICmpUle: BOOL_FOLD(args[0].ule(args[1]));
+      case Operation::ICmpSgt: BOOL_FOLD(args[0].sgt(args[1]));
+      case Operation::ICmpSge: BOOL_FOLD(args[0].sge(args[1]));
+      case Operation::ICmpSlt: BOOL_FOLD(args[0].slt(args[1]));
+      case Operation::ICmpSle: BOOL_FOLD(args[0].sle(args[1]));
+
+      case Operation::Not:   INT_FOLD(~args[0]);
+      
+      case Operation::ZExt:  INT_FOLD(args[0].zext(node.type().bitwidth()));
+      case Operation::SExt:  INT_FOLD(args[0].sext(node.type().bitwidth()));
+      case Operation::Trunc: INT_FOLD(args[0].trunc(node.type().bitwidth()));
+      // clang-format on
+
+    default:
+      return std::nullopt;
+    }
+  }
+  std::optional<size_t> foldSelect(const ENode& node) {
+    if (!constants.contains(egraph->find(node.operands[0])))
+      return std::nullopt;
+
+    bool value = llvm::cast<ConstantIntData>(
+                     egraph->get(node.operands[0])->nodes.at(0).data.get())
+                     ->value()
+                     .getBoolValue();
+    return value ? node.operands[1] : node.operands[2];
+  }
+
+  template <typename F>
+  std::optional<size_t> foldIntOp(const ENode& node, F&& func) {
+    std::optional<llvm::APInt> folded = tryFoldConstIntOperands(node, func);
+    if (!folded)
+      return std::nullopt;
+
+    return egraph->add_dirty(ENode{std::make_shared<ConstantIntData>(*folded)});
+  }
+  template <typename F>
+  std::optional<size_t> foldBoolOp(const ENode& node, F&& func) {
+    std::optional<bool> folded = tryFoldConstIntOperands(node, func);
+    if (!folded)
+      return std::nullopt;
+
+    return egraph->add_dirty(ENode{
+        std::make_shared<ConstantIntData>(llvm::APInt(1, (uint64_t)*folded))});
+  }
+
+  template <typename F, typename R = std::decay_t<decltype(std::declval<F>()(
+                            std::declval<llvm::ArrayRef<llvm::APInt>>()))>>
+  std::optional<R> tryFoldConstIntOperands(const ENode& node, F&& func) {
+    bool operands_are_constant = std::all_of(
+        node.operands.begin(), node.operands.end(), [&](size_t operand) {
+          return constants.contains(egraph->find(operand));
+        });
+
+    if (!operands_are_constant)
+      return std::nullopt;
+
+    llvm::SmallVector<llvm::APInt> operands;
+    operands.reserve(node.operands.size());
+
+    for (size_t opid : node.operands) {
+      EClass* operand = egraph->get(opid);
+
+      CAFFEINE_ASSERT(operand);
+      CAFFEINE_ASSERT(operand->is_constant());
+
+      operands.push_back(
+          llvm::cast<ConstantIntData>(operand->nodes.at(0).data.get())
+              ->value());
+    }
+
+    return func(operands);
+  }
+
+public:
+  EGraph* egraph;
+  tsl::hopscotch_set<size_t> constants;
+};
+
+void EGraph::constprop() {
+  EGraphConstantPropagator propagator{this};
+  std::queue<size_t> queue;
+
+  for (auto it = classes.begin(); it != classes.end(); ++it) {
+    size_t id = it.key();
+    EClass& eclass = it.value();
+
+    if (eclass.is_constant()) {
+      propagator.constants.insert(id);
+    } else {
+      queue.push(id);
+    }
+  }
+
+  while (!queue.empty()) {
+    size_t id = queue.front();
+    queue.pop();
+
+    propagator.visit(id);
+  }
+}
+
+} // namespace caffeine

--- a/src/IR/EGraphConstprop.cpp
+++ b/src/IR/EGraphConstprop.cpp
@@ -39,7 +39,7 @@ private:
                     [&](llvm::ArrayRef<llvm::APInt> args) { return (expr); })
 
     switch (node.data->opcode()) {
-      // clang-format off
+    // clang-format off
       case Operation::Add:  INT_FOLD(args[0] + args[1]);
       case Operation::Sub:  INT_FOLD(args[0] - args[1]);
       case Operation::Mul:  INT_FOLD(args[0] * args[1]);

--- a/test/unit/IR/EGraph.cpp
+++ b/test/unit/IR/EGraph.cpp
@@ -36,3 +36,20 @@ TEST_F(EGraphTests, constprop_add) {
 
   ASSERT_EQ(egraph.find(id_c), egraph.find(id_d));
 }
+
+TEST_F(EGraphTests, constprop_not) {
+  auto a = add(ConstantInt::Create(false));
+  auto b = add(UnaryOp::CreateNot(a));
+
+  size_t id_a = egraph.add(*a);
+  size_t id_b = egraph.add(*b);
+
+  egraph.constprop();
+  egraph.rebuild();
+
+  size_t id_c = egraph.add(*ConstantInt::Create(true));
+
+  ASSERT_NE(id_a, id_b);
+  ASSERT_NE(id_a, id_c);
+  ASSERT_EQ(egraph.find(id_b), egraph.find(id_c));
+}

--- a/test/unit/IR/EGraph.cpp
+++ b/test/unit/IR/EGraph.cpp
@@ -1,0 +1,38 @@
+#include "caffeine/IR/EGraph.h"
+#include "caffeine/IR/Operation.h"
+#include <gtest/gtest.h>
+
+using namespace caffeine;
+
+class EGraphTests : public ::testing::Test {
+public:
+  EGraph egraph;
+
+  OpRef add(const OpRef& op) {
+    return EGraphNode::Create(op->type(), egraph.add(*op));
+  }
+};
+
+TEST_F(EGraphTests, constprop_add) {
+  auto a = add(ConstantInt::Create(llvm::APInt(32, 15)));
+  auto b = add(ConstantInt::Create(llvm::APInt(32, 11)));
+  auto c = add(BinaryOp::CreateAdd(a, b));
+  auto d = add(ConstantInt::Create(llvm::APInt(32, 15 + 11)));
+
+  size_t id_a = egraph.add(*a);
+  size_t id_b = egraph.add(*b);
+  size_t id_c = egraph.add(*c);
+  size_t id_d = egraph.add(*d);
+
+  ASSERT_NE(id_a, id_b);
+  ASSERT_NE(id_a, id_c);
+  ASSERT_NE(id_a, id_d);
+  ASSERT_NE(id_b, id_c);
+  ASSERT_NE(id_b, id_d);
+  ASSERT_NE(id_c, id_d);
+
+  egraph.constprop();
+  egraph.rebuild();
+
+  ASSERT_EQ(egraph.find(id_c), egraph.find(id_d));
+}


### PR DESCRIPTION
This PR implements incomplete constant propagation within E-Graphs, This is a big step towards making the e-graph actually have feature parity with our existing expression representation.

/stack #686 