### PR TITLE
Batched small fixes to `EGraph` in order to make it work

### DIFF
--- a/include/caffeine/IR/EGraph.h
+++ b/include/caffeine/IR/EGraph.h
@@ -168,7 +168,7 @@ private:
 private:
   UnionFind<size_t> union_find;
   tsl::hopscotch_map<ENode, size_t, LLVMHasher> hashcons;
-  tsl::hopscotch_map<size_t, EClass> classes;
+  std::unordered_map<size_t, EClass> classes;
   tsl::hopscotch_set<size_t> updated;
   std::vector<size_t> worklist;
 

--- a/include/caffeine/IR/EGraphMatching.h
+++ b/include/caffeine/IR/EGraphMatching.h
@@ -207,5 +207,6 @@ namespace ematching {
 using EMatchSubClause = ematching::SubClause;
 using EMatchClause = ematching::Clause;
 using EMatcherData = ematching::MatchData;
+using EMatcher = ematching::EMatcher;
 
 } // namespace caffeine

--- a/src/IR/EGraph.cpp
+++ b/src/IR/EGraph.cpp
@@ -277,14 +277,16 @@ void EGraph::repair(size_t eclass_id) {
 
     auto it = new_parents.find(canonical);
     if (it != new_parents.end()) {
-      merge(p_eclass, it->second);
-      it.value() = find(p_eclass);
+      it.value() = merge(p_eclass, it->second);
     } else {
       new_parents.insert({canonical, find(p_eclass)});
     }
   }
 
   eclass.parents = new_parents;
+
+  for (ENode& node : eclass.nodes)
+    node = canonicalize(node);
 }
 
 void EGraph::unparent(size_t eclass_id) {

--- a/src/IR/EGraph.cpp
+++ b/src/IR/EGraph.cpp
@@ -127,13 +127,13 @@ size_t EGraph::find(size_t id) {
 EClass* EGraph::get(size_t id) {
   auto it = classes.find(find(id));
   if (it != classes.end())
-    return &it.value();
+    return &it->second;
   return nullptr;
 }
 const EClass* EGraph::get(size_t id) const {
   auto it = classes.find(find(id));
   if (it != classes.end())
-    return &it.value();
+    return &it->second;
   return nullptr;
 }
 

--- a/src/IR/EGraphConstprop.cpp
+++ b/src/IR/EGraphConstprop.cpp
@@ -144,8 +144,7 @@ void EGraph::constprop() {
   std::queue<size_t> queue;
 
   for (auto it = classes.begin(); it != classes.end(); ++it) {
-    size_t id = it.key();
-    EClass& eclass = it.value();
+    auto& [id, eclass] = *it;
 
     if (eclass.is_constant()) {
       propagator.constants.insert(id);

--- a/src/IR/EGraphMatcher.cpp
+++ b/src/IR/EGraphMatcher.cpp
@@ -67,6 +67,10 @@ public:
       potentials[clause_id].erase(eclass_id);
     }
 
+    // Don't calculate any potential matches for e-classes which have expired.
+    if (egraph->find(eclass_id) != eclass_id)
+      return;
+
     for (size_t node_id = 0; node_id < eclass.nodes.size(); ++node_id) {
       const ENode& node = eclass.nodes[node_id];
 
@@ -158,6 +162,11 @@ public:
 
       const auto& matches = data.matches(clause.matcher);
       for (const auto& [eclass_id, enodes] : matches) {
+        if (egraph->find(eclass_id) != eclass_id)
+          continue;
+        if (!egraph->updated.contains(eclass_id))
+          continue;
+
         for (size_t enode_id : enodes) {
           const EClass* eclass = egraph->get(eclass_id);
           const ENode& enode = eclass->nodes[enode_id];

--- a/src/IR/EGraphMatching.cpp
+++ b/src/IR/EGraphMatching.cpp
@@ -82,13 +82,7 @@ size_t GraphAccessor::add(const ENode& enode) {
   return egraph->add(enode);
 }
 size_t GraphAccessor::add_merge(size_t eclass, const ENode& node) {
-  auto canonical = egraph->canonicalize(node);
-  if (auto existing = egraph->classof(node))
-    return merge(eclass, *existing);
-
-  // Safe since this will only add the node to the existing class. It won't
-  // result in any existing indices used in matches becoming invalid.
-  return egraph->add_merge(eclass, node);
+  return merge(eclass, add(node));
 }
 
 size_t GraphAccessor::merge(size_t id1, size_t id2) {


### PR DESCRIPTION
This PR is a series of small fixes to various bits of code involved in the e-graph and e-matching. They have been extracted from the next set of changes that will introduce rewrites and start using them before making calls to the solver.

/stack #710 