### PR TITLE
Add an e-graph accessor class for use in rewrite rules

### DIFF
--- a/include/caffeine/IR/EGraph.h
+++ b/include/caffeine/IR/EGraph.h
@@ -113,6 +113,12 @@ public:
 
   size_t add_merge(size_t eclass, const ENode& node);
 
+  // Checks whether the e-node is contained within the graph, and, if so,
+  // returns the corresponding e-class.
+  //
+  // The passed-in enode must be in canonical form.
+  std::optional<size_t> classof(const ENode& node) const;
+
   void rebuild();
 
   // Extract an optimal representation for the given expression. This will try

--- a/include/caffeine/IR/EGraphMatching.h
+++ b/include/caffeine/IR/EGraphMatching.h
@@ -121,7 +121,7 @@ namespace ematching {
   // applied.
   class GraphAccessor {
   public:
-    GraphAccessor(EGraph* egraph, MatchData* data);
+    GraphAccessor(EGraph* egraph, const MatchData* data);
 
     // Create a new e-class with the given e-node.
     size_t add(const ENode& enode);
@@ -154,7 +154,7 @@ namespace ematching {
 
   private:
     EGraph* egraph;
-    MatchData* data;
+    const MatchData* data;
 
     std::vector<std::pair<size_t, size_t>> merges;
 

--- a/include/caffeine/IR/EGraphMatching.h
+++ b/include/caffeine/IR/EGraphMatching.h
@@ -12,6 +12,7 @@ namespace ematching {
 } // namespace ematching
 
 class ENode;
+class EClass;
 class EGraph;
 class EGraphMatcher;
 
@@ -110,6 +111,47 @@ namespace ematching {
 
     const ClauseData& matches(size_t subclause) const;
     llvm::ArrayRef<size_t> matches(size_t subclause, size_t eclass) const;
+  };
+  
+  class GraphAccessor {
+  public:
+    GraphAccessor(EGraph* egraph, MatchData* data);
+    ~GraphAccessor();
+
+    // Create a new e-class with the given e-node.
+    size_t add(const ENode& enode);
+    size_t add_merge(size_t eclass, const ENode& enode);
+
+    // Merge two e-classes together.
+    //
+    // The actual act of merging is delayed until all e-graph updates have gone
+    // through.
+    size_t merge(size_t id1, size_t id2);
+
+    const EClass* get(size_t eclass) const;
+
+    bool contains_match(size_t subclause, size_t eclass) const;
+
+    const MatchData::ClauseData& matches(size_t subclause) const;
+    llvm::ArrayRef<size_t> matches(size_t subclause, size_t eclass) const;
+
+    GraphAccessor(const GraphAccessor&) = delete;
+    GraphAccessor(GraphAccessor&&) = delete;
+
+    GraphAccessor& operator=(const GraphAccessor&) = delete;
+    GraphAccessor& operator=(GraphAccessor&&) = delete;
+
+  private:
+    // Actually write out the changes to the underlying e-graph.
+    void persist();
+
+  private:
+    EGraph* egraph;
+    MatchData* data;
+
+    std::vector<std::pair<size_t, size_t>> merges;
+
+    friend class caffeine::EGraphMatcher;
   };
 
   class EMatcherBuilder {

--- a/include/caffeine/IR/EGraphMatching.h
+++ b/include/caffeine/IR/EGraphMatching.h
@@ -112,11 +112,16 @@ namespace ematching {
     const ClauseData& matches(size_t subclause) const;
     llvm::ArrayRef<size_t> matches(size_t subclause, size_t eclass) const;
   };
-  
+
+  // Wrapper around EGraph and MatchData that only allows changes that will not
+  // invalidate the indices of elements within the e-graph.
+  //
+  // Basically, it allows you to inspect the e-graph and add new e-classes to
+  // it, but will delay merges until all current rewrite rules have been
+  // applied.
   class GraphAccessor {
   public:
     GraphAccessor(EGraph* egraph, MatchData* data);
-    ~GraphAccessor();
 
     // Create a new e-class with the given e-node.
     size_t add(const ENode& enode);
@@ -143,6 +148,8 @@ namespace ematching {
 
   private:
     // Actually write out the changes to the underlying e-graph.
+    //
+    // If this method is not called then no changes will be made to the e-graph.
     void persist();
 
   private:

--- a/src/IR/EGraph.cpp
+++ b/src/IR/EGraph.cpp
@@ -198,6 +198,13 @@ size_t EGraph::add_merge(size_t eclass_id, const ENode& node) {
   return eclass_id;
 }
 
+std::optional<size_t> EGraph::classof(const ENode& node) const {
+  auto it = hashcons.find(node);
+  if (it == hashcons.end())
+    return std::nullopt;
+  return find(it->second);
+}
+
 void EGraph::rebuild() {
   using std::swap;
 

--- a/src/IR/EGraphMatching.cpp
+++ b/src/IR/EGraphMatching.cpp
@@ -71,9 +71,6 @@ llvm::ArrayRef<size_t> MatchData::matches(size_t subclause,
 
 GraphAccessor::GraphAccessor(EGraph* egraph, MatchData* data)
     : egraph(egraph), data(data) {}
-GraphAccessor::~GraphAccessor() {
-  persist();
-}
 
 void GraphAccessor::persist() {
   for (auto [lhs, rhs] : merges)

--- a/src/IR/EGraphMatching.cpp
+++ b/src/IR/EGraphMatching.cpp
@@ -69,7 +69,7 @@ llvm::ArrayRef<size_t> MatchData::matches(size_t subclause,
   return it->second;
 }
 
-GraphAccessor::GraphAccessor(EGraph* egraph, MatchData* data)
+GraphAccessor::GraphAccessor(EGraph* egraph, const MatchData* data)
     : egraph(egraph), data(data) {}
 
 void GraphAccessor::persist() {

--- a/src/IR/EGraphMatching.cpp
+++ b/src/IR/EGraphMatching.cpp
@@ -107,6 +107,14 @@ bool GraphAccessor::contains_match(size_t subclause, size_t eclass) const {
   return data->contains_match(subclause, eclass);
 }
 
+const MatchData::ClauseData& GraphAccessor::matches(size_t subclause) const {
+  return data->matches(subclause);
+}
+llvm::ArrayRef<size_t> GraphAccessor::matches(size_t subclause,
+                                              size_t eclass) const {
+  return data->matches(subclause, eclass);
+}
+
 size_t EMatcherBuilder::add_clause(Operation::Opcode opcode,
                                    llvm::ArrayRef<size_t> submatchers,
                                    std::unique_ptr<SubClauseFilter>&& filter) {


### PR DESCRIPTION
This PR introduces the `GraphAccessor` class. All it does is prevent merges from happening while the rewrite rules are being applied, while recording which ones should happen so that they can all be done at once after the rewrites have occurred. See the comment on the class for more details.

/stack #704 

<!-- dummy comment -->