### PR TITLE
Ensure that the install from the bazel build is usable

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -5,7 +5,7 @@ load("//bazel:packaging.bzl", "caffeine_naming", "pkg_headers")
 load("//bazel:clang-format.bzl", "do_format", "format_test")
 load("@hedron_compile_commands//:refresh_compile_commands.bzl", "refresh_compile_commands")
 load("@rules_pkg//:pkg.bzl", "pkg_tar")
-load("@rules_pkg//:mappings.bzl", "pkg_filegroup", "pkg_files")
+load("@rules_pkg//:mappings.bzl", "pkg_attributes", "pkg_filegroup", "pkg_files")
 load("@rules_pkg//:install.bzl", "pkg_install")
 
 package(default_visibility = ["//visibility:public"])
@@ -132,7 +132,6 @@ caffeine_naming(
 )
 
 FILE_RENAMES = {
-    "//tools/caffeine": "bin/caffeine",
     "//:caffeine-shared": "lib/libcaffeine.so",
     "//tools/opt-plugin": "lib/libcaffeine-opt-plugin.so",
     "//libraries/builtins": "lib/caffeine/caffeine-builtins.bc",
@@ -141,8 +140,21 @@ FILE_RENAMES = {
     "//:cmake-config": "lib/cmake/caffeine/caffeine-config.cmake",
     "//interface:caffeine.h": "include/caffeine/interface/caffeine.h",
     "scripts/vcpkg/gllvm-toolchain.cmake": "share/vcpkg/gllvm-toolchain.cmake",
-    "scripts/vcpkg/x64-linux-gllvm.cmake": "share/vcpkg/x64-linux-gllvm",
+    "scripts/vcpkg/x64-linux-gllvm.cmake": "share/vcpkg/x64-linux-gllvm.cmake",
 }
+
+BINARY_RENAMES = {
+    "//tools/caffeine": "bin/caffeine",
+    "@llvm//llvm:opt": "bin/caffeine-opt",
+}
+
+pkg_files(
+    name = "caffeine-executables",
+    srcs = BINARY_RENAMES.keys(),
+    attributes = pkg_attributes(mode = "755"),
+    renames = BINARY_RENAMES,
+    visibility = ["//visibility:private"],
+)
 
 pkg_files(
     name = "caffeine-files",
@@ -154,6 +166,7 @@ pkg_files(
 pkg_filegroup(
     name = "caffeine-package",
     srcs = [
+        ":caffeine-executables",
         ":caffeine-files",
         ":caffeine-headers",
     ],

--- a/cmake/CaffeineBazelConfig.cmake.in
+++ b/cmake/CaffeineBazelConfig.cmake.in
@@ -11,6 +11,7 @@ if(_IMPORT_PREFIX STREQUAL "/")
 endif()
 
 add_executable(caffeine::caffeine-bin               IMPORTED GLOBAL)
+add_executable(caffeine::caffeine-opt               IMPORTED GLOBAL)
 
 add_library(caffeine::caffeine            SHARED    IMPORTED GLOBAL)
 add_library(caffeine::caffeine-opt-plugin SHARED    IMPORTED GLOBAL)
@@ -19,12 +20,18 @@ add_library(caffeine::interface           INTERFACE IMPORTED GLOBAL)
 set_target_properties(caffeine::caffeine-bin PROPERTIES
   IMPORTED_LOCATION "${_IMPORT_PREFIX}/bin/caffeine"
 )
+set_target_properties(caffeine::caffeine-opt PROPERTIES
+  IMPORTED_LOCATION "${_IMPORT_PREFIX}/bin/caffeine-opt"
+)
+
 set_target_properties(caffeine::caffeine PROPERTIES
   INTERFACE_INCLUDE_DIRECTORIES "${_IMPORT_PREFIX}/include/"
   IMPORTED_SONAME               "${_IMPORT_PREFIX}/lib/libcaffeine.so"
+  IMPORTED_LOCATION             "${_IMPORT_PREFIX}/lib/libcaffeine.so"
 )
 set_target_properties(caffeine::caffeine-opt-plugin PROPERTIES
   IMPORTED_SONAME              "${_IMPORT_PREFIX}/lib/libcaffeine-opt-plugin.so"
+  IMPORTED_LOCATION            "${_IMPORT_PREFIX}/lib/libcaffeine-opt-plugin.so"
 )
 set_target_properties(caffeine::interface PROPERTIES
   INTERFACE_INCLUDE_DIRECTORIES "${_IMPORT_PREFIX}/include/caffeine/interface/"


### PR DESCRIPTION
When trying to use the install from the bazel build from within cmake I discovered that there were a few issues:
- The binaries did not have executable permissions
- The x86-linux-gllvm triplet was missing the cmake extension so vcpkg was unable to find it.
- It was very difficult to figure out how to use opt with caffeine in a way that works.
- The exported cmake targets were missing info on where to actually find the binaries in the install directory. This meant that generator rules such as `$<TARGET_FILE:caffeine::caffeine>` would not work.

This commit addresses all three:
- I've specified that the binaries should be executable
- I've fixed the rename rule for the triplet file
- I've exported our copy of opt as caffeine-opt so that it can just be used directly instead of futzing around with llvm versions to try and make it work.
- I now set the `IMPORTED_LOCATION` target for all targets within the cmake config file so that `$<TARGET_FILE:...>` generator expressions work as expected.