### PR TITLE
Add e-matcher clause storage class

### DIFF
--- a/include/caffeine/IR/EGraphMatching.h
+++ b/include/caffeine/IR/EGraphMatching.h
@@ -91,6 +91,24 @@ namespace ematching {
     EMatcherUpdater update;
   };
 
+  class MatchData {
+  public:
+    using ClauseData = std::unordered_map<size_t, std::vector<size_t>>;
+    using MapData = std::vector<ClauseData>;
+
+  private:
+    // Map of subclause -> eclass -> node index
+    MapData matches_;
+
+  public:
+    MatchData(MapData&& matches) : matches_(std::move(matches)) {}
+
+    bool contains_match(size_t subclause, size_t eclass) const;
+
+    const ClauseData& matches(size_t subclause) const;
+    llvm::ArrayRef<size_t> matches(size_t subclause, size_t eclass) const;
+  };
+
 } // namespace ematching
 
 } // namespace caffeine

--- a/src/IR/EGraphMatching.cpp
+++ b/src/IR/EGraphMatching.cpp
@@ -50,4 +50,23 @@ llvm::hash_code hash_value(const SubClause& subclause) {
                             filter_hash);
 }
 
+bool MatchData::contains_match(size_t subclause, size_t eclass) const {
+  if (subclause >= matches_.size())
+    return false;
+
+  return matches_[subclause].find(eclass) != matches_[subclause].end();
+}
+
+const MatchData::ClauseData& MatchData::matches(size_t subclause) const {
+  return matches_.at(subclause);
+}
+llvm::ArrayRef<size_t> MatchData::matches(size_t subclause,
+                                          size_t eclass) const {
+  const auto& cdata = matches_.at(subclause);
+  auto it = cdata.find(eclass);
+  if (it == cdata.end())
+    return {};
+  return it->second;
+}
+
 } // namespace caffeine::ematching

--- a/src/IR/EGraphMatching.cpp
+++ b/src/IR/EGraphMatching.cpp
@@ -69,4 +69,60 @@ llvm::ArrayRef<size_t> MatchData::matches(size_t subclause,
   return it->second;
 }
 
+size_t EMatcherBuilder::add_clause(Operation::Opcode opcode,
+                                   llvm::ArrayRef<size_t> submatchers,
+                                   std::unique_ptr<SubClauseFilter>&& filter) {
+  for (size_t subclause : submatchers)
+    CAFFEINE_ASSERT(subclause < subclause_id);
+
+  SubClause clause{
+      opcode, llvm::SmallVector<size_t>(submatchers.begin(), submatchers.end()),
+      std::move(filter)};
+
+  auto [it, inserted] = subclauses.emplace(std::move(clause), subclause_id);
+  if (!inserted)
+    return it->second;
+
+  return subclause_id++;
+}
+
+void EMatcherBuilder::add_matcher(size_t clause, EMatcherUpdater update,
+                                  std::optional<EMatcherFilter> filter) {
+  clauses.push_back(Clause{clause, filter, update});
+}
+
+EMatcher EMatcherBuilder::build() {
+  EMatcher matcher;
+
+  std::vector<std::pair<size_t, SubClause>> clausetmp;
+  clausetmp.reserve(subclauses.size());
+  for (auto it = subclauses.begin(); it != subclauses.end(); ++it) {
+    clausetmp.emplace_back(it->second,
+                           std::move(*const_cast<SubClause*>(&it->first)));
+  }
+
+  std::sort(clausetmp.begin(), clausetmp.end(),
+            [](const auto& a, const auto& b) { return a.first < b.first; });
+
+  matcher.subclauses.reserve(clausetmp.size());
+  for (auto& val : clausetmp)
+    matcher.subclauses.push_back(std::move(val.second));
+
+  subclauses.clear();
+  subclause_id = 0;
+
+  matcher.clauses = std::move(clauses);
+
+  for (size_t i = 0; i < matcher.subclauses.size(); ++i) {
+    const SubClause& clause = matcher.subclauses[i];
+    matcher.subindex[clause.opcode].push_back(i);
+  }
+
+  return matcher;
+}
+
+EMatcherBuilder EMatcher::builder() {
+  return EMatcherBuilder();
+}
+
 } // namespace caffeine::ematching


### PR DESCRIPTION
This PR introduces the `EMatcher` class. It is responsible for holding all the match clauses (i.e. queries) and rewrite rules that will be used to simplify the e-graph.

In the next PR I'll introduce the code to actually go and apply all the rewrite rules.

/stack #703 