### PR TITLE
Allow captures within e-matching with multiple values

### DIFF
--- a/include/caffeine/IR/EGraphMatching.h
+++ b/include/caffeine/IR/EGraphMatching.h
@@ -126,12 +126,12 @@ namespace ematching {
   // applied.
   class GraphAccessor {
   public:
-    using CapturesMap = std::unordered_map<size_t, const ENode*>;
+    using CapturesMap =
+        std::unordered_map<size_t, llvm::SmallVector<const ENode*>>;
 
   public:
-    GraphAccessor(
-        EGraph* egraph, const MatchData* data,
-        const CapturesMap* captures = nullptr);
+    GraphAccessor(EGraph* egraph, const MatchData* data,
+                  const CapturesMap* captures = nullptr);
 
     // Create a new e-class with the given e-node.
     size_t add(const ENode& enode);
@@ -156,7 +156,18 @@ namespace ematching {
 
     EGraph* graph();
 
+    // Retrieve the single capture for the provided subclause.
+    //
+    // An assertion failure will occur if subclause has no matches or subclause
+    // has multiple matches.
     const ENode* capture(size_t subclause) const;
+    // Retrieve all the captures for the provided subclause. Captures within the
+    // returned array are ordered according to when they are found in a DFS
+    // expansion of the top-level capture clause.
+    //
+    // An assertion failure will be emitted if there are no captures for the
+    // provided subclause.
+    llvm::ArrayRef<const ENode*> captures(size_t subclause) const;
 
     GraphAccessor(const GraphAccessor&) = delete;
     GraphAccessor(GraphAccessor&&) = delete;

--- a/include/caffeine/IR/EGraphMatching.h
+++ b/include/caffeine/IR/EGraphMatching.h
@@ -126,9 +126,12 @@ namespace ematching {
   // applied.
   class GraphAccessor {
   public:
+    using CapturesMap = std::unordered_map<size_t, const ENode*>;
+
+  public:
     GraphAccessor(
         EGraph* egraph, const MatchData* data,
-        const std::unordered_map<size_t, const ENode*>* captures = nullptr);
+        const CapturesMap* captures = nullptr);
 
     // Create a new e-class with the given e-node.
     size_t add(const ENode& enode);
@@ -170,7 +173,7 @@ namespace ematching {
   private:
     EGraph* egraph;
     const MatchData* data;
-    const std::unordered_map<size_t, const ENode*>* captures;
+    const CapturesMap* captures_;
 
     std::vector<std::pair<size_t, size_t>> merges;
 

--- a/src/IR/EGraphMatcher.cpp
+++ b/src/IR/EGraphMatcher.cpp
@@ -252,7 +252,6 @@ public:
     const EClass* eclass = egraph->get(eclass_id);
 
     auto matches = data.matches(subclause_id, eclass_id);
-    auto guard = make_guard([&] { captures.erase(subclause_id); });
 
     for (size_t node_id : matches) {
       const ENode* node = &eclass->nodes.at(node_id);
@@ -275,8 +274,10 @@ public:
 
       iterate(0, func, iterate);
 
-      if (subclause.is_capture)
-        captures[subclause_id].pop_back();
+      if (subclause.is_capture) {
+        CAFFEINE_ASSERT(!captures.at(subclause_id).empty());
+        captures.at(subclause_id).pop_back();
+      }
     }
 
     auto it = captures.find(subclause_id);

--- a/src/IR/EGraphMatcher.cpp
+++ b/src/IR/EGraphMatcher.cpp
@@ -33,7 +33,7 @@ public:
   std::unordered_map<size_t, std::vector<size_t>> reversed = {};
 
   // Map containing all subclauses that are captured.
-  std::unordered_map<size_t, const ENode*> captures = {};
+  GraphAccessor::CapturesMap captures = {};
 
 public:
   void equality_saturation() {

--- a/src/IR/EGraphMatcher.cpp
+++ b/src/IR/EGraphMatcher.cpp
@@ -217,7 +217,7 @@ public:
     const ENode* enode = &eclass->nodes.at(enode_id);
     const SubClause& subclause = matcher->subclause(subclause_id);
 
-    captures.emplace(subclause_id, enode);
+    captures.insert({subclause_id, {enode}});
     auto guard = make_guard([&] { captures.clear(); });
 
     if (!matcher->captures.at(subclause_id)) {
@@ -258,7 +258,7 @@ public:
       const ENode* node = &eclass->nodes.at(node_id);
 
       if (subclause.is_capture)
-        captures[subclause_id] = node;
+        captures[subclause_id].push_back(node);
 
       auto iterate = [&](size_t index, const auto& func, const auto& iterate) {
         if (index >= subclause.submatchers.size()) {
@@ -274,7 +274,14 @@ public:
       };
 
       iterate(0, func, iterate);
+
+      if (subclause.is_capture)
+        captures[subclause_id].pop_back();
     }
+
+    auto it = captures.find(subclause_id);
+    if (it != captures.end() && it->second.empty())
+      captures.erase(it);
   }
 };
 

--- a/src/IR/EGraphMatching.cpp
+++ b/src/IR/EGraphMatching.cpp
@@ -129,9 +129,25 @@ EGraph* GraphAccessor::graph() {
 
 const ENode* GraphAccessor::capture(size_t subclause) const {
   auto it = captures_->find(subclause);
-  if (it == captures_->end())
-    CAFFEINE_ABORT(fmt::format(
-        "subclause {} was not found within the capture set", subclause));
+  CAFFEINE_ASSERT(
+      it != captures_->end(),
+      fmt::format("subclause {} was not found within the capture set",
+                  subclause));
+  CAFFEINE_ASSERT(it->second.size() == 1,
+                  fmt::format("subclause {} had multiple ({}) captures",
+                              subclause, it->second.size()));
+  return it->second.front();
+}
+llvm::ArrayRef<const ENode*> GraphAccessor::captures(size_t subclause) const {
+  auto it = captures_->find(subclause);
+  CAFFEINE_ASSERT(
+      it != captures_->end(),
+      fmt::format("subclause {} was not found within the capture set",
+                  subclause));
+  // This should never happen but it doesn't hurt to check.
+  CAFFEINE_ASSERT(
+      !it->second.empty(),
+      fmt::format("subclause {} had empty capture set?", subclause));
   return it->second;
 }
 

--- a/src/IR/EGraphMatching.cpp
+++ b/src/IR/EGraphMatching.cpp
@@ -71,10 +71,9 @@ llvm::ArrayRef<size_t> MatchData::matches(size_t subclause,
   return it->second;
 }
 
-GraphAccessor::GraphAccessor(
-    EGraph* egraph, const MatchData* data,
-    const std::unordered_map<size_t, const ENode*>* captures)
-    : egraph(egraph), data(data), captures(captures) {}
+GraphAccessor::GraphAccessor(EGraph* egraph, const MatchData* data,
+                             const CapturesMap* captures)
+    : egraph(egraph), data(data), captures_(captures) {}
 
 void GraphAccessor::persist() {
   for (auto [lhs, rhs] : merges)
@@ -129,8 +128,8 @@ EGraph* GraphAccessor::graph() {
 }
 
 const ENode* GraphAccessor::capture(size_t subclause) const {
-  auto it = captures->find(subclause);
-  if (it == captures->end())
+  auto it = captures_->find(subclause);
+  if (it == captures_->end())
     CAFFEINE_ABORT(fmt::format(
         "subclause {} was not found within the capture set", subclause));
   return it->second;


### PR DESCRIPTION
This PR is an extension to #729 that extends the captures system to allow a clause to capture multiple values simultaneously. Immediately after implementing #729, I found a use case that still didn't work (rewriting `(shl (lshr ?x ?y) ?z)` where `?y` and `?z` are constants) so I've now gone and extended capturing to support that use case as well.

/stack #729