### PR TITLE
Implement additional eliminations for `icmp` opcode variants

### DIFF
--- a/include/caffeine/IR/EGraphMatching.h
+++ b/include/caffeine/IR/EGraphMatching.h
@@ -216,6 +216,9 @@ namespace ematching {
 
     // (and ?x 0) -> (ixx 0)
     void and_zero_elimination(EMatcherBuilder& builder);
+
+    // (icmp.## ?x ?x) -> true or false
+    void icmp_eliminations(EMatcherBuilder& builder);
   } // namespace reductions
 
   class EMatcher {

--- a/src/IR/EMatching/AllMatchers.cpp
+++ b/src/IR/EMatching/AllMatchers.cpp
@@ -72,6 +72,7 @@ void EMatcherBuilder::add_defaults() {
   reductions::and_elimination(*this);
   reductions::xor_elimination(*this);
   reductions::or_elimination(*this);
+  reductions::icmp_eliminations(*this);
 
   reductions::and_zero_elimination(*this);
 }

--- a/src/IR/EMatching/Rewrites/ICmpElimination.cpp
+++ b/src/IR/EMatching/Rewrites/ICmpElimination.cpp
@@ -1,0 +1,34 @@
+#include "caffeine/IR/EGraph.h"
+#include "caffeine/IR/EGraphMatching.h"
+#include "caffeine/IR/EMatching/Filters.h"
+#include "caffeine/IR/OperationData.h"
+
+namespace caffeine::ematching::reductions {
+
+static void eliminate_to_bool(EMatcherBuilder& builder,
+                              Operation::Opcode opcode, bool value) {
+  size_t clause = builder.add_clause(
+      opcode, {}, std::make_unique<IdenticalOperandsFilter>());
+  auto matcher = [=](GraphAccessor& egraph, size_t eclass_id, size_t) {
+    egraph.add_merge(eclass_id, ENode{std::make_unique<ConstantIntData>(
+                                    value ? llvm::APInt::getAllOnesValue(1)
+                                          : llvm::APInt::getNullValue(1))});
+  };
+
+  builder.add_matcher(clause, std::move(matcher));
+}
+
+void icmp_eliminations(EMatcherBuilder& builder) {
+  eliminate_to_bool(builder, Operation::ICmpEq, true);
+  eliminate_to_bool(builder, Operation::ICmpNe, false);
+  eliminate_to_bool(builder, Operation::ICmpUgt, false);
+  eliminate_to_bool(builder, Operation::ICmpUge, true);
+  eliminate_to_bool(builder, Operation::ICmpUlt, false);
+  eliminate_to_bool(builder, Operation::ICmpUle, true);
+  eliminate_to_bool(builder, Operation::ICmpSgt, false);
+  eliminate_to_bool(builder, Operation::ICmpSge, true);
+  eliminate_to_bool(builder, Operation::ICmpSlt, false);
+  eliminate_to_bool(builder, Operation::ICmpSle, true);
+}
+
+} // namespace caffeine::ematching::reductions

--- a/test/unit/IR/EMatching.cpp
+++ b/test/unit/IR/EMatching.cpp
@@ -167,3 +167,23 @@ TEST_F(EMatchingTests, sub_elimination) {
 
   ASSERT_EQ(egraph.find(cid), egraph.find(did));
 }
+
+TEST_F(EMatchingTests, icmp_elimination) {
+  r::icmp_eliminations(builder);
+  auto matcher = builder.build();
+
+  auto a = add(Constant::Create(Type::int_ty(32), "a"));
+  auto b = add(Constant::Create(Type::int_ty(32), "b"));
+  auto c = add(ICmpOp::CreateICmpEQ(a, b));
+  auto d = add(ConstantInt::Create(true));
+
+  auto aid = egraph.add(*a);
+  auto bid = egraph.add(*b);
+  auto cid = egraph.add(*c);
+  auto did = egraph.add(*d);
+
+  egraph.merge(aid, bid);
+  egraph.simplify(matcher);
+
+  ASSERT_EQ(egraph.find(cid), egraph.find(did));
+}

--- a/test/unit/IR/EMatching.cpp
+++ b/test/unit/IR/EMatching.cpp
@@ -147,3 +147,23 @@ TEST_F(EMatchingTests, and_zero_elimination) {
   ASSERT_EQ(egraph.find(cid), egraph.find(bid));
   ASSERT_NE(egraph.find(aid), egraph.find(cid));
 }
+
+TEST_F(EMatchingTests, sub_elimination) {
+  r::sub_elimination(builder, Operation::Add);
+  auto matcher = builder.build();
+
+  auto a = add(Constant::Create(Type::int_ty(32), "a"));
+  auto b = add(Constant::Create(Type::int_ty(32), "b"));
+  auto c = add(BinaryOp::CreateSub(a, b));
+  auto d = add(ConstantInt::CreateZero(32));
+
+  size_t aid = egraph.add(*a);
+  size_t bid = egraph.add(*b);
+  size_t cid = egraph.add(*c);
+  size_t did = egraph.add(*d);
+
+  egraph.merge(aid, bid);
+  egraph.simplify(matcher);
+
+  ASSERT_EQ(egraph.find(cid), egraph.find(did));
+}

--- a/test/unit/IR/EMatching.cpp
+++ b/test/unit/IR/EMatching.cpp
@@ -149,7 +149,7 @@ TEST_F(EMatchingTests, and_zero_elimination) {
 }
 
 TEST_F(EMatchingTests, sub_elimination) {
-  r::sub_elimination(builder, Operation::Add);
+  r::sub_elimination(builder);
   auto matcher = builder.build();
 
   auto a = add(Constant::Create(Type::int_ty(32), "a"));


### PR DESCRIPTION
This PR implements a bunch of rewrites that take operations of the form `(icmp.xx ?x ?x)` and replace them with an equivalent constant value. I've also included a test case that verifies that things are working correctly.

/stack #708 