### PR TITLE
Optimize builtins with `-O3`

### DIFF
--- a/libraries/builtins/BUILD
+++ b/libraries/builtins/BUILD
@@ -10,6 +10,7 @@ bitcode_library_standalone(
     defines = [
         "CAFFEINE_BAZEL",
     ],
+    copts = ["-O3"],
     strip_include_prefix = "/libraries/builtins",
     # Notice the order of libcxx vs libc. libcxx comes
     # first, because it uses `#include_next` directives


### PR DESCRIPTION
Previously these weren't being optimized at all, which was resulting in some rather slow code. This isn't what we want so having it be optimized should help speed things up somewhat.