### PR TITLE
Track which e-classes have been updated within EGraph

### DIFF
--- a/include/caffeine/IR/EGraph.h
+++ b/include/caffeine/IR/EGraph.h
@@ -155,6 +155,7 @@ private:
   UnionFind<size_t> union_find;
   tsl::hopscotch_map<ENode, size_t, LLVMHasher> hashcons;
   tsl::hopscotch_map<size_t, EClass> classes;
+  tsl::hopscotch_set<size_t> updated;
   std::vector<size_t> worklist;
 
   friend class EGraphExtractor;


### PR DESCRIPTION
This is needed to efficiently do updates when performing simplifications.

/stack #705 

<!-- dummy comment -->