### PR TITLE
Generalize unwinding

### DIFF
--- a/include/caffeine/Interpreter/ExternalFuncs/GenericUnwinding.h
+++ b/include/caffeine/Interpreter/ExternalFuncs/GenericUnwinding.h
@@ -1,0 +1,79 @@
+#include "caffeine/Interpreter/ExternalFunction.h"
+#include "caffeine/Interpreter/InterpreterContext.h"
+#include "caffeine/Support/LLVMFmt.h"
+#include <boost/range/algorithm/find_if.hpp>
+#include <fmt/format.h>
+#include <iterator>
+#include <llvm/IR/InstrTypes.h>
+#include <llvm/IR/Instructions.h>
+#include <llvm/IR/Module.h>
+
+#include <iostream>
+
+#include "unwind.h"
+
+namespace caffeine {
+
+class GenericUnwinding : public ExternalStackFrame {
+protected:
+  enum State : uint8_t {
+    UNINITIALIZED,
+    SEARCHING,
+    RETURNING,
+    PROCESSING_CATCH,
+    DONE,
+    FORKING,
+  };
+
+  enum CatchType : uint8_t { NONE, CATCH, FILTER, CLEANUP };
+
+public:
+  using ExternalStackFrame::ExternalStackFrame;
+  struct UnwindPhaseState {
+    State state = UNINITIALIZED;
+
+    // Filters have a negative select value so we need to keep track of
+    // what actually caught the exception
+    CatchType catch_type = NONE;
+
+    // The index of the frame that caught the exception
+    int current_frame;
+
+    // The landingpad clause which caught the exception
+    llvm::Constant* catching_clause = nullptr;
+
+    // Assertions to add to the new context
+    AssertionList assertions;
+
+    std::vector<UnwindPhaseState> possible_states;
+    AssertionList unmatched_exceptions;
+    size_t clause_num;
+
+    UnwindPhaseState(State state, CatchType catch_type, int current_frame,
+                     llvm::Constant* catching_clause, AssertionList assertions)
+        : state{state}, catch_type{catch_type}, current_frame{current_frame},
+          catching_clause{catching_clause}, assertions{assertions} {}
+
+    UnwindPhaseState() = default;
+
+    UnwindPhaseState(const UnwindPhaseState&) = default;
+  };
+
+protected:
+  // Returns whether all the possible states have been returned or if this
+  // function needs to be called again
+  bool getPossibleStates(InterpreterContext& ctx);
+
+  void findLandingPad(InterpreterContext& ctx);
+
+public:
+  GenericUnwinding(const GenericUnwinding&) = default;
+  virtual void step(InterpreterContext& ctx) override;
+  virtual void returningStep(InterpreterContext&) = 0;
+
+protected:
+  UnwindPhaseState uw_state;
+  llvm::Function* can_catch_func;
+};
+
+} // namespace caffeine

--- a/src/Interpreter/ExternalFuncs/GenericUnwinding.cpp
+++ b/src/Interpreter/ExternalFuncs/GenericUnwinding.cpp
@@ -46,12 +46,6 @@ bool GenericUnwinding::getPossibleStates(InterpreterContext& ctx) {
     CAFFEINE_ASSERT(bb->isLandingPad());
 
     auto lpad = bb->getLandingPadInst();
-    if (lpad->isCleanup()) {
-      // Always enter a cleanup clause
-      uw_state.possible_states.emplace_back(
-          RETURNING, CLEANUP, uw_state.current_frame, nullptr, AssertionList());
-      return true;
-    }
 
     for (; uw_state.clause_num < lpad->getNumClauses(); uw_state.clause_num++) {
       auto clause = lpad->getClause(uw_state.clause_num);
@@ -108,6 +102,14 @@ bool GenericUnwinding::getPossibleStates(InterpreterContext& ctx) {
       } else {
         CAFFEINE_UNREACHABLE();
       }
+    }
+
+    // Check the cleanup flag last
+    if (lpad->isCleanup()) {
+      // Always enter a cleanup clause
+      uw_state.possible_states.emplace_back(
+          RETURNING, CLEANUP, uw_state.current_frame, nullptr, AssertionList());
+      return true;
     }
 
     uw_state.clause_num = 0;

--- a/src/Interpreter/ExternalFuncs/GenericUnwinding.cpp
+++ b/src/Interpreter/ExternalFuncs/GenericUnwinding.cpp
@@ -1,0 +1,196 @@
+#include "caffeine/Interpreter/ExternalFuncs/GenericUnwinding.h"
+#include "caffeine/Interpreter/ExternalFunction.h"
+#include "caffeine/Interpreter/InterpreterContext.h"
+#include "caffeine/Support/LLVMFmt.h"
+#include <boost/range/algorithm/find_if.hpp>
+#include <fmt/format.h>
+#include <iterator>
+#include <llvm/IR/InstrTypes.h>
+#include <llvm/IR/Instructions.h>
+#include <llvm/IR/Module.h>
+
+#include <iostream>
+
+#include "unwind.h"
+
+namespace caffeine {
+
+bool GenericUnwinding::getPossibleStates(InterpreterContext& ctx) {
+  for (; uw_state.current_frame >= 0; uw_state.current_frame--) {
+    StackFrame& frame_wrapper = ctx.context().stack.at(uw_state.current_frame);
+    if (frame_wrapper.is_external()) {
+      continue;
+    }
+
+    IRStackFrame& frame = frame_wrapper.get_regular();
+    if (!frame.func->hasPersonalityFn()) {
+      continue;
+    }
+
+    auto* personality_func =
+        frame.func->getPersonalityFn()->stripPointerCasts();
+    CAFFEINE_ASSERT(personality_func);
+
+    CAFFEINE_ASSERT(personality_func->getName() == "__gxx_personality_v0",
+                    fmt::format("unknown personality function! {}",
+                                personality_func->getName()));
+
+    auto inst =
+        llvm::dyn_cast<llvm::InvokeInst>(frame.get_current_instruction());
+
+    if (!inst) {
+      continue;
+    }
+
+    llvm::BasicBlock* bb = inst->getUnwindDest();
+    CAFFEINE_ASSERT(bb->isLandingPad());
+
+    auto lpad = bb->getLandingPadInst();
+    if (lpad->isCleanup()) {
+      // Always enter a cleanup clause
+      uw_state.possible_states.emplace_back(
+          RETURNING, CLEANUP, uw_state.current_frame, nullptr, AssertionList());
+      return true;
+    }
+
+    for (; uw_state.clause_num < lpad->getNumClauses(); uw_state.clause_num++) {
+      auto clause = lpad->getClause(uw_state.clause_num);
+      if (lpad->isCatch(uw_state.clause_num)) {
+        // Null clauses are also always entered
+        if (clause->isNullValue()) {
+          uw_state.possible_states.emplace_back(RETURNING, CATCH,
+                                                uw_state.current_frame, clause,
+                                                AssertionList());
+          return true;
+        }
+
+        std::vector<LLVMValue> args_ = {args[0], ctx.load(clause), args[1]};
+        ctx.call_function(can_catch_func, args_);
+        uw_state.state = PROCESSING_CATCH;
+        uw_state.catching_clause = clause;
+        return false;
+      } else if (lpad->isFilter(uw_state.clause_num)) {
+        if (clause->isNullValue()) {
+          uw_state.possible_states.emplace_back(RETURNING, FILTER,
+                                                uw_state.current_frame, clause,
+                                                AssertionList());
+          return true;
+        }
+
+        LLVMValue clause_value = ctx.load(clause);
+        CAFFEINE_ASSERT(clause_value.is_aggregate(),
+                        "filter clauses should be aggregate");
+
+        OpRef matches_any_ele = ConstantInt::Create(false);
+        for (size_t i = 0; i < clause_value.aggregate().size(); i++) {
+          matches_any_ele = BinaryOp::CreateOr(
+              matches_any_ele,
+              ICmpOp::CreateICmpEQ(
+                  clause_value.aggregate()[i].scalar().pointer().value(
+                      ctx.context().heaps),
+                  args[0].scalar().pointer().value(ctx.context().heaps)));
+        }
+
+        Assertion should_enter = !Assertion(matches_any_ele);
+
+        if (ctx.check(should_enter) == SolverResult::SAT) {
+          uw_state.possible_states.emplace_back(RETURNING, FILTER,
+                                                uw_state.current_frame, clause,
+                                                AssertionList(should_enter));
+        }
+
+        if (ctx.check(!should_enter) == SolverResult::SAT) {
+          uw_state.unmatched_exceptions.insert(!should_enter);
+        } else {
+          // The exception always resolves to this clause
+          return true;
+        }
+      } else {
+        CAFFEINE_UNREACHABLE();
+      }
+    }
+
+    uw_state.clause_num = 0;
+  }
+
+  uw_state.possible_states.emplace_back(RETURNING, NONE, uw_state.current_frame,
+                                        nullptr, uw_state.unmatched_exceptions);
+
+  return true;
+}
+
+void GenericUnwinding::findLandingPad(InterpreterContext& ctx) {
+  if (!getPossibleStates(ctx)) {
+    return;
+  }
+
+  uw_state.state = FORKING;
+}
+
+void GenericUnwinding::step(InterpreterContext& ctx) {
+
+  switch (uw_state.state) {
+  case UNINITIALIZED: {
+    uw_state.state = SEARCHING;
+
+    // Subtract two because we don't want to check the current stack frame
+    // (it's an ExternalStackFrame for GenericUnwinding)
+    uw_state.current_frame = ctx.context().stack.size() - 2;
+
+    uw_state.clause_num = 0;
+
+    can_catch_func = ctx.getModule()->getFunction("caffeine_can_catch");
+    CAFFEINE_ASSERT(can_catch_func);
+    return;
+  }
+  case SEARCHING: {
+    findLandingPad(ctx);
+    return;
+  }
+  case RETURNING: {
+    returningStep(ctx);
+    return;
+  }
+  case PROCESSING_CATCH: {
+    CAFFEINE_ASSERT(result_);
+    CAFFEINE_ASSERT(!resume_value_);
+
+    Assertion should_enter = ICmpOp::CreateICmpEQ((*result_).scalar().expr(),
+                                                  ConstantInt::Create(true));
+
+    if (ctx.check(should_enter) == SolverResult::SAT) {
+      uw_state.possible_states.emplace_back(
+          RETURNING, CATCH, uw_state.current_frame, uw_state.catching_clause,
+          AssertionList(should_enter));
+    }
+
+    if (ctx.check(!should_enter) == SolverResult::SAT) {
+      uw_state.unmatched_exceptions.insert(!should_enter);
+      // Keep searching
+      uw_state.state = SEARCHING;
+    } else {
+      // The exception always resolves to this clause
+      uw_state.state = FORKING;
+    }
+
+    return;
+  }
+
+  case FORKING: {
+    ctx.fork_external<GenericUnwinding>(uw_state.possible_states,
+                                        [=](InterpreterContext&,
+                                            GenericUnwinding* frame,
+                                            const UnwindPhaseState& s) {
+                                          frame->uw_state = s;
+                                          frame->uw_state.state = RETURNING;
+                                        });
+    return;
+  }
+
+  default:
+    CAFFEINE_ABORT(
+        "GenericUnwinding function implementation entered an invalid state");
+  }
+}
+
+} // namespace caffeine

--- a/src/Interpreter/ExternalFuncs/UnwindPhase1.cpp
+++ b/src/Interpreter/ExternalFuncs/UnwindPhase1.cpp
@@ -1,3 +1,4 @@
+#include "caffeine/Interpreter/ExternalFuncs/GenericUnwinding.h"
 #include "caffeine/Interpreter/ExternalFunction.h"
 #include "caffeine/Interpreter/InterpreterContext.h"
 #include "caffeine/Support/LLVMFmt.h"
@@ -16,260 +17,34 @@ namespace caffeine {
 
 namespace {
 
-  class UnwindPhase1 final : public ExternalStackFrameMixin<UnwindPhase1> {
-  private:
-    enum State : uint8_t {
-      UNINITIALIZED,
-      SEARCHING,
-      RETURNING,
-      PROCESSING_CATCH,
-      DONE,
-      FORKING,
-    };
-
-    enum CatchType : uint8_t { NONE, CATCH, FILTER, CLEANUP };
-
+  class UnwindPhase1 final : public GenericUnwinding {
   public:
-    struct UnwindPhaseState {
-      State state = UNINITIALIZED;
+    using GenericUnwinding::GenericUnwinding;
+    using GenericUnwinding::step;
+    void returningStep(InterpreterContext& ctx) override {
+      uw_state.state = DONE;
 
-      // Filters have a negative select value so we need to keep track of
-      // what actually caught the exception
-      CatchType catch_type = NONE;
+      auto curr_func = ctx.getCurrentFunction();
+      CAFFEINE_ASSERT(curr_func);
 
-      // The index of the frame that caught the exception
-      int current_frame;
+      auto ret_ty = curr_func->getReturnType();
+      CAFFEINE_ASSERT(ret_ty);
 
-      // The landingpad clause which caught the exception
-      llvm::Constant* catching_clause = nullptr;
+      _Unwind_Reason_Code result = _URC_END_OF_STACK;
 
-      // Assertions to add to the new context
-      AssertionList assertions;
-
-      std::vector<UnwindPhaseState> possible_states;
-      AssertionList unmatched_exceptions;
-      size_t clause_num;
-
-      UnwindPhaseState(State state, CatchType catch_type, int current_frame,
-                       llvm::Constant* catching_clause,
-                       AssertionList assertions)
-          : state{state}, catch_type{catch_type}, current_frame{current_frame},
-            catching_clause{catching_clause}, assertions{assertions} {}
-
-      UnwindPhaseState() = default;
-
-      UnwindPhaseState(const UnwindPhaseState&) = default;
-    };
-
-  private:
-    // Returns whether all the possible states have been returned or if this
-    // function needs to be called again
-    bool getPossibleStates(InterpreterContext& ctx) {
-      for (; uw_state.current_frame >= 0; uw_state.current_frame--) {
-        StackFrame& frame_wrapper =
-            ctx.context().stack.at(uw_state.current_frame);
-        if (frame_wrapper.is_external()) {
-          continue;
-        }
-
-        IRStackFrame& frame = frame_wrapper.get_regular();
-        if (!frame.func->hasPersonalityFn()) {
-          continue;
-        }
-
-        auto* personality_func =
-            frame.func->getPersonalityFn()->stripPointerCasts();
-        CAFFEINE_ASSERT(personality_func);
-
-        CAFFEINE_ASSERT(personality_func->getName() == "__gxx_personality_v0",
-                        fmt::format("unknown personality function! {}",
-                                    personality_func->getName()));
-
-        auto inst =
-            llvm::dyn_cast<llvm::InvokeInst>(frame.get_current_instruction());
-
-        if (!inst) {
-          continue;
-        }
-
-        llvm::BasicBlock* bb = inst->getUnwindDest();
-        CAFFEINE_ASSERT(bb->isLandingPad());
-
-        auto lpad = bb->getLandingPadInst();
-        if (lpad->isCleanup()) {
-          // Always enter a cleanup clause
-          uw_state.possible_states.emplace_back(RETURNING, CLEANUP,
-                                                uw_state.current_frame, nullptr,
-                                                AssertionList());
-          return true;
-        }
-
-        for (; uw_state.clause_num < lpad->getNumClauses();
-             uw_state.clause_num++) {
-          auto clause = lpad->getClause(uw_state.clause_num);
-          if (lpad->isCatch(uw_state.clause_num)) {
-            // Null clauses are also always entered
-            if (clause->isNullValue()) {
-              uw_state.possible_states.emplace_back(RETURNING, CATCH,
-                                                    uw_state.current_frame,
-                                                    clause, AssertionList());
-              return true;
-            }
-
-            std::vector<LLVMValue> args_ = {args[0], ctx.load(clause), args[1]};
-            ctx.call_function(can_catch_func, args_);
-            uw_state.state = PROCESSING_CATCH;
-            uw_state.catching_clause = clause;
-            return false;
-          } else if (lpad->isFilter(uw_state.clause_num)) {
-            if (clause->isNullValue()) {
-              uw_state.possible_states.emplace_back(RETURNING, FILTER,
-                                                    uw_state.current_frame,
-                                                    clause, AssertionList());
-              return true;
-            }
-
-            LLVMValue clause_value = ctx.load(clause);
-            CAFFEINE_ASSERT(clause_value.is_aggregate(),
-                            "filter clauses should be aggregate");
-
-            OpRef matches_any_ele = ConstantInt::Create(false);
-            for (size_t i = 0; i < clause_value.aggregate().size(); i++) {
-              matches_any_ele = BinaryOp::CreateOr(
-                  matches_any_ele,
-                  ICmpOp::CreateICmpEQ(
-                      clause_value.aggregate()[i].scalar().pointer().value(
-                          ctx.context().heaps),
-                      args[0].scalar().pointer().value(ctx.context().heaps)));
-            }
-
-            Assertion should_enter = !Assertion(matches_any_ele);
-
-            if (ctx.check(should_enter) == SolverResult::SAT) {
-              uw_state.possible_states.emplace_back(
-                  RETURNING, FILTER, uw_state.current_frame, clause,
-                  AssertionList(should_enter));
-            }
-
-            if (ctx.check(!should_enter) == SolverResult::SAT) {
-              uw_state.unmatched_exceptions.insert(!should_enter);
-            } else {
-              // The exception always resolves to this clause
-              return true;
-            }
-          } else {
-            CAFFEINE_UNREACHABLE();
-          }
-        }
-
-        uw_state.clause_num = 0;
+      if (uw_state.catch_type != NONE) {
+        result = _URC_NO_REASON;
       }
 
-      uw_state.possible_states.emplace_back(RETURNING, NONE,
-                                            uw_state.current_frame, nullptr,
-                                            uw_state.unmatched_exceptions);
-
-      return true;
+      ctx.context().stack.pop_back();
+      ctx.jump_return(LLVMValue(ConstantInt::Create(
+          llvm::APInt(ret_ty->getIntegerBitWidth(), result))));
     }
 
-    void findLandingPad(InterpreterContext& ctx) {
-      if (!getPossibleStates(ctx)) {
-        return;
-      }
-
-      uw_state.state = FORKING;
+    std::unique_ptr<ExternalStackFrame> clone() const override {
+      return std::make_unique<UnwindPhase1>(
+          *dynamic_cast_if_supported<const UnwindPhase1*>(this));
     }
-
-  public:
-    using ExternalStackFrameMixin<UnwindPhase1>::ExternalStackFrameMixin;
-
-    UnwindPhase1(const UnwindPhase1&) = default;
-    void step(InterpreterContext& ctx) override {
-
-      switch (uw_state.state) {
-      case UNINITIALIZED: {
-        uw_state.state = SEARCHING;
-
-        // Subtract two because we don't want to check the current stack frame
-        // (it's an ExternalStackFrame for UnwindPhase1)
-        uw_state.current_frame = ctx.context().stack.size() - 2;
-
-        uw_state.clause_num = 0;
-
-        can_catch_func = ctx.getModule()->getFunction("caffeine_can_catch");
-        CAFFEINE_ASSERT(can_catch_func);
-        return;
-      }
-      case SEARCHING: {
-        findLandingPad(ctx);
-        return;
-      }
-      case RETURNING: {
-        uw_state.state = DONE;
-
-        auto curr_func = ctx.getCurrentFunction();
-        CAFFEINE_ASSERT(curr_func);
-
-        auto ret_ty = curr_func->getReturnType();
-        CAFFEINE_ASSERT(ret_ty);
-
-        _Unwind_Reason_Code result = _URC_END_OF_STACK;
-
-        if (uw_state.catch_type != NONE) {
-          result = _URC_NO_REASON;
-        }
-
-        ctx.context().stack.pop_back();
-        ctx.jump_return(LLVMValue(ConstantInt::Create(
-            llvm::APInt(ret_ty->getIntegerBitWidth(), result))));
-
-        return;
-      }
-      case PROCESSING_CATCH: {
-        CAFFEINE_ASSERT(result_);
-        CAFFEINE_ASSERT(!resume_value_);
-
-        Assertion should_enter = ICmpOp::CreateICmpEQ(
-            (*result_).scalar().expr(), ConstantInt::Create(true));
-
-        if (ctx.check(should_enter) == SolverResult::SAT) {
-          uw_state.possible_states.emplace_back(
-              RETURNING, CATCH, uw_state.current_frame,
-              uw_state.catching_clause, AssertionList(should_enter));
-        }
-
-        if (ctx.check(!should_enter) == SolverResult::SAT) {
-          uw_state.unmatched_exceptions.insert(!should_enter);
-          // Keep searching
-          uw_state.state = SEARCHING;
-        } else {
-          // The exception always resolves to this clause
-          uw_state.state = FORKING;
-        }
-
-        return;
-      }
-
-      case FORKING: {
-        ctx.fork_external<UnwindPhase1>(uw_state.possible_states,
-                                        [=](InterpreterContext&,
-                                            UnwindPhase1* frame,
-                                            const UnwindPhaseState& s) {
-                                          frame->uw_state = s;
-                                          frame->uw_state.state = RETURNING;
-                                        });
-        return;
-      }
-
-      default:
-        CAFFEINE_ABORT(
-            "UnwindPhase1 function implementation entered an invalid state");
-      }
-    }
-
-  private:
-    UnwindPhaseState uw_state;
-    llvm::Function* can_catch_func;
   };
 
   class UnwindPhase1Function : public ExternalFunction {
@@ -283,14 +58,14 @@ namespace {
       }
 
       if (!func->getArg(0)->getType()->isPointerTy()) {
-        ctx.fail(
-            "invalid UnwindPhase1Function signature (invalid first argument)");
+        ctx.fail("invalid UnwindPhase1Function signature (invalid first "
+                 "argument)");
         return;
       }
 
       if (!func->getArg(1)->getType()->isPointerTy()) {
-        ctx.fail(
-            "invalid UnwindPhase1Function signature (invalid second argument)");
+        ctx.fail("invalid UnwindPhase1Function signature (invalid second "
+                 "argument)");
         return;
       }
 


### PR DESCRIPTION
This PR generalizes unwinding into an abstract class. After the unwind target is found, a subclass can choose what to do with this information. This is because phase 1 and phase 2 unwinding are pretty similar, and only seem to differ in what they do in the end