### PR TITLE
Add accessors for clauses and subclauses to `EMatcher`

### DIFF
--- a/include/caffeine/IR/EGraphMatching.h
+++ b/include/caffeine/IR/EGraphMatching.h
@@ -226,7 +226,7 @@ namespace ematching {
 
     // (zext.ixx (trunc.iyy ?z)) -> (and v (ixx (2^yy - 1)))
     void zext_trunc_elimination(EMatcherBuilder& builder);
-    
+
     // (select (i1 1) ?x ?y) -> ?x
     // (select (i1 0) ?x ?y) -> ?y
     void select_constprop(EMatcherBuilder& builder);
@@ -238,6 +238,9 @@ namespace ematching {
   class EMatcher {
   public:
     static EMatcherBuilder builder();
+
+    const Clause& clause(size_t clause) const;
+    const SubClause& subclause(size_t subclause) const;
 
   private:
     std::vector<Clause> clauses;

--- a/src/IR/EGraphMatching.cpp
+++ b/src/IR/EGraphMatching.cpp
@@ -181,4 +181,11 @@ EMatcherBuilder EMatcher::builder() {
   return EMatcherBuilder();
 }
 
+const Clause& EMatcher::clause(size_t clause) const {
+  return clauses.at(clause);
+}
+const SubClause& EMatcher::subclause(size_t subclause) const {
+  return subclauses.at(subclause);
+}
+
 } // namespace caffeine::ematching


### PR DESCRIPTION
As in title. This adds some utility functions so that users that aren't friends with `EMatcher` can get read-only access to the clauses and subclauses contained within the `EMatcher` instance.