### PR TITLE
Add a non-owning erased function type

### DIFF
--- a/include/caffeine/ADT/FunctionView.h
+++ b/include/caffeine/ADT/FunctionView.h
@@ -1,0 +1,81 @@
+#pragma once
+
+#include <type_traits>
+#include <utility>
+
+namespace caffeine {
+
+template <typename Sig>
+class function_view;
+
+/**
+ * A non-owning reference to a function or other callable object.
+ *
+ * This is meant to be used as a function pointer in cases where the code
+ * calling the function doesn't need to own the function. This mainly comes up
+ * in function arguments.
+ *
+ * The implementation here is mainly based off of [1] although it doesn't make
+ * the same design decisions as described in the blog post. The idea is also
+ * inspired by [2] and, as there is no corresponding implementation within
+ * boost, here's a new one.
+ *
+ * [1]: https://www.foonathan.net/2017/01/function-ref-implementation/
+ * [2]: http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2018/p0792r2.html
+ */
+template <typename Ret, typename... Args>
+class function_view<Ret(Args...)> {
+private:
+  using callable = Ret (*)(Args...);
+  using internal = Ret (*)(void* data, Args&&... args);
+
+  void* data;
+  internal cb;
+
+private:
+  function_view(void* data, internal cb) : data(data), cb(cb) {}
+
+public:
+  function_view(callable func) {
+    data = reinterpret_cast<void*>(func);
+    cb = [](void* data, Args&&... args) -> Ret {
+      auto func = reinterpret_cast<callable>(data);
+      return static_cast<Ret>(func(std::forward<Args>(args)...));
+    };
+  }
+
+  template <typename T>
+  function_view(const T& func) {
+    data = const_cast<void*>(static_cast<const void*>(&func));
+    cb = [](void* data, Args&&... args) -> Ret {
+      const auto& func = *static_cast<const T*>(data);
+      return static_cast<Ret>(func(std::forward<Args>(args)...));
+    };
+  }
+
+  template <typename T>
+  function_view(T& func) {
+    data = static_cast<void*>(&func);
+    cb = [](void* data, Args&&... args) -> Ret {
+      auto& func = *static_cast<T*>(data);
+      return static_cast<Ret>(func(std::forward<Args>(args)...));
+    };
+  }
+
+  template <typename T>
+  function_view(T&& func) {
+    static_assert(!std::is_reference_v<T>);
+
+    data = static_cast<void*>(&func);
+    cb = [](void* data, Args&&... args) -> Ret {
+      auto& func = *static_cast<T*>(data);
+      return static_cast<Ret>(std::move(func)(std::forward<Args>(args)...));
+    };
+  }
+
+  Ret operator()(Args&&... args) const {
+    return cb(data, std::forward<Args>(args)...);
+  }
+};
+
+} // namespace caffeine

--- a/include/caffeine/IR/EGraphMatching.h
+++ b/include/caffeine/IR/EGraphMatching.h
@@ -226,7 +226,7 @@ namespace ematching {
 
     // (zext.ixx (trunc.iyy ?z)) -> (and v (ixx (2^yy - 1)))
     void zext_trunc_elimination(EMatcherBuilder& builder);
-    
+
     // (select (i1 1) ?x ?y) -> ?x
     // (select (i1 0) ?x ?y) -> ?y
     void select_constprop(EMatcherBuilder& builder);

--- a/test/unit/ADT/FunctionView.cpp
+++ b/test/unit/ADT/FunctionView.cpp
@@ -1,0 +1,31 @@
+#include "caffeine/ADT/FunctionView.h"
+#include <gtest/gtest.h>
+
+using namespace caffeine;
+
+TEST(FunctionViewTests, function_pointer) {
+  static bool func_ran = false;
+
+  void (*func)() = []() { func_ran = true; };
+  function_view<void()> view = func;
+  view();
+
+  ASSERT_TRUE(func_ran);
+}
+
+TEST(FunctionViewTests, const_local) {
+  bool func_ran = false;
+
+  auto func = [&] { func_ran = true; };
+  function_view<void()> view = func;
+  view();
+
+  ASSERT_TRUE(func_ran);
+}
+
+TEST(FunctionViewTests, temporary) {
+  bool func_ran = false;
+  function_view<void()>([&] { func_ran = true; })();
+
+  ASSERT_TRUE(func_ran);
+}


### PR DESCRIPTION
This commit introduces a new erased function type called `function_view`. It is meant to be somewhat similar to std::function with the main difference being that it doesn't actually take ownership over the function but instead serves a function reference.

The idea is based off of the std::function_ref proposal for C++ but the implementation, while somewhat inspired by a blog post I found on something very similar, is mainly my own.

The code in this commit should work equally well with function pointers as with arbitrary callable objects and the test cases included verify that everything works as expected here.