### PR TITLE
Introduce matcher `Clause` and `SubClause` types

### DIFF
--- a/src/IR/EGraphMatching.cpp
+++ b/src/IR/EGraphMatching.cpp
@@ -1,4 +1,5 @@
 #include "caffeine/IR/EGraphMatching.h"
+#include "caffeine/IR/EGraph.h"
 
 namespace caffeine::ematching {
 
@@ -14,6 +15,39 @@ bool SubClauseFilter::operator!=(const SubClauseFilter& filter) const {
 
 llvm::hash_code hash_value(const SubClauseFilter& filter) {
   return llvm::hash_combine(filter.type, filter.hash());
+}
+
+bool SubClause::is_potential_match(const ENode& node) const {
+  if (opcode != node.opcode() && opcode != Operation::Invalid)
+    return false;
+
+  if (filter && !filter->matches(node))
+    return false;
+  return true;
+}
+
+bool SubClause::operator==(const SubClause& clause) const {
+  if (opcode != clause.opcode)
+    return false;
+  if (submatchers != clause.submatchers)
+    return false;
+  if (filter != clause.filter)
+    return false;
+  return true;
+}
+bool SubClause::operator!=(const SubClause& clause) const {
+  return !(*this == clause);
+}
+
+llvm::hash_code hash_value(const SubClause& subclause) {
+  using llvm::hash_value;
+
+  size_t filter_hash =
+      !subclause.filter ? 0 : (size_t)hash_value(*subclause.filter);
+
+  return llvm::hash_combine(subclause.opcode,
+                            (llvm::ArrayRef<size_t>)subclause.submatchers,
+                            filter_hash);
 }
 
 } // namespace caffeine::ematching

--- a/src/IR/EMatching/Filters.cpp
+++ b/src/IR/EMatching/Filters.cpp
@@ -1,4 +1,5 @@
 #include "caffeine/IR/EMatching/Filters.h"
+#include "caffeine/IR/EGraph.h"
 #include "caffeine/IR/EGraphMatching.h"
 #include "caffeine/IR/OperationData.h"
 #include <algorithm>


### PR DESCRIPTION
This PR introduces the `Clause` and `SubClause` types which are used to match against e-classes in the graph.

The `SubClause` type matches against an individual e-node. It can include an opcode requirement, as well as refer to other subclauses that need to match on the operands of the e-node in order for the current subclause to match. For more custom filters, it can optionally include a `SubClauseFilter` instance (added in #701) which can do custom filtering beyond that.

The `Clause` type is then a top-level matching item that will correspond to a rewrite rule. It contains the actual rewrite function (`update`), a reference to the top-level subclause that it matches against, and, optionally, a global filter that can check for non-local requirements.

In the next PR, I'll introduce the `EMatcher` class which is responsible for actually storing all of these in a way that can be used.

/stack #702 