### PR TITLE
Implement resume semantics

### DIFF
--- a/src/Interpreter/StackFrame.cpp
+++ b/src/Interpreter/StackFrame.cpp
@@ -57,7 +57,10 @@ void IRStackFrame::set_result(std::optional<LLVMValue> result,
     if (!resume_value.has_value()) {
       jump_to(invoke->getNormalDest());
     } else {
-      CAFFEINE_UNIMPLEMENTED("Resume instruction is not implemented");
+      jump_to(invoke->getUnwindDest());
+      auto& landingpad = *current;
+      insert(&landingpad, *resume_value);
+      current++;
     }
   }
 }


### PR DESCRIPTION
This PR implements the resume branch of the `set_result` method. There's no tests, but it seems to work in https://github.com/insufficiently-caffeinated/caffeine/pull/598