### PR TITLE
Compile bitcode tests with `-O3`

### DIFF
--- a/test/regression/issue-489.fail.write-to-const-global.c
+++ b/test/regression/issue-489.fail.write-to-const-global.c
@@ -1,5 +1,5 @@
 const int global = 0;
 
-void test() {
+void test() __attribute__((optnone)) {
   *(int*)&global = 3;
 }

--- a/test/run-fail/BUILD
+++ b/test/run-fail/BUILD
@@ -4,7 +4,7 @@ load("//bazel:bitcode.bzl", "caffeine_bitcode_test")
 generate_tests(
     exclude = [
         "collatz.c",
-        "murmurhash3.c"
+        "murmurhash3.c",
     ],
     should_fail = True,
 )
@@ -12,13 +12,15 @@ generate_tests(
 caffeine_bitcode_test(
     name = "collatz",
     srcs = ["collatz.c"],
+    copts = ["-O3"],
     should_fail = True,
-    tags = ["manual"]
+    tags = ["manual"],
 )
 
 caffeine_bitcode_test(
     name = "murmurhash3",
     srcs = ["murmurhash3.c"],
+    copts = ["-O3"],
     should_fail = True,
-    tags = ["manual"]
+    tags = ["manual"],
 )

--- a/test/tests.bzl
+++ b/test/tests.bzl
@@ -28,6 +28,7 @@ def generate_tests(
             srcs = [file],
             skip = file in skip_files,
             should_fail = should_fail,
+            copts = ["-O3"],
         )
 
 # buildifier: disable=function-docstring
@@ -55,4 +56,5 @@ def generate_regression_tests():
             name = _strip_ext(file),
             srcs = [file],
             should_fail = should_fail,
+            copts = ["-O3"],
         )


### PR DESCRIPTION
Having to run them in an unoptimized mode makes for really slow tests due to all the load and store queries that must be made to the solver. This resolves the issue by ensuring that they're compiled in the same way they were in the cmake build system.