### PR TITLE
Implement a rewrite to eliminate `(zext (trunc x))` operations

### DIFF
--- a/include/caffeine/IR/EGraphMatching.h
+++ b/include/caffeine/IR/EGraphMatching.h
@@ -223,7 +223,7 @@ namespace ematching {
 
     // (icmp.## ?x ?x) -> true or false
     void icmp_eliminations(EMatcherBuilder& builder);
-    
+
     // (zext.ixx (trunc.iyy ?z)) -> (and v (ixx (2^yy - 1)))
     void zext_trunc_elimination(EMatcherBuilder& builder);
   } // namespace reductions

--- a/include/caffeine/IR/EGraphMatching.h
+++ b/include/caffeine/IR/EGraphMatching.h
@@ -223,6 +223,9 @@ namespace ematching {
 
     // (icmp.## ?x ?x) -> true or false
     void icmp_eliminations(EMatcherBuilder& builder);
+    
+    // (zext.ixx (trunc.iyy ?z)) -> (and v (ixx (2^yy - 1)))
+    void zext_trunc_elimination(EMatcherBuilder& builder);
   } // namespace reductions
 
   class EMatcher {

--- a/src/IR/EMatching/AllMatchers.cpp
+++ b/src/IR/EMatching/AllMatchers.cpp
@@ -75,6 +75,7 @@ void EMatcherBuilder::add_defaults() {
   reductions::icmp_eliminations(*this);
 
   reductions::and_zero_elimination(*this);
+  reductions::zext_trunc_elimination(*this);
 }
 
 } // namespace caffeine::ematching

--- a/src/IR/EMatching/Rewrites/ZExtTruncElimination.cpp
+++ b/src/IR/EMatching/Rewrites/ZExtTruncElimination.cpp
@@ -1,0 +1,31 @@
+#include "caffeine/IR/EGraph.h"
+#include "caffeine/IR/EGraphMatching.h"
+#include "caffeine/IR/Operation.h"
+
+namespace caffeine::ematching::reductions {
+
+void zext_trunc_elimination(EMatcherBuilder& builder) {
+  size_t trunc = builder.add_clause(Operation::Trunc);
+  size_t zext = builder.add_clause(Operation::ZExt);
+
+  auto matcher = [=](GraphAccessor& egraph, size_t eclass_id, size_t enode_id) {
+    const EClass* eclass = egraph.get(eclass_id);
+    const ENode& enode = eclass->nodes[enode_id];
+    const EClass* tclass = egraph.get(enode.operands[0]);
+
+    for (size_t tnode_id : egraph.matches(trunc, enode.operands[0])) {
+      const ENode& tnode = tclass->nodes[tnode_id];
+
+      auto op = BinaryOp::CreateAnd(
+          UnaryOp::CreateTruncOrZExt(eclass->type(),
+                                     egraph.get_op(tnode.operands[0])),
+          ConstantInt::Create(llvm::APInt::getLowBitsSet(
+              eclass->type().bitwidth(), tclass->type().bitwidth())));
+      egraph.add_merge(eclass_id, op);
+    }
+  };
+
+  builder.add_matcher(zext, std::move(matcher));
+}
+
+} // namespace caffeine::ematching::reductions

--- a/test/unit/IR/EMatching.cpp
+++ b/test/unit/IR/EMatching.cpp
@@ -187,3 +187,22 @@ TEST_F(EMatchingTests, icmp_elimination) {
 
   ASSERT_EQ(egraph.find(cid), egraph.find(did));
 }
+
+TEST_F(EMatchingTests, zext_trunc_elimination) {
+  r::zext_trunc_elimination(builder);
+  auto matcher = builder.build();
+
+  auto a = add(Constant::Create(Type::int_ty(32), "a"));
+  auto b = add(UnaryOp::CreateTrunc(Type::int_ty(16), a));
+  auto c = add(UnaryOp::CreateZExt(Type::int_ty(24), b));
+  auto d = add(ConstantInt::Create(llvm::APInt(24, 0xFFFF)));
+  auto e = add(UnaryOp::CreateTrunc(Type::int_ty(24), a));
+  auto f = add(BinaryOp::CreateAnd(e, d));
+
+  auto cid = egraph.add(*c);
+  auto fid = egraph.add(*f);
+
+  egraph.simplify(matcher);
+
+  ASSERT_EQ(egraph.find(cid), egraph.find(fid));
+}


### PR DESCRIPTION
This PR implements a rewrite that converts a `(zext (trunc ?x))` into a single truncate or zext along with an and operation. This is one of the rewrites that is needed to eliminate loads and stores to arrays.

/stack #723 