### PR TITLE
Fix TypeId lookup

### DIFF
--- a/src/Interpreter/TypeidDb.cpp
+++ b/src/Interpreter/TypeidDb.cpp
@@ -1,16 +1,24 @@
 #include <caffeine/Interpreter/TypeidDb.h>
+#include <caffeine/Support/Assert.h>
+
+#include "caffeine/Support/LLVMFmt.h"
+#include <fmt/format.h>
+#include <iostream>
 
 namespace caffeine {
 
 int32_t TypeidDb::get_selector(const llvm::Constant* exception_ty) {
+  CAFFEINE_ASSERT(exception_ty, "must not be a null pointer");
   std::unique_lock lock(mutex);
 
-  auto val = values.find(exception_ty);
-  if (val != values.end()) {
-    return val->second;
+  {
+    auto val = values.find(exception_ty->stripPointerCasts());
+    if (val != values.end()) {
+      return val->second;
+    }
   }
 
-  values[exception_ty] = curr;
+  values[exception_ty->stripPointerCasts()] = curr;
   int32_t res = curr;
   curr++;
   return res;

--- a/src/Interpreter/TypeidDb.cpp
+++ b/src/Interpreter/TypeidDb.cpp
@@ -11,11 +11,9 @@ int32_t TypeidDb::get_selector(const llvm::Constant* exception_ty) {
   CAFFEINE_ASSERT(exception_ty, "must not be a null pointer");
   std::unique_lock lock(mutex);
 
-  {
-    auto val = values.find(exception_ty->stripPointerCasts());
-    if (val != values.end()) {
-      return val->second;
-    }
+  if (auto val = values.find(exception_ty->stripPointerCasts());
+      val != values.end()) {
+    return val->second;
   }
 
   values[exception_ty->stripPointerCasts()] = curr;


### PR DESCRIPTION
Stripping bitcasts makes sure we register the global object instead of
some bitcast