### PR TITLE
Add some utility methods to `EGraphAccessor`

### DIFF
--- a/include/caffeine/IR/EGraphMatching.h
+++ b/include/caffeine/IR/EGraphMatching.h
@@ -137,6 +137,7 @@ namespace ematching {
     size_t merge(size_t id1, size_t id2);
 
     const EClass* get(size_t eclass) const;
+    OpRef get_op(size_t eclass) const;
 
     bool contains_match(size_t subclause, size_t eclass) const;
 

--- a/include/caffeine/IR/EGraphMatching.h
+++ b/include/caffeine/IR/EGraphMatching.h
@@ -130,6 +130,9 @@ namespace ematching {
     size_t add(const ENode& enode);
     size_t add_merge(size_t eclass, const ENode& enode);
 
+    size_t add(const OpRef& op);
+    size_t add_merge(size_t eclass, const OpRef& op);
+
     // Merge two e-classes together.
     //
     // The actual act of merging is delayed until all e-graph updates have gone

--- a/src/IR/EGraphMatching.cpp
+++ b/src/IR/EGraphMatching.cpp
@@ -1,5 +1,6 @@
 #include "caffeine/IR/EGraphMatching.h"
 #include "caffeine/IR/EGraph.h"
+#include "caffeine/IR/Operation.h"
 
 namespace caffeine::ematching {
 
@@ -95,6 +96,10 @@ size_t GraphAccessor::merge(size_t id1, size_t id2) {
 
 const EClass* GraphAccessor::get(size_t eclass) const {
   return egraph->get(eclass);
+}
+
+OpRef GraphAccessor::get_op(size_t eclass_id) const {
+  return EGraphNode::Create(get(eclass_id)->type(), eclass_id);
 }
 
 bool GraphAccessor::contains_match(size_t subclause, size_t eclass) const {

--- a/src/IR/EGraphMatching.cpp
+++ b/src/IR/EGraphMatching.cpp
@@ -86,6 +86,13 @@ size_t GraphAccessor::add_merge(size_t eclass, const ENode& node) {
   return merge(eclass, add(node));
 }
 
+size_t GraphAccessor::add(const OpRef& op) {
+  return egraph->add(*op);
+}
+size_t GraphAccessor::add_merge(size_t eclass, const OpRef& op) {
+  return merge(eclass, add(op));
+}
+
 size_t GraphAccessor::merge(size_t id1, size_t id2) {
   if (id1 == id2)
     return id1;


### PR DESCRIPTION
This PR adds a few extra utility methods to `EGraphAccessor`:
- `get_op` returns an `OpRef` for a given `EClass`
- `add` and `add_merge` overloads that take `OpRef`s instead of `ENode`s