### PR TITLE
Add some `SubClauseFilter` implementations

### DIFF
--- a/include/caffeine/IR/EGraphMatching.h
+++ b/include/caffeine/IR/EGraphMatching.h
@@ -1,0 +1,46 @@
+#pragma once
+
+#include "caffeine/IR/EGraph.h"
+
+namespace caffeine {
+
+namespace ematching {
+
+  // A custom filter for a subclause for any other conditions beyond filtering
+  // based on opcode.
+  //
+  // This class needs to be hashable and comparable so it's also necessary for
+  // any derived class to implement the hash and is_equal virtual methods,
+  // respectively. The implementation in the parent class will ensure that
+  // is_equal is only called when the types are equal.
+  class SubClauseFilter {
+  public:
+    // Check whether the passed-in ENode is a valid match. If this returns false
+    // then the node will not be considered as a match for this sub-clause.
+    virtual bool matches(const ENode& node) const = 0;
+
+    bool operator==(const SubClauseFilter& filter) const;
+    bool operator!=(const SubClauseFilter& filter) const;
+
+    virtual ~SubClauseFilter() = default;
+
+  protected:
+    SubClauseFilter(const void* type) : type(type) {}
+
+  private:
+    // Compare whether this class is equal to the derived one.
+    //
+    // This will only be called if the other class has the same type as this
+    // one.
+    virtual bool is_equal(const SubClauseFilter& other) const = 0;
+    virtual size_t hash() const = 0;
+
+    friend llvm::hash_code hash_value(const SubClauseFilter& filter);
+
+  private:
+    const void* type;
+  };
+
+} // namespace ematching
+
+} // namespace caffeine

--- a/include/caffeine/IR/EMatching/Filters.h
+++ b/include/caffeine/IR/EMatching/Filters.h
@@ -1,0 +1,45 @@
+#pragma once
+
+#include "caffeine/IR/EGraphMatching.h"
+
+namespace caffeine::ematching {
+
+// A filter that checks whether all the operands refer to the same e-class.
+class IdenticalOperandsFilter final : public SubClauseFilter {
+public:
+  IdenticalOperandsFilter();
+
+  bool matches(const ENode& node) const override;
+
+private:
+  bool is_equal(const SubClauseFilter&) const override {
+    return true;
+  }
+  size_t hash() const override {
+    return 0;
+  }
+
+  static char ID;
+};
+
+// A filter that checks whether the integer value of the operand (when it is a
+// ConstantInt) is equivalent to the provided value.
+//
+// The provided value will either be sign-extended or truncated to match the
+// bitwidth of the integer in the operation.
+class ConstantOperandFilter final : public SubClauseFilter {
+public:
+  ConstantOperandFilter(const llvm::APInt& value);
+
+  bool matches(const ENode& node) const override;
+
+private:
+  bool is_equal(const SubClauseFilter& filter) const override;
+  size_t hash() const override;
+
+  llvm::APInt value;
+
+  static char ID;
+};
+
+} // namespace caffeine::ematching

--- a/src/IR/EGraphMatching.cpp
+++ b/src/IR/EGraphMatching.cpp
@@ -1,0 +1,19 @@
+#include "caffeine/IR/EGraphMatching.h"
+
+namespace caffeine::ematching {
+
+bool SubClauseFilter::operator==(const SubClauseFilter& filter) const {
+  if (type != filter.type)
+    return false;
+
+  return is_equal(filter);
+}
+bool SubClauseFilter::operator!=(const SubClauseFilter& filter) const {
+  return !(*this == filter);
+}
+
+llvm::hash_code hash_value(const SubClauseFilter& filter) {
+  return llvm::hash_combine(filter.type, filter.hash());
+}
+
+} // namespace caffeine::ematching

--- a/src/IR/EMatching/Filters.cpp
+++ b/src/IR/EMatching/Filters.cpp
@@ -1,0 +1,43 @@
+#include "caffeine/IR/EMatching/Filters.h"
+#include "caffeine/IR/EGraphMatching.h"
+#include "caffeine/IR/OperationData.h"
+#include <algorithm>
+
+namespace caffeine::ematching {
+
+char IdenticalOperandsFilter::ID = 0;
+
+IdenticalOperandsFilter::IdenticalOperandsFilter() : SubClauseFilter(&ID) {}
+
+bool IdenticalOperandsFilter::matches(const ENode& node) const {
+  if (node.operands.empty())
+    return true;
+
+  return std::all_of(
+      node.operands.begin(), node.operands.end(),
+      [&](size_t operand) { return operand == node.operands.front(); });
+}
+
+char ConstantOperandFilter::ID = 0;
+
+ConstantOperandFilter::ConstantOperandFilter(const llvm::APInt& value)
+    : SubClauseFilter(&ID), value(value) {}
+
+bool ConstantOperandFilter::matches(const ENode& node) const {
+  auto data = llvm::dyn_cast<ConstantIntData>(node.data.get());
+  if (!data)
+    return false;
+
+  return data->value() == value.sextOrTrunc(data->type().bitwidth());
+}
+
+bool ConstantOperandFilter::is_equal(const SubClauseFilter& filter) const {
+  auto other = static_cast<decltype(this)>(&filter);
+
+  return value == other->value;
+}
+size_t ConstantOperandFilter::hash() const {
+  return llvm::hash_value(value);
+}
+
+} // namespace caffeine::ematching


### PR DESCRIPTION
This PR adds two implementations of `SubClauseFilter`:
- `IdenticalOperandsFilter`: Checks whether all the operands of the `ENode` refer to the same `E-Class`
- `ConstantOperandFilter`: Checks whether the integer value of the `ENode` is equivalent to the sign-extended value of a given constant.

Again, these aren't used anywhere yet but will be used in future PRs.

/stack #701 