### PR TITLE
Automatically cache expressions for egraph e-classes

### DIFF
--- a/include/caffeine/IR/EGraph.h
+++ b/include/caffeine/IR/EGraph.h
@@ -30,11 +30,26 @@ public:
   friend llvm::hash_code hash_value(const ENode& node);
 };
 
+struct EClassCost {
+  uint64_t cost;
+  size_t index;
+};
+
+class EClassCache {
+public:
+  OpRef expr;
+  std::optional<EClassCost> cost;
+
+  EClassCache() = default;
+
+  void clear();
+};
+
 class EClass {
 public:
   std::vector<ENode> nodes;
   tsl::hopscotch_map<ENode, size_t> parents = {};
-  OpRef cached_expr = nullptr;
+  EClassCache cache{};
 
   bool operator==(const EClass& eclass) const;
   bool operator!=(const EClass& eclass) const;
@@ -143,16 +158,17 @@ public:
   OpRef extract(size_t eclass);
 
 private:
-  std::pair<uint64_t, size_t> eval_cost(size_t eclass_id);
+  EClassCost eval_cost(size_t eclass_id);
   uint64_t eval_cost(const ENode& node);
   uint64_t eval_cost(Operation::Opcode opcode);
 
   void update_cached(size_t eclass, const OpRef& expr);
+  void update_cached(size_t eclass, EClassCost cost);
 
 private:
   const EGraph* graph;
   bool is_const;
-  tsl::hopscotch_map<size_t, std::pair<uint64_t, size_t>> costs;
+  tsl::hopscotch_map<size_t, EClassCost> costs;
   tsl::hopscotch_map<size_t, OpRef> expressions;
   tsl::hopscotch_set<size_t> visited;
 };

--- a/include/caffeine/IR/EGraph.h
+++ b/include/caffeine/IR/EGraph.h
@@ -34,6 +34,7 @@ class EClass {
 public:
   std::vector<ENode> nodes;
   tsl::hopscotch_map<ENode, size_t> parents = {};
+  OpRef cached_expr = nullptr;
 
   bool operator==(const EClass& eclass) const;
   bool operator!=(const EClass& eclass) const;
@@ -137,6 +138,7 @@ private:
 class EGraphExtractor {
 public:
   EGraphExtractor(const EGraph* egraph);
+  EGraphExtractor(EGraph* egraph);
 
   OpRef extract(size_t eclass);
 
@@ -145,8 +147,11 @@ private:
   uint64_t eval_cost(const ENode& node);
   uint64_t eval_cost(Operation::Opcode opcode);
 
+  void update_cached(size_t eclass, const OpRef& expr);
+
 private:
   const EGraph* graph;
+  bool is_const;
   tsl::hopscotch_map<size_t, std::pair<uint64_t, size_t>> costs;
   tsl::hopscotch_map<size_t, OpRef> expressions;
   tsl::hopscotch_set<size_t> visited;


### PR DESCRIPTION
Repeatedly rebuilding minimal-cost expressions that represent a given e-graph node every time we do an assertion is actually rather expensive. By caching both the expression and minimal cost for each e-graph node we can drastically reduce the cost of building expressions anew. The only issue is that, as e-classes are merged, the cached expressions may no longer be optimal. I've addressed this by invalidating the caches of all affected parents during egraph rebuild.

/stack #681 