### PR TITLE
Extract EGraph utility methods from the EGraph integration PR

### DIFF
--- a/include/caffeine/IR/EGraph.h
+++ b/include/caffeine/IR/EGraph.h
@@ -26,6 +26,7 @@ public:
   bool operator!=(const ENode& node) const;
 
   Type type() const;
+  Operation::Opcode opcode() const;
 
   friend llvm::hash_code hash_value(const ENode& node);
 };

--- a/include/caffeine/IR/EGraph.h
+++ b/include/caffeine/IR/EGraph.h
@@ -110,6 +110,16 @@ public:
   OpRef extract(size_t id);
   OpRef extract(size_t id) const;
 
+  // Extract an optimal represent for an expression that contains references to
+  // egraph nodes. This will return the same expression with all instances of
+  // EGraphNode replaced with their corresponding minimal expression.
+  //
+  // It is preferrable to use this method instead of first adding the expression
+  // and then extracting it from the resulting eclass id as this will help
+  // minimize the e-graph.
+  OpRef extract(const Operation& op);
+  OpRef extract(const Operation& op) const;
+
   // Build expressions for a bunch of e-classes at once. This is more efficient
   // than calling extract for each expression since some internal caches can be
   // reused.

--- a/include/caffeine/IR/EGraph.h
+++ b/include/caffeine/IR/EGraph.h
@@ -161,6 +161,7 @@ public:
   EGraphExtractor(EGraph* egraph);
 
   OpRef extract(size_t eclass);
+  OpRef extract(const Operation& expr);
 
 private:
   EClassCost eval_cost(size_t eclass_id);

--- a/include/caffeine/IR/EGraph.h
+++ b/include/caffeine/IR/EGraph.h
@@ -107,6 +107,9 @@ public:
   // Extract an optimal representation for the given expression. This will try
   // to minimize both the size of the generated expression as well as the cost
   // it would involve in a solver.
+  //
+  // Note that if you are going to perform lots of extractions without modifying
+  // the e-graph then it is preferable to use EGraphExtractor instead.
   OpRef extract(size_t id);
   OpRef extract(size_t id) const;
 
@@ -119,14 +122,6 @@ public:
   // minimize the e-graph.
   OpRef extract(const Operation& op);
   OpRef extract(const Operation& op) const;
-
-  // Build expressions for a bunch of e-classes at once. This is more efficient
-  // than calling extract for each expression since some internal caches can be
-  // reused.
-  void bulk_extract(llvm::ArrayRef<size_t> ids,
-                    llvm::SmallVectorImpl<OpRef>* exprs);
-  void bulk_extract(llvm::ArrayRef<size_t> ids,
-                    llvm::SmallVectorImpl<OpRef>* exprs) const;
 
   void constprop();
 

--- a/src/IR/EGraph.cpp
+++ b/src/IR/EGraph.cpp
@@ -24,6 +24,9 @@ bool ENode::operator!=(const ENode& node) const {
 Type ENode::type() const {
   return data->type();
 }
+Operation::Opcode ENode::opcode() const {
+  return data ? data->opcode() : Operation::Invalid;
+}
 
 llvm::hash_code hash_value(const ENode& node) {
   using llvm::hash_value;

--- a/src/IR/EGraph.cpp
+++ b/src/IR/EGraph.cpp
@@ -295,26 +295,10 @@ OpRef EGraph::extract(size_t id) const {
 }
 
 OpRef EGraph::extract(const Operation& op) {
-  if (auto node = llvm::dyn_cast<EGraphNode>(&op))
-    return extract(node->id());
-
-  llvm::SmallVector<OpRef> operands;
-  operands.reserve(op.num_operands());
-  for (const auto& operand : op.operands())
-    operands.push_back(extract(operand));
-
-  return op.with_new_operands(operands);
+  return EGraphExtractor(this).extract(op);
 }
 OpRef EGraph::extract(const Operation& op) const {
-  if (auto node = llvm::dyn_cast<EGraphNode>(&op))
-    return extract(node->id());
-
-  llvm::SmallVector<OpRef> operands;
-  operands.reserve(op.num_operands());
-  for (const auto& operand : op.operands())
-    operands.push_back(extract(operand));
-
-  return op.with_new_operands(operands);
+  return EGraphExtractor(this).extract(op);
 }
 
 EGraphExtractor::EGraphExtractor(const EGraph* graph)

--- a/src/IR/EGraph.cpp
+++ b/src/IR/EGraph.cpp
@@ -22,7 +22,7 @@ bool ENode::operator!=(const ENode& node) const {
 }
 
 Type ENode::type() const {
-  return data->type();
+  return data ? data->type() : Type::void_ty();
 }
 Operation::Opcode ENode::opcode() const {
   return data ? data->opcode() : Operation::Invalid;

--- a/src/IR/EGraph.cpp
+++ b/src/IR/EGraph.cpp
@@ -295,6 +295,29 @@ OpRef EGraph::extract(size_t id) const {
   return std::move(exprs[0]);
 }
 
+OpRef EGraph::extract(const Operation& op) {
+  if (auto node = llvm::dyn_cast<EGraphNode>(&op))
+    return extract(node->id());
+
+  llvm::SmallVector<OpRef> operands;
+  operands.reserve(op.num_operands());
+  for (const auto& operand : op.operands())
+    operands.push_back(extract(operand));
+
+  return op.with_new_operands(operands);
+}
+OpRef EGraph::extract(const Operation& op) const {
+  if (auto node = llvm::dyn_cast<EGraphNode>(&op))
+    return extract(node->id());
+
+  llvm::SmallVector<OpRef> operands;
+  operands.reserve(op.num_operands());
+  for (const auto& operand : op.operands())
+    operands.push_back(extract(operand));
+
+  return op.with_new_operands(operands);
+}
+
 void EGraph::bulk_extract(llvm::ArrayRef<size_t> ids,
                           llvm::SmallVectorImpl<OpRef>* exprs) {
   rebuild();

--- a/src/IR/EGraph.cpp
+++ b/src/IR/EGraph.cpp
@@ -426,5 +426,18 @@ OpRef EGraphExtractor::extract(size_t id) {
   update_cached(id, expr);
   return expr;
 }
+OpRef EGraphExtractor::extract(const Operation& expr) {
+  if (auto node = llvm::dyn_cast<EGraphNode>(&expr))
+    return extract(node->id());
+
+  llvm::SmallVector<OpRef, 3> operands;
+  operands.reserve(expr.num_operands());
+
+  for (const auto& operand : expr.operands()) {
+    operands.push_back(extract(operand));
+  }
+
+  return expr.with_new_operands(operands);
+}
 
 } // namespace caffeine

--- a/src/IR/EGraph.cpp
+++ b/src/IR/EGraph.cpp
@@ -116,7 +116,7 @@ EClass* EGraph::get(size_t id) {
   return nullptr;
 }
 const EClass* EGraph::get(size_t id) const {
-  auto it = classes.find(id);
+  auto it = classes.find(find(id));
   if (it != classes.end())
     return &it.value();
   return nullptr;

--- a/src/IR/EGraph.cpp
+++ b/src/IR/EGraph.cpp
@@ -285,14 +285,10 @@ size_t EGraph::create_eclass(const ENode& node) {
 }
 
 OpRef EGraph::extract(size_t id) {
-  llvm::SmallVector<OpRef, 1> exprs;
-  bulk_extract({id}, &exprs);
-  return std::move(exprs[0]);
+  return EGraphExtractor(this).extract(id);
 }
 OpRef EGraph::extract(size_t id) const {
-  llvm::SmallVector<OpRef, 1> exprs;
-  bulk_extract({id}, &exprs);
-  return std::move(exprs[0]);
+  return EGraphExtractor(this).extract(id);
 }
 
 OpRef EGraph::extract(const Operation& op) {
@@ -316,19 +312,6 @@ OpRef EGraph::extract(const Operation& op) const {
     operands.push_back(extract(operand));
 
   return op.with_new_operands(operands);
-}
-
-void EGraph::bulk_extract(llvm::ArrayRef<size_t> ids,
-                          llvm::SmallVectorImpl<OpRef>* exprs) {
-  rebuild();
-  const_cast<const EGraph*>(this)->bulk_extract(ids, exprs);
-}
-void EGraph::bulk_extract(llvm::ArrayRef<size_t> ids,
-                          llvm::SmallVectorImpl<OpRef>* exprs) const {
-  auto extractor = EGraphExtractor{this};
-
-  for (size_t id : ids)
-    exprs->push_back(extractor.extract(id));
 }
 
 EGraphExtractor::EGraphExtractor(const EGraph* graph)

--- a/test/unit/IR/EGraph.cpp
+++ b/test/unit/IR/EGraph.cpp
@@ -53,3 +53,15 @@ TEST_F(EGraphTests, constprop_not) {
   ASSERT_NE(id_a, id_c);
   ASSERT_EQ(egraph.find(id_b), egraph.find(id_c));
 }
+
+TEST_F(EGraphTests, get_non_canonical) {
+  size_t a = egraph.add(*Constant::Create(Type::int_ty(32), "a"));
+  size_t b = egraph.add(*Constant::Create(Type::int_ty(32), "b"));
+
+  egraph.merge(a, b);
+  egraph.rebuild();
+
+  ASSERT_NE(egraph.get(a), nullptr);
+  ASSERT_NE(egraph.get(b), nullptr);
+  ASSERT_EQ(egraph.get(a), egraph.get(b));
+}


### PR DESCRIPTION
This PR extracts a couple of utility methods for `EGraph` that were introduced in #689. That PR is rather large so I've extracted these so that they can be reviewed more easily.

Here's a detailed summary of what was added:
- An `EGraph::extract` overload that takes an `Operation` instance and extracts it without requiring all intermediate expressions to be in the egraph.
- A similar overload for `EGraphExtractor::extract`
- An accessor for the opcode of an `ENode`.
- I have also deleted `EGraph::bulk_extract` since it was superseded by `EGraphExtractor`.