### PR TITLE
Add a rewrite for `(trunc (zext ?x))` expressions

### DIFF
--- a/include/caffeine/IR/EGraphMatching.h
+++ b/include/caffeine/IR/EGraphMatching.h
@@ -254,6 +254,9 @@ namespace ematching {
     // (zext.ixx (trunc.iyy ?z)) -> (and v (ixx (2^yy - 1)))
     void zext_trunc_elimination(EMatcherBuilder& builder);
 
+    // (trunc.ixx (zext.iyy ?x)) -> (zext-or-trunc.ixx ?x)
+    void trunc_zext_elimination(EMatcherBuilder& builder);
+
     // (select (i1 1) ?x ?y) -> ?x
     // (select (i1 0) ?x ?y) -> ?y
     void select_constprop(EMatcherBuilder& builder);

--- a/src/IR/EMatching/AllMatchers.cpp
+++ b/src/IR/EMatching/AllMatchers.cpp
@@ -76,6 +76,7 @@ void EMatcherBuilder::add_defaults() {
 
   reductions::and_zero_elimination(*this);
   reductions::zext_trunc_elimination(*this);
+  reductions::trunc_zext_elimination(*this);
   reductions::select_constprop(*this);
   reductions::load_store_elimination(*this);
 }

--- a/src/IR/EMatching/Rewrites/ZExtTruncElimination.cpp
+++ b/src/IR/EMatching/Rewrites/ZExtTruncElimination.cpp
@@ -23,4 +23,20 @@ void zext_trunc_elimination(EMatcherBuilder& builder) {
   builder.add_matcher(zext, std::move(matcher));
 }
 
+void trunc_zext_elimination(EMatcherBuilder& builder) {
+  size_t zext = builder.add_capture(Operation::ZExt);
+  size_t trunc = builder.add_capture(Operation::Trunc, {zext});
+
+  auto matcher = [=](GraphAccessor& egraph, size_t eclass_id, size_t) {
+    const ENode* znode = egraph.capture(zext);
+    const ENode* tnode = egraph.capture(trunc);
+
+    auto op = UnaryOp::CreateTruncOrZExt(tnode->type(),
+                                         egraph.get_op(znode->operands[0]));
+    egraph.add_merge(eclass_id, op);
+  };
+
+  builder.add_matcher(trunc, std::move(matcher));
+}
+
 } // namespace caffeine::ematching::reductions


### PR DESCRIPTION
This simplifies the expression into a single overall `trunc` or `zext` opcode.