### PR TITLE
Add more efficient combined add + merge operation to `EGraph`

### DIFF
--- a/include/caffeine/IR/EGraph.h
+++ b/include/caffeine/IR/EGraph.h
@@ -27,6 +27,7 @@ public:
 
   Type type() const;
   Operation::Opcode opcode() const;
+  bool is_constant() const;
 
   friend llvm::hash_code hash_value(const ENode& node);
 };

--- a/include/caffeine/IR/EGraph.h
+++ b/include/caffeine/IR/EGraph.h
@@ -56,7 +56,7 @@ public:
   bool operator==(const EClass& eclass) const;
   bool operator!=(const EClass& eclass) const;
 
-  void merge(EClass& eclass);
+  void merge(EClass&& eclass);
 
   bool is_constant() const;
   Type type() const;
@@ -103,6 +103,8 @@ public:
 
   size_t add(const ENode& node);
   size_t add(const Operation& op);
+
+  size_t add_merge(size_t eclass, const ENode& node);
 
   void rebuild();
 

--- a/src/IR/EGraph.cpp
+++ b/src/IR/EGraph.cpp
@@ -28,6 +28,15 @@ Type ENode::type() const {
 Operation::Opcode ENode::opcode() const {
   return data ? data->opcode() : Operation::Invalid;
 }
+bool ENode::is_constant() const {
+  switch (opcode()) {
+  case Operation::ConstantInt:
+  case Operation::ConstantFloat:
+    return true;
+  default:
+    return false;
+  }
+}
 
 llvm::hash_code hash_value(const ENode& node) {
   using llvm::hash_value;
@@ -93,14 +102,7 @@ bool EClass::is_constant() const {
 
   if (nodes.empty())
     return false;
-
-  switch (nodes.front().data->opcode()) {
-  case Opcode::ConstantInt:
-  case Opcode::ConstantFloat:
-    return true;
-  default:
-    return false;
-  }
+  return nodes.front().is_constant();
 }
 
 Type EClass::type() const {

--- a/src/IR/EGraph.cpp
+++ b/src/IR/EGraph.cpp
@@ -65,7 +65,7 @@ llvm::hash_code hash_value(const EClass& eclass) {
       llvm::hash_combine_range(eclass.parents.begin(), eclass.parents.end()));
 }
 
-void EClass::merge(EClass& eclass) {
+void EClass::merge(EClass&& eclass) {
   CAFFEINE_ASSERT(this != &eclass);
   CAFFEINE_ASSERT(type() == eclass.type());
 
@@ -98,8 +98,6 @@ void EClass::merge(EClass& eclass) {
 }
 
 bool EClass::is_constant() const {
-  using Opcode = Operation::Opcode;
-
   if (nodes.empty())
     return false;
   return nodes.front().is_constant();
@@ -138,7 +136,7 @@ size_t EGraph::merge(size_t id1, size_t id2) {
 
   auto new_id = union_find.do_union(id1, id2);
 
-  classes.at(new_id).merge(classes.at(id2));
+  classes.at(new_id).merge(std::move(classes.at(id2)));
   classes.erase(id2);
 
   if (classes.at(new_id).is_constant())
@@ -183,6 +181,21 @@ size_t EGraph::add(const Operation& op) {
   }
 
   return add(ENode{op.data(), std::move(operands)});
+}
+
+size_t EGraph::add_merge(size_t eclass_id, const ENode& node) {
+  auto [it, inserted] = hashcons.emplace(node, eclass_id);
+  if (!inserted)
+    return merge(eclass_id, it->second);
+
+  EClass& eclass = classes.at(eclass_id);
+  eclass.merge(EClass{{node}});
+
+  if (eclass.is_constant())
+    unparent(eclass_id);
+
+  worklist.push_back(eclass_id);
+  return eclass_id;
 }
 
 void EGraph::rebuild() {


### PR DESCRIPTION
As in the title. We can avoid creating a temporary e-class in this case since the new e-node will be automatically merged with the existing one. This will help save some amount of memory in these cases.