### PR TITLE
Implement `llvm.eh.typeid.for` intrinsic

### DIFF
--- a/include/caffeine/Interpreter/CaffeineContext.h
+++ b/include/caffeine/Interpreter/CaffeineContext.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "caffeine/ADT/StringMap.h"
+#include "caffeine/Interpreter/TypeidDb.h"
 #include <llvm/IR/Intrinsics.h>
 #include <memory>
 
@@ -61,6 +62,7 @@ private:
   std::unique_ptr<FailureLogger> logger_;
   std::unique_ptr<CoverageTracker> cov_;
   CaffeineOptions options_;
+  std::shared_ptr<TypeidDb> typeid_db_;
 
 public:
   const ExternalFunction* function(std::string_view name) const;
@@ -73,6 +75,9 @@ public:
   const CaffeineOptions& options() const;
 
   std::shared_ptr<Solver> build_solver() const;
+
+  // Returns the Typeid DB for the InterpreterContext
+  std::shared_ptr<TypeidDb> typeid_db();
 
 public:
   // Builder class for CaffeineContext.

--- a/include/caffeine/Interpreter/ExternalFunction.h
+++ b/include/caffeine/Interpreter/ExternalFunction.h
@@ -102,6 +102,7 @@ public:
   static std::unique_ptr<ExternalFunction> umul_with_overflow();
   static std::unique_ptr<ExternalFunction> memset();
   static std::unique_ptr<ExternalFunction> bswap();
+  static std::unique_ptr<ExternalFunction> typeidFor();
 
 private:
   Intrinsics() = delete;

--- a/include/caffeine/Interpreter/ExternalFunction.h
+++ b/include/caffeine/Interpreter/ExternalFunction.h
@@ -102,7 +102,7 @@ public:
   static std::unique_ptr<ExternalFunction> umul_with_overflow();
   static std::unique_ptr<ExternalFunction> memset();
   static std::unique_ptr<ExternalFunction> bswap();
-  static std::unique_ptr<ExternalFunction> typeidFor();
+  static std::unique_ptr<ExternalFunction> eh_typeid_for();
 
 private:
   Intrinsics() = delete;

--- a/include/caffeine/Interpreter/InterpreterContext.h
+++ b/include/caffeine/Interpreter/InterpreterContext.h
@@ -3,7 +3,6 @@
 #include "caffeine/IR/OperationBuilder.h"
 #include "caffeine/Interpreter/Context.h"
 #include "caffeine/Interpreter/Policy.h"
-#include "caffeine/Interpreter/TypeidDb.h"
 #include "caffeine/Solver/Solver.h"
 #include "caffeine/Support/Casting.h"
 #include <functional>
@@ -38,7 +37,7 @@ public:
   /**
    * Get the CaffeineContext instance associated with this InterpreterContext.
    */
-  const CaffeineContext& caffeine() const;
+  CaffeineContext& caffeine() const;
 
   // Accessors for LLVM data. These use the LLVM syntax for consistency with
   // existing code.
@@ -370,11 +369,6 @@ public:
    */
   void call_function(llvm::Function* func, Span<LLVMValue> args);
 
-  /**
-   * Returns the Typeid DB for the InterpreterContext
-   */
-  TypeidDb& typeid_db();
-
 private:
   // Set the current context as dead and emit the appropriate notifications.
   void set_dead(ExecutionPolicy::ExitStatus status,
@@ -403,7 +397,6 @@ private:
   ContextQueueEntry* entry_;
   CaffeineContext* shared_;
   std::shared_ptr<Solver> solver_;
-  TypeidDb typeid_db_;
 };
 
 template <typename Frame, typename C, typename Func>

--- a/include/caffeine/Interpreter/InterpreterContext.h
+++ b/include/caffeine/Interpreter/InterpreterContext.h
@@ -3,6 +3,7 @@
 #include "caffeine/IR/OperationBuilder.h"
 #include "caffeine/Interpreter/Context.h"
 #include "caffeine/Interpreter/Policy.h"
+#include "caffeine/Interpreter/TypeidDb.h"
 #include "caffeine/Solver/Solver.h"
 #include "caffeine/Support/Casting.h"
 #include <functional>
@@ -369,6 +370,11 @@ public:
    */
   void call_function(llvm::Function* func, Span<LLVMValue> args);
 
+  /**
+   * Returns the Typeid DB for the InterpreterContext
+   */
+  TypeidDb& typeid_db();
+
 private:
   // Set the current context as dead and emit the appropriate notifications.
   void set_dead(ExecutionPolicy::ExitStatus status,
@@ -397,6 +403,7 @@ private:
   ContextQueueEntry* entry_;
   CaffeineContext* shared_;
   std::shared_ptr<Solver> solver_;
+  TypeidDb typeid_db_;
 };
 
 template <typename Frame, typename C, typename Func>

--- a/include/caffeine/Interpreter/TypeidDb.h
+++ b/include/caffeine/Interpreter/TypeidDb.h
@@ -1,0 +1,21 @@
+#include <mutex>
+#include <unordered_map>
+
+#include <llvm/IR/Constant.h>
+
+namespace caffeine {
+
+class TypeidDb {
+public:
+  int32_t get_selector(const llvm::Constant* exception_ty);
+
+private:
+  // For thread safety
+  mutable std::mutex mutex;
+  // For keeping track of which constants match which
+  // select values
+  std::unordered_map<const llvm::Constant*, int32_t> values;
+  int32_t curr = 1;
+};
+
+} // namespace caffeine

--- a/src/Interpreter/CaffeineContext.cpp
+++ b/src/Interpreter/CaffeineContext.cpp
@@ -68,6 +68,10 @@ CoverageTracker* CaffeineContext::coverage() const {
   return cov_.get();
 }
 
+std::shared_ptr<TypeidDb> CaffeineContext::typeid_db() {
+  return typeid_db_;
+}
+
 // All builder functions
 
 CaffeineContext Builder::build() {
@@ -75,6 +79,7 @@ CaffeineContext Builder::build() {
   ctx.functions_ = std::move(functions_);
   ctx.intrinsics_ = std::move(intrinsics_);
   ctx.options_ = std::move(options_);
+  ctx.typeid_db_ = std::make_shared<TypeidDb>();
 
   if (policy_) {
     ctx.policy_ = std::move(policy_);
@@ -170,7 +175,7 @@ Builder& Builder::with_default_intrinsics() {
                  Intrinsics::smul_with_overflow());
   with_intrinsic(llvm::Intrinsic::memset, Intrinsics::memset());
   with_intrinsic(llvm::Intrinsic::bswap, Intrinsics::bswap());
-  with_intrinsic(llvm::Intrinsic::eh_typeid_for, Intrinsics::typeidFor());
+  with_intrinsic(llvm::Intrinsic::eh_typeid_for, Intrinsics::eh_typeid_for());
 
   return *this;
 }

--- a/src/Interpreter/CaffeineContext.cpp
+++ b/src/Interpreter/CaffeineContext.cpp
@@ -170,6 +170,7 @@ Builder& Builder::with_default_intrinsics() {
                  Intrinsics::smul_with_overflow());
   with_intrinsic(llvm::Intrinsic::memset, Intrinsics::memset());
   with_intrinsic(llvm::Intrinsic::bswap, Intrinsics::bswap());
+  with_intrinsic(llvm::Intrinsic::eh_typeid_for, Intrinsics::typeidFor());
 
   return *this;
 }

--- a/src/Interpreter/InterpreterContext.cpp
+++ b/src/Interpreter/InterpreterContext.cpp
@@ -21,7 +21,7 @@ const Context& InterpreterContext::context() const {
   return entry_->context;
 }
 
-const CaffeineContext& InterpreterContext::caffeine() const {
+CaffeineContext& InterpreterContext::caffeine() const {
   return *shared_;
 }
 
@@ -395,10 +395,6 @@ void InterpreterContext::call_function(llvm::Function* func,
   }
 
   context().stack.push_back(std::move(frame_wrapper));
-}
-
-TypeidDb& InterpreterContext::typeid_db() {
-  return typeid_db_;
 }
 
 } // namespace caffeine

--- a/src/Interpreter/InterpreterContext.cpp
+++ b/src/Interpreter/InterpreterContext.cpp
@@ -397,4 +397,8 @@ void InterpreterContext::call_function(llvm::Function* func,
   context().stack.push_back(std::move(frame_wrapper));
 }
 
+TypeidDb& InterpreterContext::typeid_db() {
+  return typeid_db_;
+}
+
 } // namespace caffeine

--- a/src/Interpreter/Intrinsics/llvm.eh.typeid.for.cpp
+++ b/src/Interpreter/Intrinsics/llvm.eh.typeid.for.cpp
@@ -1,11 +1,12 @@
 #include "caffeine/IR/Value.h"
+#include "caffeine/Interpreter/CaffeineContext.h"
 #include "caffeine/Interpreter/ExternalFunction.h"
 #include "caffeine/Interpreter/Interpreter.h"
 
 namespace caffeine {
 
 namespace {
-  class TypeidForIntrinsic : public ExternalFunction {
+  class EhTypeidForIntrinsic : public ExternalFunction {
   public:
     void call(llvm::Function*, InterpreterContext& ctx,
               Span<LLVMValue> args) const {
@@ -20,15 +21,15 @@ namespace {
       CAFFEINE_ASSERT(global_val,
                       "The arg to llvm.typeid.for should be a constant");
 
-      int32_t res = ctx.typeid_db().get_selector(global_val);
+      int32_t res = ctx.caffeine().typeid_db()->get_selector(global_val);
 
       ctx.jump_return(LLVMValue(ConstantInt::Create(llvm::APInt(32, res))));
     }
   };
 } // namespace
 
-std::unique_ptr<ExternalFunction> Intrinsics::typeidFor() {
-  return std::make_unique<TypeidForIntrinsic>();
+std::unique_ptr<ExternalFunction> Intrinsics::eh_typeid_for() {
+  return std::make_unique<EhTypeidForIntrinsic>();
 }
 
 } // namespace caffeine

--- a/src/Interpreter/Intrinsics/llvm.eh.typeid.for.cpp
+++ b/src/Interpreter/Intrinsics/llvm.eh.typeid.for.cpp
@@ -1,0 +1,34 @@
+#include "caffeine/IR/Value.h"
+#include "caffeine/Interpreter/ExternalFunction.h"
+#include "caffeine/Interpreter/Interpreter.h"
+
+namespace caffeine {
+
+namespace {
+  class TypeidForIntrinsic : public ExternalFunction {
+  public:
+    void call(llvm::Function*, InterpreterContext& ctx,
+              Span<LLVMValue> args) const {
+      CAFFEINE_ASSERT(args.size() == 1);
+
+      // This dance has to happen because we don't have the llvm::Constant
+      // being fed into this function
+      auto call = llvm::dyn_cast<llvm::CallBase>(ctx.getCurrentInstruction());
+      CAFFEINE_ASSERT(call,
+                      "This intrinsic must have been called from somewhere");
+      auto global_val = llvm::dyn_cast<llvm::Constant>(call->getArgOperand(0));
+      CAFFEINE_ASSERT(global_val,
+                      "The arg to llvm.typeid.for should be a constant");
+
+      int32_t res = ctx.typeid_db().get_selector(global_val);
+
+      ctx.jump_return(LLVMValue(ConstantInt::Create(llvm::APInt(32, res))));
+    }
+  };
+} // namespace
+
+std::unique_ptr<ExternalFunction> Intrinsics::typeidFor() {
+  return std::make_unique<TypeidForIntrinsic>();
+}
+
+} // namespace caffeine

--- a/src/Interpreter/TypeidDb.cpp
+++ b/src/Interpreter/TypeidDb.cpp
@@ -1,0 +1,19 @@
+#include <caffeine/Interpreter/TypeidDb.h>
+
+namespace caffeine {
+
+int32_t TypeidDb::get_selector(const llvm::Constant* exception_ty) {
+  std::unique_lock lock(mutex);
+
+  auto val = values.find(exception_ty);
+  if (val != values.end()) {
+    return val->second;
+  }
+
+  values[exception_ty] = curr;
+  int32_t res = curr;
+  curr++;
+  return res;
+}
+
+} // namespace caffeine

--- a/test/run-pass/intrin/typeid_for/BUILD
+++ b/test/run-pass/intrin/typeid_for/BUILD
@@ -1,3 +1,3 @@
 load("//test:tests.bzl", "generate_tests")
 
-generate_tests(skip_files = [])
+generate_tests()

--- a/test/run-pass/intrin/typeid_for/BUILD
+++ b/test/run-pass/intrin/typeid_for/BUILD
@@ -1,0 +1,3 @@
+load("//test:tests.bzl", "generate_tests")
+
+generate_tests(skip_files = [])

--- a/test/run-pass/intrin/typeid_for/typeid-for.ll
+++ b/test/run-pass/intrin/typeid_for/typeid-for.ll
@@ -1,0 +1,38 @@
+target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128"
+target triple = "x86_64-pc-linux-gnu"
+
+@_ZTIi0 = internal constant i64 0, align 8
+
+define dso_local void @test() local_unnamed_addr #0
+  personality i8* bitcast (i32 (...)* @__gxx_personality_v0 to i8*)
+{
+  %b = call i32 @llvm.eh.typeid.for(i8* bitcast (i64* @_ZTIi0 to i8*))
+  %a = icmp eq i32 %b, 1
+  invoke void @caffeine_assert(i1 zeroext %a)
+    to label %normal
+    unwind label %unwind
+
+unwind:
+  %res = landingpad { i8*, i32 } cleanup
+  unreachable
+
+normal:
+  ret void
+}
+
+declare dso_local void @caffeine_assume(i1 zeroext) local_unnamed_addr #1
+declare dso_local void @caffeine_assert(i1 zeroext) local_unnamed_addr #1
+declare dso_local i32 @__gxx_personality_v0(...)
+
+; Function Attrs: nounwind readnone
+declare i32 @llvm.eh.typeid.for(i8*)
+
+attributes #0 = { nounwind uwtable "correctly-rounded-divide-sqrt-fp-math"="false" "disable-tail-calls"="false" "frame-pointer"="none" "less-precise-fpmad"="false" "min-legal-vector-width"="0" "no-infs-fp-math"="false" "no-jump-tables"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="false" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
+attributes #1 = { "correctly-rounded-divide-sqrt-fp-math"="false" "disable-tail-calls"="false" "frame-pointer"="none" "less-precise-fpmad"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="false" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
+attributes #2 = { nounwind }
+
+!llvm.module.flags = !{!0}
+!llvm.ident = !{!1}
+
+!0 = !{i32 1, !"wchar_size", i32 4}
+!1 = !{!"clang version 10.0.0-4ubuntu1 "}


### PR DESCRIPTION
This instrinsic is needed to get the selector values for c++
std::type_infos