### PR TITLE
Delay unparenting constant e-classes until the e-graph is rebuilt

### DIFF
--- a/include/caffeine/IR/EGraph.h
+++ b/include/caffeine/IR/EGraph.h
@@ -50,8 +50,12 @@ public:
 class EClass {
 public:
   std::vector<ENode> nodes;
-  tsl::hopscotch_map<ENode, size_t> parents = {};
-  EClassCache cache{};
+  tsl::hopscotch_map<ENode, size_t> parents;
+  EClassCache cache;
+  // Gives the index of the constant value
+  std::optional<size_t> constant_index = std::nullopt;
+
+  EClass(std::vector<ENode>&& nodes);
 
   bool operator==(const EClass& eclass) const;
   bool operator!=(const EClass& eclass) const;
@@ -60,6 +64,9 @@ public:
 
   bool is_constant() const;
   Type type() const;
+
+  ENode* constant();
+  const ENode* constant() const;
 
   friend llvm::hash_code hash_value(const EClass& node);
 };

--- a/src/IR/EGraph.cpp
+++ b/src/IR/EGraph.cpp
@@ -145,9 +145,6 @@ size_t EGraph::merge(size_t id1, size_t id2) {
   classes.at(new_id).merge(std::move(classes.at(id2)));
   classes.erase(id2);
 
-  if (classes.at(new_id).is_constant())
-    unparent(new_id);
-
   worklist.push_back(new_id);
   return new_id;
 }
@@ -196,9 +193,6 @@ size_t EGraph::add_merge(size_t eclass_id, const ENode& node) {
 
   EClass& eclass = classes.at(eclass_id);
   eclass.merge(EClass{{node}});
-
-  if (eclass.is_constant())
-    unparent(eclass_id);
 
   worklist.push_back(eclass_id);
   return eclass_id;
@@ -249,6 +243,9 @@ void EGraph::rebuild() {
 
 void EGraph::repair(size_t eclass_id) {
   EClass& eclass = classes.at(eclass_id);
+
+  if (eclass.is_constant())
+    unparent(eclass_id);
 
   // Note: merge actually properly handles updating the cache so we don't clear
   //       the cache here. However, that doesn't apply for parents of this


### PR DESCRIPTION
In order to save on memory for constant e-classes we delete all other e-nodes within the class. However, this has the side effect that indexes to existing e-nodes are invalidated. This isn't a problem for the current codebase, the future implementation of e-matching relies on this for rewrites to actually work so it needs to be changed. To make it work, we maintain all the e-nodes within the e-class until `EGraph::rebuild` is called at which point we can then clean everything up.

/stack #699 