### PR TITLE
Implement a captures system for `EMatcher`

### DIFF
--- a/src/IR/EGraphMatcher.cpp
+++ b/src/IR/EGraphMatcher.cpp
@@ -30,6 +30,9 @@ public:
   // Used to remove matches from an updated clause
   std::unordered_map<size_t, std::vector<size_t>> reversed = {};
 
+  // Map containing all subclauses that are captured.
+  std::unordered_map<size_t, const ENode*> captures = {};
+
 public:
   void equality_saturation() {
     egraph->constprop();
@@ -42,7 +45,7 @@ public:
 
       egraph->updated.clear();
 
-      GraphAccessor accessor(egraph, &data);
+      GraphAccessor accessor(egraph, &data, &captures);
 
       for (auto [clause_id, eclass_id, enode_id] : work) {
         const auto& clause = matcher->clauses[clause_id];

--- a/src/IR/EGraphMatcher.cpp
+++ b/src/IR/EGraphMatcher.cpp
@@ -1,3 +1,5 @@
+#include "caffeine/ADT/FunctionView.h"
+#include "caffeine/ADT/Guard.h"
 #include "caffeine/IR/EGraph.h"
 #include "caffeine/IR/EGraphMatching.h"
 #include "caffeine/IR/OperationBase.h"
@@ -49,7 +51,11 @@ public:
 
       for (auto [clause_id, eclass_id, enode_id] : work) {
         const auto& clause = matcher->clauses[clause_id];
-        clause.update(accessor, eclass_id, enode_id);
+
+        all_captures(clause.matcher, eclass_id, enode_id, data,
+                     [&, eclass_id = eclass_id, enode_id = enode_id] {
+                       clause.update(accessor, eclass_id, enode_id);
+                     });
       }
 
       accessor.persist();
@@ -197,6 +203,78 @@ public:
     if (it == matcher->subindex.end())
       return {};
     return it->second;
+  }
+
+  // Iterate through all combinations of captures and, for each one, call the
+  // provided function once the captures map has all the required types.
+  //
+  // Note that the initial subclause is always considered to be a capture, even
+  // if it is not meant to be since at this phase we've already eliminated it
+  // down to 1 match.
+  void all_captures(size_t subclause_id, size_t eclass_id, size_t enode_id,
+                    const EMatcherData& data, function_view<void()> func) {
+    const EClass* eclass = egraph->get(eclass_id);
+    const ENode* enode = &eclass->nodes.at(enode_id);
+    const SubClause& subclause = matcher->subclause(subclause_id);
+
+    captures.emplace(subclause_id, enode);
+    auto guard = make_guard([&] { captures.clear(); });
+
+    if (!matcher->captures.at(subclause_id)) {
+      func();
+      return;
+    }
+
+    auto iterate = [&](size_t index, const auto& func, const auto& iterate) {
+      if (index >= subclause.submatchers.size()) {
+        func();
+        return;
+      }
+
+      size_t submatcher = subclause.submatchers[index];
+      size_t operand = enode->operands[index];
+
+      all_captures_impl(submatcher, operand, data,
+                        [&] { iterate(index + 1, func, iterate); });
+    };
+
+    iterate(0, func, iterate);
+  }
+
+  void all_captures_impl(size_t subclause_id, size_t eclass_id,
+                         const EMatcherData& data, function_view<void()> func) {
+    if (!matcher->captures[subclause_id]) {
+      func();
+      return;
+    }
+
+    const SubClause& subclause = matcher->subclause(subclause_id);
+    const EClass* eclass = egraph->get(eclass_id);
+
+    auto matches = data.matches(subclause_id, eclass_id);
+    auto guard = make_guard([&] { captures.erase(subclause_id); });
+
+    for (size_t node_id : matches) {
+      const ENode* node = &eclass->nodes.at(node_id);
+
+      if (subclause.is_capture)
+        captures[subclause_id] = node;
+
+      auto iterate = [&](size_t index, const auto& func, const auto& iterate) {
+        if (index >= subclause.submatchers.size()) {
+          func();
+          return;
+        }
+
+        size_t submatcher = subclause.submatchers[index];
+        size_t operand = node->operands[index];
+
+        all_captures_impl(submatcher, operand, data,
+                          [&] { iterate(index + 1, func, iterate); });
+      };
+
+      iterate(0, func, iterate);
+    }
   }
 };
 

--- a/src/IR/EGraphMatching.cpp
+++ b/src/IR/EGraphMatching.cpp
@@ -143,9 +143,9 @@ size_t EMatcherBuilder::add_clause(Operation::Opcode opcode,
   for (size_t subclause : submatchers)
     CAFFEINE_ASSERT(subclause < subclause_id);
 
-  SubClause clause{
-      opcode, std::vector<size_t>(submatchers.begin(), submatchers.end()),
-      std::move(filter), is_capture};
+  SubClause clause{opcode,
+                   std::vector<size_t>(submatchers.begin(), submatchers.end()),
+                   std::move(filter), is_capture};
 
   auto [it, inserted] = subclauses.emplace(std::move(clause), subclause_id);
   if (!inserted)

--- a/src/IR/EGraphMatching.cpp
+++ b/src/IR/EGraphMatching.cpp
@@ -1,6 +1,7 @@
 #include "caffeine/IR/EGraphMatching.h"
 #include "caffeine/IR/EGraph.h"
 #include "caffeine/IR/Operation.h"
+#include <fmt/format.h>
 
 namespace caffeine::ematching {
 
@@ -48,7 +49,7 @@ llvm::hash_code hash_value(const SubClause& subclause) {
 
   return llvm::hash_combine(subclause.opcode,
                             (llvm::ArrayRef<size_t>)subclause.submatchers,
-                            filter_hash);
+                            filter_hash, subclause.is_capture);
 }
 
 bool MatchData::contains_match(size_t subclause, size_t eclass) const {
@@ -70,8 +71,10 @@ llvm::ArrayRef<size_t> MatchData::matches(size_t subclause,
   return it->second;
 }
 
-GraphAccessor::GraphAccessor(EGraph* egraph, const MatchData* data)
-    : egraph(egraph), data(data) {}
+GraphAccessor::GraphAccessor(
+    EGraph* egraph, const MatchData* data,
+    const std::unordered_map<size_t, const ENode*>* captures)
+    : egraph(egraph), data(data), captures(captures) {}
 
 void GraphAccessor::persist() {
   for (auto [lhs, rhs] : merges)
@@ -125,15 +128,24 @@ EGraph* GraphAccessor::graph() {
   return egraph;
 }
 
+const ENode* GraphAccessor::capture(size_t subclause) const {
+  auto it = captures->find(subclause);
+  if (it == captures->end())
+    CAFFEINE_ABORT(fmt::format(
+        "subclause {} was not found within the capture set", subclause));
+  return it->second;
+}
+
 size_t EMatcherBuilder::add_clause(Operation::Opcode opcode,
                                    llvm::ArrayRef<size_t> submatchers,
-                                   std::unique_ptr<SubClauseFilter>&& filter) {
+                                   std::unique_ptr<SubClauseFilter>&& filter,
+                                   bool is_capture) {
   for (size_t subclause : submatchers)
     CAFFEINE_ASSERT(subclause < subclause_id);
 
   SubClause clause{
-      opcode, llvm::SmallVector<size_t>(submatchers.begin(), submatchers.end()),
-      std::move(filter)};
+      opcode, std::vector<size_t>(submatchers.begin(), submatchers.end()),
+      std::move(filter), is_capture};
 
   auto [it, inserted] = subclauses.emplace(std::move(clause), subclause_id);
   if (!inserted)
@@ -161,8 +173,17 @@ EMatcher EMatcherBuilder::build() {
             [](const auto& a, const auto& b) { return a.first < b.first; });
 
   matcher.subclauses.reserve(clausetmp.size());
-  for (auto& val : clausetmp)
-    matcher.subclauses.push_back(std::move(val.second));
+  matcher.captures.reserve(clausetmp.size());
+  for (auto& [id, subclause] : clausetmp) {
+    bool capture =
+        subclause.is_capture ||
+        std::any_of(
+            subclause.submatchers.begin(), subclause.submatchers.end(),
+            [&](size_t submatcher) { return matcher.captures.at(submatcher); });
+
+    matcher.captures.push_back(capture);
+    matcher.subclauses.push_back(std::move(subclause));
+  }
 
   subclauses.clear();
   subclause_id = 0;


### PR DESCRIPTION
This PR introduces a system that allows update functions within the E-Matcher to easily access the e-nodes that are needed to implement the rewrite. In addition, the e-matching code will now automatically call update with every combination of the captured nodes.

The motivation behind this is that as the number of expressions that make up the rewrite rule selector increase, so too does the difficulty in adding them all up to get the required data. This means that it is really difficult to write rewrite rules that use even 3 layers of matching clauses. By centralizing the difficult parts within the e-matching algorithm it can be much easier to write all of the rewrite rules we need.

The main algorithm is contained within `all_matchers` and `all_matchers_impl` within the `EGraphMatcher` class. It recursively enumerates all combinations of captures within the matching set of subclauses and ignores trees of subclauses which don't have any matches.

I am leaving this PR as draft until #728 and #727 are merged.