### PR TITLE
Include compiler within the name of the CI artifact

### DIFF
--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -71,7 +71,7 @@ jobs:
       - name: Upload release tarball
         uses: actions/upload-artifact@v2
         with:
-          name: caffeine-${{ matrix.mode }}
+          name: caffeine-${{ matrix.compiler }}-${{ matrix.mode }}
           path: caffeine.tar.gz
 
   format:


### PR DESCRIPTION
As in title. Noticed that these the same across multiple runs which seems to result in problems.