### PR TITLE
Prevent Z3 from intercepting SIGINT within solver calls

### DIFF
--- a/src/Solver/Z3Solver.cpp
+++ b/src/Solver/Z3Solver.cpp
@@ -192,6 +192,9 @@ SolverResult Z3Solver::resolve(AssertionList& assertions,
   auto block = CAFFEINE_TRACE_SPAN("Z3Solver::resolve");
 
   z3::solver solver = impl->tactic.mk_solver();
+  // We need to disable Ctrl^C at the solver level in order to prevent Z3 from
+  // catching SIGINT when we don't want it to.
+  solver.set("ctrl_c", false);
   Z3Model::ConstMap constMap;
 
   Z3OpVisitor visitor{&solver, constMap};

--- a/src/Solver/Z3Solver.h
+++ b/src/Solver/Z3Solver.h
@@ -28,8 +28,6 @@ public:
     ctx.set("model", true);
     // Automatically select and configure the solver
     ctx.set("auto_config", true);
-    // Z3 will set a SIGINT handler unless we tell it not to
-    ctx.set("ctrl_c", false);
   }
 };
 


### PR DESCRIPTION
By default, Z3 will intercept a SIGINT signal that occurs within a solver call, swallow it, and return UNKNOWN from the solver. This doesn't at all match with what we want to do on a SIGINT call.

By looking at the Z3 source code, you can see an option "ctrl_c" that supposedly controls whether Z3 will catch SIGINT or not. The previous effort to fix this set the "ctrl_c" parameter on the Z3 context. What the Z3 API does not tell you is that "ctrl_c" is not a valid paramter on the Z3 context and that if you try to set "ctrl_c" on a Z3 context then it will just silently fail to do anything. This obviously meant that the previous attempt at fixing this (by me) did not do anything.

In this attempt, I traced the uses of the "ctrl_c" parameter within the Z3 codebase back to the public API that allows us to set them. As it turns out, the "ctrl_c" option is a _solver_ parameter and not a context or global parameter. I, for one, did not even know there were solver parameters. However, once this is known then the fix is fairly trivial. This commit removes the previous attempt at setting a context parameter and instead just sets the solver parameter after having constructed it.

@Skrinikov this should help somewhat with simplifying what needs to be done for #637 