### PR TITLE
Convert EGraphExtractor into a class that can be used externally

### DIFF
--- a/include/caffeine/IR/EGraph.h
+++ b/include/caffeine/IR/EGraph.h
@@ -111,7 +111,32 @@ private:
   tsl::hopscotch_map<size_t, EClass> classes;
   std::vector<size_t> worklist;
 
-  friend struct EGraphExtractor;
+  friend class EGraphExtractor;
+};
+
+/**
+ * A stateful extractor for expressions contained within an E-Graph.
+ *
+ * Actually building the expressions involves a bunch of caching of intermediate
+ * expressions so the more extractions that can be done while reusing the same
+ * extractor the faster things will be.
+ */
+class EGraphExtractor {
+public:
+  EGraphExtractor(const EGraph* egraph);
+
+  OpRef extract(size_t eclass);
+
+private:
+  std::pair<uint64_t, size_t> eval_cost(size_t eclass_id);
+  uint64_t eval_cost(const ENode& node);
+  uint64_t eval_cost(Operation::Opcode opcode);
+
+private:
+  const EGraph* graph;
+  tsl::hopscotch_map<size_t, std::pair<uint64_t, size_t>> costs;
+  tsl::hopscotch_map<size_t, OpRef> expressions;
+  tsl::hopscotch_set<size_t> visited;
 };
 
 } // namespace caffeine

--- a/src/IR/EGraph.cpp
+++ b/src/IR/EGraph.cpp
@@ -172,90 +172,6 @@ size_t EGraph::create_eclass(const ENode& node) {
   return id;
 }
 
-struct EGraphExtractor {
-  const EGraph* graph;
-  tsl::hopscotch_map<size_t, std::pair<uint64_t, size_t>> costs;
-  tsl::hopscotch_map<size_t, OpRef> expressions;
-  tsl::hopscotch_set<size_t> visited;
-
-  EGraphExtractor(const EGraph* graph) : graph(graph) {}
-
-  std::pair<uint64_t, size_t> eval_cost(size_t eclass_id) {
-    eclass_id = graph->find(eclass_id);
-
-    auto it = costs.find(eclass_id);
-    if (it != costs.end())
-      return it->second;
-
-    if (!visited.insert(eclass_id).second) {
-      // We've encountered a cycle in the expression tree. In this case we just
-      // return a large so that the cycle doesn't get chosen.
-      //
-      // Note that the only way it is possible to get a cycle is if classes were
-      // merged in such a way that a cycle is formed. There will always be an
-      // alternative in that case.
-      return {UINT32_MAX, SIZE_MAX};
-    }
-
-    const EClass& eclass = graph->classes.at(eclass_id);
-    uint64_t cost = UINT64_MAX;
-    size_t index = SIZE_MAX;
-    for (size_t i = 0; i < eclass.nodes.size(); ++i) {
-      uint64_t node_cost = eval_cost(eclass.nodes[i]);
-      if (node_cost < cost) {
-        cost = node_cost;
-        index = i;
-      }
-    }
-
-    CAFFEINE_ASSERT(index != SIZE_MAX);
-    costs.insert({eclass_id, {cost, index}});
-    return {cost, index};
-  }
-  uint64_t eval_cost(const ENode& node) {
-    uint64_t cost = eval_cost(node.data->opcode());
-    for (size_t operand : node.operands)
-      cost += eval_cost(operand).first;
-    return cost;
-  }
-  uint64_t eval_cost(Operation::Opcode opcode) {
-    using Opcode = Operation::Opcode;
-
-    switch (opcode) {
-    // Symbolic constants are expensive, better to use a large non-symbolic
-    // expression instead.
-    case Opcode::ConstantNamed:
-    case Opcode::ConstantNumbered:
-    case Opcode::ConstantArray:
-      return 1 << 16;
-
-    default:
-      return 1;
-    }
-  }
-
-  OpRef extract(size_t id) {
-    id = graph->find(id);
-    auto it = expressions.find(id);
-    if (it != expressions.end())
-      return it->second;
-
-    auto [cost, index] = eval_cost(id);
-    const EClass& eclass = graph->classes.at(id);
-    const ENode& node = eclass.nodes.at(index);
-
-    llvm::SmallVector<OpRef, 4> operands;
-    operands.reserve(node.operands.size());
-
-    for (size_t opid : node.operands)
-      operands.push_back(extract(opid));
-
-    OpRef expr = Operation::CreateRaw(node.data, operands);
-    expressions.emplace(id, expr);
-    return expr;
-  }
-};
-
 OpRef EGraph::extract(size_t id) {
   llvm::SmallVector<OpRef, 1> exprs;
   bulk_extract({id}, &exprs);
@@ -278,6 +194,83 @@ void EGraph::bulk_extract(llvm::ArrayRef<size_t> ids,
 
   for (size_t id : ids)
     exprs->push_back(extractor.extract(id));
+}
+
+EGraphExtractor::EGraphExtractor(const EGraph* graph) : graph(graph) {}
+
+std::pair<uint64_t, size_t> EGraphExtractor::eval_cost(size_t eclass_id) {
+  eclass_id = graph->find(eclass_id);
+
+  auto it = costs.find(eclass_id);
+  if (it != costs.end())
+    return it->second;
+
+  if (!visited.insert(eclass_id).second) {
+    // We've encountered a cycle in the expression tree. In this case we just
+    // return a large so that the cycle doesn't get chosen.
+    //
+    // Note that the only way it is possible to get a cycle is if classes were
+    // merged in such a way that a cycle is formed. There will always be an
+    // alternative in that case.
+    return {UINT32_MAX, SIZE_MAX};
+  }
+
+  const EClass& eclass = graph->classes.at(eclass_id);
+  uint64_t cost = UINT64_MAX;
+  size_t index = SIZE_MAX;
+  for (size_t i = 0; i < eclass.nodes.size(); ++i) {
+    uint64_t node_cost = eval_cost(eclass.nodes[i]);
+    if (node_cost < cost) {
+      cost = node_cost;
+      index = i;
+    }
+  }
+
+  CAFFEINE_ASSERT(index != SIZE_MAX);
+  costs.insert({eclass_id, {cost, index}});
+  return {cost, index};
+}
+uint64_t EGraphExtractor::eval_cost(const ENode& node) {
+  uint64_t cost = eval_cost(node.data->opcode());
+  for (size_t operand : node.operands)
+    cost += eval_cost(operand).first;
+  return cost;
+}
+uint64_t eval_cost(Operation::Opcode opcode) {
+  using Opcode = Operation::Opcode;
+
+  switch (opcode) {
+  // Symbolic constants are expensive, better to use a large non-symbolic
+  // expression instead.
+  case Opcode::ConstantNamed:
+  case Opcode::ConstantNumbered:
+  case Opcode::ConstantArray:
+    return 1 << 16;
+
+  default:
+    return 1;
+  }
+}
+
+OpRef EGraphExtractor::extract(size_t id) {
+  id = graph->find(id);
+  auto it = expressions.find(id);
+  if (it != expressions.end())
+    return it->second;
+
+  auto [cost, index] = eval_cost(id);
+  const EClass& eclass = graph->classes.at(id);
+  const ENode& node = eclass.nodes.at(index);
+
+  llvm::SmallVector<OpRef, 4> operands;
+  operands.reserve(node.operands.size());
+
+  for (size_t opid : node.operands)
+    operands.push_back(extract(opid));
+
+  OpRef expr = Operation::CreateRaw(node.data, operands);
+  expressions.emplace(id, expr);
+  return expr;
 }
 
 } // namespace caffeine

--- a/src/IR/EGraph.cpp
+++ b/src/IR/EGraph.cpp
@@ -236,7 +236,7 @@ uint64_t EGraphExtractor::eval_cost(const ENode& node) {
     cost += eval_cost(operand).first;
   return cost;
 }
-uint64_t eval_cost(Operation::Opcode opcode) {
+uint64_t EGraphExtractor::eval_cost(Operation::Opcode opcode) {
   using Opcode = Operation::Opcode;
 
   switch (opcode) {


### PR DESCRIPTION
While writing further PRs I've come up with a couple of use cases where being able to reuse the caches needed to extract egraph expressions would be useful. This PR converts the `EGraphExtractor` class to one that can be used outside of `EGraph`.