### PR TITLE
Implement an AssertionList that uses eclass IDs

### DIFF
--- a/include/caffeine/Model/GraphAssertionList.h
+++ b/include/caffeine/Model/GraphAssertionList.h
@@ -1,0 +1,79 @@
+#pragma once
+
+#include "caffeine/Support/Assert.h"
+#include <llvm/ADT/ArrayRef.h>
+#include <tsl/hopscotch_set.h>
+#include <vector>
+
+namespace caffeine {
+
+class EGraph;
+
+/**
+ * A list of assertions which are stored as e-class IDs.
+ *
+ * This class follows much the same design as AssertionList except that the
+ * assertions are stored as e-class IDs. This also means that
+ */
+class GraphAssertionList {
+private:
+  std::vector<size_t> list_;
+  tsl::hopscotch_set<size_t> lookup_;
+  size_t mark_ = 0;
+
+public:
+  using const_iterator = decltype(list_)::const_iterator;
+
+  GraphAssertionList() = default;
+
+  size_t size() const {
+    return list_.size();
+  }
+  bool empty() const {
+    return size() == 0;
+  }
+
+  size_t operator[](size_t idx) const {
+    return list_.at(idx);
+  }
+
+  // Replace all eclass IDs with their canonical form and remove any duplicates
+  // introduced due to this.
+  //
+  // Note that this will invalidate any checkpoints that have been made.
+  void canonicalize(const EGraph& egraph);
+
+  // Mark that all the current assertions within this list are satisfiable.
+  void mark_sat();
+
+  void insert(size_t assertion);
+  void insert(llvm::ArrayRef<size_t> assertions);
+
+  bool contains(size_t assertion);
+
+  const_iterator begin() const {
+    return list_.begin();
+  }
+  const_iterator end() const {
+    return list_.end();
+  }
+
+  llvm::ArrayRef<size_t> proven() const;
+  llvm::ArrayRef<size_t> unproven() const;
+
+  /**
+   * Create a checkpoint of the current position of the tail of the list. This
+   * allows for items to be temporarily inserted into the list and then removed
+   * once no longer needed.
+   *
+   * The number returned by this method is the index of the end iterator in the
+   * backing array.
+   *
+   * To remove all items inserted since the corresponding checkpoint call the
+   * restore method.
+   */
+  size_t checkpoint() const;
+  void restore(size_t checkpoint);
+};
+
+} // namespace caffeine

--- a/src/Model/GraphAssertionList.cpp
+++ b/src/Model/GraphAssertionList.cpp
@@ -1,0 +1,101 @@
+#include "caffeine/Model/GraphAssertionList.h"
+#include "caffeine/IR/EGraph.h"
+#include "caffeine/IR/OperationData.h"
+#include <algorithm>
+
+namespace caffeine {
+
+void GraphAssertionList::canonicalize(const EGraph& egraph) {
+  GraphAssertionList canonical;
+  llvm::SmallVector<size_t> queued;
+
+  for (size_t i = 0; i < size(); ++i) {
+    if (i == mark_)
+      canonical.mark_sat();
+
+    queued.push_back(list_[i]);
+
+    while (!queued.empty()) {
+      size_t assertion = egraph.find(queued.pop_back_val());
+
+      const EClass* eclass = egraph.get(assertion);
+      CAFFEINE_ASSERT(eclass);
+
+      if (auto data = llvm::dyn_cast<ConstantIntData>(
+              eclass->nodes.front().data.get())) {
+        // We have a literal false in the assertion list, clear everything and
+        // change the overall list of assertions to just be [false]
+        if (!data->value().getBoolValue()) {
+          canonical.list_.clear();
+          canonical.lookup_.clear();
+          canonical.insert(assertion);
+
+          if (i < mark_)
+            canonical.mark_sat();
+
+          goto done;
+        } else {
+          // There's no need to have assertions which are just the literal true.
+          continue;
+        }
+      }
+
+      // (and ?x1 ?x2) -> ?x1, ?x2
+      auto it = std::find_if(
+          eclass->nodes.begin(), eclass->nodes.end(),
+          [](const ENode& node) { return node.opcode() == Operation::And; });
+      if (it != eclass->nodes.end()) {
+        for (size_t operand : it->operands)
+          queued.push_back(operand);
+        continue;
+      }
+
+      canonical.insert(assertion);
+    }
+  }
+
+done:
+  *this = std::move(canonical);
+}
+
+void GraphAssertionList::mark_sat() {
+  mark_ = size();
+}
+
+void GraphAssertionList::insert(size_t assertion) {
+  if (!lookup_.insert(assertion).second)
+    return;
+
+  list_.push_back(assertion);
+}
+void GraphAssertionList::insert(llvm::ArrayRef<size_t> assertions) {
+  for (size_t assertion : assertions)
+    insert(assertion);
+}
+
+bool GraphAssertionList::contains(size_t assertion) {
+  return lookup_.contains(assertion);
+}
+
+llvm::ArrayRef<size_t> GraphAssertionList::proven() const {
+  return llvm::ArrayRef<size_t>(list_.data(), list_.data() + mark_);
+}
+llvm::ArrayRef<size_t> GraphAssertionList::unproven() const {
+  return llvm::ArrayRef<size_t>(list_.data() + mark_,
+                                list_.data() + list_.size());
+}
+
+size_t GraphAssertionList::checkpoint() const {
+  return size();
+}
+void GraphAssertionList::restore(size_t checkpoint) {
+  CAFFEINE_ASSERT(checkpoint <= size());
+
+  for (size_t i = checkpoint; i < size(); ++i) {
+    lookup_.erase(list_[i]);
+  }
+
+  list_.resize(checkpoint);
+}
+
+} // namespace caffeine

--- a/test/unit/Model/GraphAssertionList.cpp
+++ b/test/unit/Model/GraphAssertionList.cpp
@@ -49,4 +49,3 @@ TEST_F(GraphAssertionListTests, canonicalize_decompose) {
 
   ASSERT_EQ(list.size(), 2);
 }
-

--- a/test/unit/Model/GraphAssertionList.cpp
+++ b/test/unit/Model/GraphAssertionList.cpp
@@ -1,0 +1,52 @@
+#include "caffeine/Model/GraphAssertionList.h"
+#include "caffeine/IR/EGraph.h"
+#include "caffeine/IR/Operation.h"
+
+#include <gtest/gtest.h>
+
+using namespace caffeine;
+
+class GraphAssertionListTests : public ::testing::Test {
+public:
+  EGraph egraph;
+  GraphAssertionList list;
+
+  OpRef add(const OpRef& op) {
+    return EGraphNode::Create(op->type(), egraph.add(*op));
+  }
+};
+
+TEST_F(GraphAssertionListTests, deduplicate) {
+  list.insert(1);
+  list.insert(2);
+  list.insert(1);
+
+  ASSERT_EQ(list.size(), 2);
+}
+
+TEST_F(GraphAssertionListTests, canonicalize_dedup) {
+  list.insert(
+      egraph.add(*BinaryOp::CreateAnd(Constant::Create(Type::int_ty(1), 0),
+                                      Constant::Create(Type::int_ty(1), 1))));
+  list.insert(egraph.add(*Constant::Create(Type::int_ty(1), 0)));
+  list.insert(egraph.add(*Constant::Create(Type::int_ty(1), 1)));
+
+  ASSERT_EQ(list.size(), 3);
+
+  list.canonicalize(egraph);
+
+  ASSERT_EQ(list.size(), 2);
+}
+
+TEST_F(GraphAssertionListTests, canonicalize_decompose) {
+  list.insert(
+      egraph.add(*BinaryOp::CreateAnd(Constant::Create(Type::int_ty(1), 0),
+                                      Constant::Create(Type::int_ty(1), 1))));
+
+  ASSERT_EQ(list.size(), 1);
+
+  list.canonicalize(egraph);
+
+  ASSERT_EQ(list.size(), 2);
+}
+


### PR DESCRIPTION
Pretty much as in title. This will replace the `AssertionList` within `Context` and then we'll instead build the appropriate expressions right before sending them off to the solver. 