### PR TITLE
Implement a rewrite rule that implements associativity rules

### DIFF
--- a/include/caffeine/IR/EGraph.h
+++ b/include/caffeine/IR/EGraph.h
@@ -192,6 +192,9 @@ public:
   OpRef extract(size_t eclass);
   OpRef extract(const Operation& expr);
 
+  // Update the cached costs for the eclass and all those it depends upon.
+  void update_cost(size_t eclass_id);
+
 private:
   EClassCost eval_cost(size_t eclass_id);
   uint64_t eval_cost(const ENode& node);

--- a/include/caffeine/IR/EGraphMatching.h
+++ b/include/caffeine/IR/EGraphMatching.h
@@ -140,6 +140,8 @@ namespace ematching {
     const MatchData::ClauseData& matches(size_t subclause) const;
     llvm::ArrayRef<size_t> matches(size_t subclause, size_t eclass) const;
 
+    EGraph* graph();
+
     GraphAccessor(const GraphAccessor&) = delete;
     GraphAccessor(GraphAccessor&&) = delete;
 

--- a/include/caffeine/IR/EGraphMatching.h
+++ b/include/caffeine/IR/EGraphMatching.h
@@ -192,6 +192,10 @@ namespace ematching {
     // (#binop ?x ?y) -> (#binop ?y ?x)
     void commutativity(EMatcherBuilder& builder);
     void commutativity(EMatcherBuilder& builder, Operation::Opcode opcode);
+
+    // (#op ?x (#op ?y ?z)) -> (#op (#op ?x ?y) ?z)
+    void associativity(EMatcherBuilder& builder);
+    void associativity(EMatcherBuilder& builder, Operation::Opcode opcode);
   } // namespace reductions
 
   class EMatcher {

--- a/src/IR/EGraph.cpp
+++ b/src/IR/EGraph.cpp
@@ -493,4 +493,8 @@ OpRef EGraphExtractor::extract(const Operation& expr) {
   return expr.with_new_operands(operands);
 }
 
+void EGraphExtractor::update_cost(size_t eclass_id) {
+  eval_cost(eclass_id);
+}
+
 } // namespace caffeine

--- a/src/IR/EGraphMatching.cpp
+++ b/src/IR/EGraphMatching.cpp
@@ -109,6 +109,10 @@ llvm::ArrayRef<size_t> GraphAccessor::matches(size_t subclause,
   return data->matches(subclause, eclass);
 }
 
+EGraph* GraphAccessor::graph() {
+  return egraph;
+}
+
 size_t EMatcherBuilder::add_clause(Operation::Opcode opcode,
                                    llvm::ArrayRef<size_t> submatchers,
                                    std::unique_ptr<SubClauseFilter>&& filter) {

--- a/src/IR/EMatching/Rewrites/Associativity.cpp
+++ b/src/IR/EMatching/Rewrites/Associativity.cpp
@@ -1,0 +1,97 @@
+#include "caffeine/IR/EGraph.h"
+#include "caffeine/IR/EGraphMatching.h"
+#include "caffeine/IR/EMatching/Filters.h"
+#include "caffeine/IR/OperationData.h"
+#include <caffeine/IR/OperationBase.h>
+#include <fmt/format.h>
+#include <fmt/ranges.h>
+#include <tsl/hopscotch_set.h>
+
+namespace caffeine::ematching::reductions {
+
+namespace {
+  struct AssociativityRewriter {
+    struct MatchItem {
+      size_t eclass;
+      size_t enode;
+    };
+
+    GraphAccessor* egraph;
+    size_t clause;
+    Operation::Opcode opcode;
+    size_t original;
+
+    std::vector<size_t> stack = {};
+
+    void rewrite(size_t eclass_id) {
+      const EClass* eclass = egraph->get(eclass_id);
+      const ENode& enode = eclass->nodes[eclass->cache.cost->index];
+
+      if (enode.opcode() == opcode) {
+        rewrite(enode.operands[0]);
+        rewrite(enode.operands[1]);
+      } else {
+        stack.push_back(eclass_id);
+      }
+    }
+    void rewrite(const MatchItem& item) {
+      EGraphExtractor extractor{egraph->graph()};
+      extractor.update_cost(item.eclass);
+
+      const EClass* eclass = egraph->get(item.eclass);
+      const ENode& enode = eclass->nodes[item.enode];
+
+      rewrite(enode.operands[0]);
+      rewrite(enode.operands[1]);
+      emit();
+    }
+
+    void emit() {
+      auto items = stack;
+      std::sort(items.begin(), items.end(),
+                [&](size_t a, size_t b) { return compare(a, b); });
+
+      size_t eclass = items.front();
+      auto data =
+          std::make_shared<OperationData>(opcode, egraph->get(eclass)->type());
+
+      for (size_t i = 1; i < items.size(); ++i) {
+        eclass = egraph->add(ENode{data, {eclass, items[i]}});
+      }
+
+      egraph->merge(original, eclass);
+    }
+
+    bool compare(size_t a, size_t b) {
+      const EClass* aclass = egraph->get(a);
+      const EClass* bclass = egraph->get(b);
+
+      // We want to group all the constants together
+      if (aclass->is_constant() ^ bclass->is_constant())
+        return aclass->is_constant();
+
+      // After that just try and group equivalent e-classes together
+      return a < b;
+    }
+  };
+} // namespace
+
+void associativity(EMatcherBuilder& builder, Operation::Opcode opcode) {
+  size_t clause = builder.add_clause(opcode);
+
+  builder.add_matcher(
+      clause, [=](GraphAccessor& egraph, size_t eclass_id, size_t enode_id) {
+        AssociativityRewriter r{&egraph, clause, opcode, eclass_id};
+        r.rewrite({eclass_id, enode_id});
+      });
+}
+void associativity(EMatcherBuilder& builder) {
+  Operation::Opcode valid[] = {Operation::Add,  Operation::Mul, Operation::And,
+                               Operation::Or,   Operation::Xor, Operation::FAdd,
+                               Operation::FSub, Operation::FMul};
+
+  for (auto opcode : valid)
+    associativity(builder, opcode);
+}
+
+} // namespace caffeine::ematching::reductions

--- a/test/unit/IR/EMatching.cpp
+++ b/test/unit/IR/EMatching.cpp
@@ -37,3 +37,22 @@ TEST_F(EMatchingTests, commutativity) {
   ASSERT_EQ(egraph.find(cid), egraph.find(did));
   ASSERT_NE(egraph.find(aid), egraph.find(bid));
 }
+
+TEST_F(EMatchingTests, associativity) {
+  r::associativity(builder, Operation::Add);
+  auto matcher = builder.build();
+
+  auto a = add(Constant::Create(Type::int_ty(32), "a"));
+  auto b = add(Constant::Create(Type::int_ty(32), "b"));
+  auto c = add(Constant::Create(Type::int_ty(32), "c"));
+
+  auto t1 = add(BinaryOp::CreateAdd(a, BinaryOp::CreateAdd(b, c)));
+  auto t2 = add(BinaryOp::CreateAdd(BinaryOp::CreateAdd(a, b), c));
+
+  size_t id1 = egraph.add(*t1);
+  size_t id2 = egraph.add(*t2);
+
+  egraph.simplify(matcher);
+
+  ASSERT_EQ(egraph.find(id1), egraph.find(id2));
+}


### PR DESCRIPTION
As in title. The evaluation metric uses cached costs to select the expression to canonicalize so I've also gone and exposed a method on `EGraphEvaluator` that updates the cached costs.

Somehow the previous PR (#713) here got merged into the wrong branch so I'm recreating it _again_.