### PR TITLE
Add test sharding for unit tests

### DIFF
--- a/test/unit/BUILD
+++ b/test/unit/BUILD
@@ -27,6 +27,7 @@ cc_test(
     name = "unit",
     srcs = ["main.cpp"],
     linkstatic = True,
+    shard_count = 8,
     deps = [
         ":unit-lib",
     ],


### PR DESCRIPTION
Running the unit tests is starting to take a while. This will reduce the time it takes to run them by running them in parallel.