### PR TITLE
Add implementation of e-matching and equality saturation

### DIFF
--- a/include/caffeine/IR/EGraph.h
+++ b/include/caffeine/IR/EGraph.h
@@ -155,6 +155,7 @@ private:
   UnionFind<size_t> union_find;
   tsl::hopscotch_map<ENode, size_t, LLVMHasher> hashcons;
   tsl::hopscotch_map<size_t, EClass> classes;
+  tsl::hopscotch_set<size_t> updated;
   std::vector<size_t> worklist;
 
   friend class EGraphExtractor;

--- a/include/caffeine/IR/EGraph.h
+++ b/include/caffeine/IR/EGraph.h
@@ -10,6 +10,10 @@ namespace caffeine {
 class ENode;
 class EClass;
 class Operation;
+
+namespace ematching {
+  class EMatcher;
+}
 } // namespace caffeine
 
 CAFFEINE_DECL_LLVM_HASHER(caffeine::ENode);
@@ -140,6 +144,13 @@ public:
   OpRef extract(const Operation& op);
   OpRef extract(const Operation& op) const;
 
+  // Simplify the e-graph using all the rewrite rules within matcher.
+  //
+  // The implementation of the e-graph assumes that it keep being called
+  // repeatedly with the same EMatcher instance. Calling it with different
+  // EMatcher instances will likely result in some rewrites being missed.
+  void simplify(const ematching::EMatcher& matcher);
+
   void constprop();
 
 private:
@@ -158,6 +169,7 @@ private:
   tsl::hopscotch_set<size_t> updated;
   std::vector<size_t> worklist;
 
+  friend class EGraphMatcher;
   friend class EGraphExtractor;
   friend class EGraphConstantPropagator;
 };

--- a/include/caffeine/IR/EGraphMatching.h
+++ b/include/caffeine/IR/EGraphMatching.h
@@ -204,4 +204,8 @@ namespace ematching {
 
 } // namespace ematching
 
+using EMatchSubClause = ematching::SubClause;
+using EMatchClause = ematching::Clause;
+using EMatcherData = ematching::MatchData;
+
 } // namespace caffeine

--- a/src/IR/EGraphMatcher.cpp
+++ b/src/IR/EGraphMatcher.cpp
@@ -1,0 +1,196 @@
+#include "caffeine/IR/EGraph.h"
+#include "caffeine/IR/EGraphMatching.h"
+#include "caffeine/IR/OperationBase.h"
+#include <boost/range/combine.hpp>
+#include <boost/range/join.hpp>
+#include <fmt/format.h>
+#include <magic_enum.hpp>
+#include <tsl/hopscotch_map.h>
+#include <unordered_map>
+
+namespace caffeine {
+
+using namespace ematching;
+
+class EGraphMatcher {
+public:
+  struct WorkItem {
+    size_t clause;
+    size_t eclass;
+    size_t enode;
+  };
+
+  const EMatcher* matcher;
+  EGraph* egraph;
+
+  // Map of clause -> eclass -> node index
+  std::unordered_map<size_t, std::unordered_multimap<size_t, size_t>>
+      potentials = {};
+  // Map of eclass -> clause
+  // Used to remove matches from an updated clause
+  std::unordered_map<size_t, std::vector<size_t>> reversed = {};
+
+public:
+  void equality_saturation() {
+    egraph->constprop();
+    egraph->rebuild();
+
+    while (!egraph->updated.empty()) {
+      update_potential_matches();
+      auto data = find_matches();
+      auto work = matching_work_items(data);
+
+      egraph->updated.clear();
+
+      GraphAccessor accessor(egraph, &data);
+
+      for (auto [clause_id, eclass_id, enode_id] : work) {
+        const auto& clause = matcher->clauses[clause_id];
+        clause.update(accessor, eclass_id, enode_id);
+      }
+
+      accessor.persist();
+
+      egraph->constprop();
+      egraph->rebuild();
+    }
+  }
+
+  // Methods for setting up potential matches
+  // ========================================
+
+  // Build the initial set of potential matches for the given e-class.
+  void update_eclass_potential_matches(size_t eclass_id) {
+    const EClass& eclass = *egraph->get(eclass_id);
+
+    for (size_t clause_id : reversed[eclass_id]) {
+      potentials[clause_id].erase(eclass_id);
+    }
+
+    for (size_t node_id = 0; node_id < eclass.nodes.size(); ++node_id) {
+      const ENode& node = eclass.nodes[node_id];
+
+      for (size_t clause_id :
+           boost::range::join(matching_clauses(Operation::Invalid),
+                              matching_clauses(node.opcode()))) {
+        const EMatchSubClause& clause = matcher->subclauses[clause_id];
+
+        if (clause.is_potential_match(node)) {
+          potentials[clause_id].emplace(eclass_id, node_id);
+          reversed[eclass_id].push_back(clause_id);
+        }
+      }
+    }
+  }
+
+  void update_potential_matches() {
+    if (potentials.empty()) {
+      for (const auto& [eclass, _] : egraph->classes)
+        update_eclass_potential_matches(eclass);
+    } else {
+      for (size_t eclass : egraph->updated)
+        update_eclass_potential_matches(eclass);
+    }
+  }
+
+  // Find all matching subclauses and build an EMatcherData structure for them.
+  EMatcherData find_matches() {
+    MatchData::MapData matches;
+    matches.reserve(matcher->clauses.size());
+
+    for (size_t clause_id = 0; clause_id < matcher->subclauses.size();
+         ++clause_id) {
+      MatchData::ClauseData clause_matches;
+
+      auto pit = potentials.find(clause_id);
+      if (pit == potentials.end()) {
+        matches.push_back(std::move(clause_matches));
+        continue;
+      }
+
+      const auto& clause = matcher->subclauses[clause_id];
+      const auto& potentials = pit->second;
+
+      for (const auto& [eclass_id, enode_id] : potentials) {
+        const EClass& eclass = *egraph->get(eclass_id);
+        const ENode& enode = eclass.nodes.at(enode_id);
+
+        if (!clause.submatchers.empty()) {
+          if (clause.submatchers.size() != enode.operands.size())
+            continue;
+
+          for (auto value :
+               boost::range::combine(clause.submatchers, enode.operands)) {
+            auto subclause = boost::get<0>(value);
+            auto operand = boost::get<1>(value);
+
+            if (matches.size() <= subclause)
+              goto do_continue;
+
+            const auto& submatches = matches.at(subclause);
+            if (submatches.find(operand) == submatches.end())
+              goto do_continue;
+          }
+        }
+
+        clause_matches[eclass_id].push_back(enode_id);
+
+      do_continue:
+        continue;
+      }
+
+      matches.push_back(std::move(clause_matches));
+    }
+
+    return EMatcherData(std::move(matches));
+  }
+
+  // Find all matching top-level matchers. All this does is filter out matches
+  // that don't satisfy the filter function.
+  std::vector<WorkItem> matching_work_items(const EMatcherData& data) {
+    std::vector<WorkItem> top_level;
+    GraphAccessor accessor{egraph, &data};
+
+    for (size_t clause_id = 0; clause_id < matcher->clauses.size();
+         ++clause_id) {
+      const EMatchClause& clause = matcher->clauses[clause_id];
+      const EMatchSubClause& subclause = matcher->subclauses[clause.matcher];
+
+      const auto& matches = data.matches(clause.matcher);
+      for (const auto& [eclass_id, enodes] : matches) {
+        for (size_t enode_id : enodes) {
+          const EClass* eclass = egraph->get(eclass_id);
+          const ENode& enode = eclass->nodes[enode_id];
+
+          if (subclause.opcode != Operation::Invalid) {
+            CAFFEINE_ASSERT(
+                enode.opcode() == subclause.opcode,
+                fmt::format("{} != {}", Operation::opcode_name(enode.opcode()),
+                            Operation::opcode_name(subclause.opcode)));
+          }
+
+          if (clause.filter.has_value() && !(*clause.filter)(accessor, enode))
+            continue;
+
+          top_level.push_back({clause_id, eclass_id, enode_id});
+        }
+      }
+    }
+
+    return top_level;
+  }
+
+  llvm::ArrayRef<size_t> matching_clauses(Operation::Opcode opcode) const {
+    auto it = matcher->subindex.find(opcode);
+    if (it == matcher->subindex.end())
+      return {};
+    return it->second;
+  }
+};
+
+void EGraph::simplify(const EMatcher& matcher) {
+  EGraphMatcher g{&matcher, this};
+  g.equality_saturation();
+}
+
+} // namespace caffeine


### PR DESCRIPTION
This commit is the main algorithmic part of the whole work on e-graphs and e-matching. It implements the logic for efficiently finding all queries that match within the `EMatcher` and then, for each matching query, it will apply the corresponding rewrite rule.

The algorithm implemented here is based off of the `equality_saturation` algorithm from within the [egg paper](https://arxiv.org/pdf/2004.03082.pdf). However, the details of the algorithm as implemented here end up spanning about 150 LOC. Check out `EGraphMatcher::equality_saturation` for the high level bits of code involved, and then look at the individual methods for the details of how each step is actually done.

/stack #706 