### PR TITLE
Add rewrite rules needed to elide stores when possible

### DIFF
--- a/include/caffeine/IR/EGraphMatching.h
+++ b/include/caffeine/IR/EGraphMatching.h
@@ -227,6 +227,10 @@ namespace ematching {
     // (zext.ixx (trunc.iyy ?z)) -> (and v (ixx (2^yy - 1)))
     void zext_trunc_elimination(EMatcherBuilder& builder);
     
+    // (select (i1 1) ?x ?y) -> ?x
+    // (select (i1 0) ?x ?y) -> ?y
+    void select_constprop(EMatcherBuilder& builder);
+
     // (load (store ?a ?b ?c) ?d) -> (select (icmp.eq ?b ?d) ?c (load ?a ?d))
     void load_store_elimination(EMatcherBuilder& builder);
   } // namespace reductions

--- a/include/caffeine/IR/EGraphMatching.h
+++ b/include/caffeine/IR/EGraphMatching.h
@@ -226,6 +226,9 @@ namespace ematching {
 
     // (zext.ixx (trunc.iyy ?z)) -> (and v (ixx (2^yy - 1)))
     void zext_trunc_elimination(EMatcherBuilder& builder);
+    
+    // (load (store ?a ?b ?c) ?d) -> (select (icmp.eq ?b ?d) ?c (load ?a ?d))
+    void load_store_elimination(EMatcherBuilder& builder);
   } // namespace reductions
 
   class EMatcher {

--- a/src/IR/EGraph.cpp
+++ b/src/IR/EGraph.cpp
@@ -113,6 +113,15 @@ bool EClass::is_constant() const {
   return constant_index.has_value();
 }
 
+ENode* EClass::constant() {
+  return const_cast<ENode*>(const_cast<const EClass*>(this)->constant());
+}
+const ENode* EClass::constant() const {
+  if (!constant_index)
+    return nullptr;
+  return &nodes[*constant_index];
+}
+
 Type EClass::type() const {
   return nodes.front().data->type();
 }

--- a/src/IR/EMatching/AllMatchers.cpp
+++ b/src/IR/EMatching/AllMatchers.cpp
@@ -76,6 +76,7 @@ void EMatcherBuilder::add_defaults() {
 
   reductions::and_zero_elimination(*this);
   reductions::zext_trunc_elimination(*this);
+  reductions::select_constprop(*this);
 }
 
 } // namespace caffeine::ematching

--- a/src/IR/EMatching/AllMatchers.cpp
+++ b/src/IR/EMatching/AllMatchers.cpp
@@ -77,6 +77,7 @@ void EMatcherBuilder::add_defaults() {
   reductions::and_zero_elimination(*this);
   reductions::zext_trunc_elimination(*this);
   reductions::select_constprop(*this);
+  reductions::load_store_elimination(*this);
 }
 
 } // namespace caffeine::ematching

--- a/src/IR/EMatching/Rewrites/LoadElimination.cpp
+++ b/src/IR/EMatching/Rewrites/LoadElimination.cpp
@@ -1,0 +1,35 @@
+#include "caffeine/IR/EGraph.h"
+#include "caffeine/IR/EGraphMatching.h"
+
+namespace caffeine::ematching::reductions {
+
+// (load (store ?a ?b ?c) ?d) -> (select (icmp.eq ?b ?d) ?c (load ?a ?d))
+void load_store_elimination(EMatcherBuilder& builder) {
+  size_t any = builder.add_any();
+  size_t store = builder.add_clause(Operation::Store);
+  size_t load = builder.add_clause(Operation::Load, {store, any});
+
+  auto matcher = [=](GraphAccessor& egraph, size_t eclass_id, size_t node_id) {
+    const EClass* load_class = egraph.get(eclass_id);
+    const ENode& load_enode = load_class->nodes.at(node_id);
+    const EClass* store_class = egraph.get(load_enode.operands[0]);
+
+    for (size_t id : egraph.matches(store, load_enode.operands[0])) {
+      const ENode& store_node = store_class->nodes.at(id);
+
+      size_t icmp = egraph.add(ENode{
+          std::make_unique<OperationData>(Operation::ICmpEq, Type::bool_ty()),
+          {store_node.operands[1], load_enode.operands[1]}});
+      size_t load = egraph.add(ENode{
+          load_enode.data, {store_node.operands[0], load_enode.operands[1]}});
+      egraph.add_merge(eclass_id,
+                       ENode{std::make_unique<OperationData>(Operation::Select,
+                                                             load_enode.type()),
+                             {icmp, store_node.operands[2], load}});
+    }
+  };
+
+  builder.add_matcher(load, matcher);
+}
+
+} // namespace caffeine::ematching::reductions

--- a/src/IR/EMatching/Rewrites/SelectConstprop.cpp
+++ b/src/IR/EMatching/Rewrites/SelectConstprop.cpp
@@ -1,0 +1,30 @@
+#include "caffeine/IR/EGraph.h"
+#include "caffeine/IR/EGraphMatching.h"
+#include "caffeine/IR/OperationData.h"
+
+namespace caffeine::ematching::reductions {
+
+void select_constprop(EMatcherBuilder& builder) {
+  size_t any = builder.add_any();
+  size_t constant = builder.add_clause(Operation::ConstantInt);
+  size_t select = builder.add_clause(Operation::Select, {constant, any, any});
+
+  auto matcher = [=](GraphAccessor& egraph, size_t eclass_id, size_t enode_id) {
+    const EClass* eclass = egraph.get(eclass_id);
+    const ENode& enode = eclass->nodes[enode_id];
+
+    const EClass* cclass = egraph.get(enode.operands[0]);
+    const ENode* cnode = cclass->constant();
+    const auto* data = llvm::cast<ConstantIntData>(cnode->data.get());
+
+    if (data->value().getBoolValue()) {
+      egraph.merge(eclass_id, enode.operands[1]);
+    } else {
+      egraph.merge(eclass_id, enode.operands[2]);
+    }
+  };
+
+  builder.add_matcher(select, std::move(matcher));
+}
+
+} // namespace caffeine::ematching::reductions

--- a/test/unit/IR/EMatching.cpp
+++ b/test/unit/IR/EMatching.cpp
@@ -188,6 +188,27 @@ TEST_F(EMatchingTests, icmp_elimination) {
   ASSERT_EQ(egraph.find(cid), egraph.find(did));
 }
 
+TEST_F(EMatchingTests, load_store_elimination_elim_array) {
+  r::load_store_elimination(builder);
+  auto matcher = builder.build();
+
+  // clang-format off
+  auto value  = add(Constant::Create(Type::int_ty(8), "value"));
+  auto size   = add(Constant::Create(Type::int_ty(32), "size"));
+  auto offset = add(Constant::Create(Type::int_ty(32), "offset"));
+  auto array  = add(ConstantArray::Create("array", size));
+  auto store  = add(StoreOp::Create(array, offset, value));
+  auto load   = add(LoadOp::Create(store, offset));
+  
+  auto value_id = egraph.add(*value);
+  auto load_id  = egraph.add(*load);
+  // clang-format on
+
+  egraph.simplify(matcher);
+
+  ASSERT_EQ(value_id, load_id);
+}
+
 TEST_F(EMatchingTests, zext_trunc_elimination) {
   r::zext_trunc_elimination(builder);
   auto matcher = builder.build();

--- a/test/unit/IR/EMatching.cpp
+++ b/test/unit/IR/EMatching.cpp
@@ -190,6 +190,8 @@ TEST_F(EMatchingTests, icmp_elimination) {
 
 TEST_F(EMatchingTests, load_store_elimination_elim_array) {
   r::load_store_elimination(builder);
+  r::icmp_eliminations(builder);
+  r::select_constprop(builder);
   auto matcher = builder.build();
 
   // clang-format off


### PR DESCRIPTION
This PR adds the following rewrites along with test cases to cover them:
- `(load (store))` is replaced with a select operation that replaces the `store` operation
- `(select (i1 x) ...)` is replaced with the appropriate operand

This means that, in general, loads from arrays with lots of stores to them will result in much smaller expressions since stores with constant offsets can be elided easily.

/stack #720  