### PR TITLE
Add a solver which exits early in some common cases

### DIFF
--- a/include/caffeine/Solver/EarlyExitSolver.h
+++ b/include/caffeine/Solver/EarlyExitSolver.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include "caffeine/Solver/Solver.h"
+
+namespace caffeine {
+
+class EarlyExitSolver : public Solver {
+public:
+  EarlyExitSolver(const std::shared_ptr<Solver>& solver);
+
+  SolverResult check(AssertionList& assertions,
+                     const Assertion& extra) override;
+  SolverResult resolve(AssertionList& assertions,
+                       const Assertion& extra) override;
+
+private:
+  std::shared_ptr<Solver> inner;
+};
+
+} // namespace caffeine

--- a/src/Solver/EarlyExitSolver.cpp
+++ b/src/Solver/EarlyExitSolver.cpp
@@ -1,0 +1,28 @@
+#include "caffeine/Solver/EarlyExitSolver.h"
+#include "caffeine/Model/AssertionList.h"
+
+namespace caffeine {
+
+EarlyExitSolver::EarlyExitSolver(const std::shared_ptr<Solver>& solver)
+    : inner(solver) {}
+
+SolverResult EarlyExitSolver::check(AssertionList& assertions,
+                                    const Assertion& extra) {
+  if (extra.is_constant_value(false))
+    return SolverResult::UNSAT;
+
+  if (assertions.unproven().empty() && extra.is_constant_value(true))
+    return SolverResult::SAT;
+
+  return inner->check(assertions, extra);
+}
+
+SolverResult EarlyExitSolver::resolve(AssertionList& assertions,
+                                      const Assertion& extra) {
+  if (extra.is_constant_value(false))
+    return SolverResult::UNSAT;
+
+  return inner->resolve(assertions, extra);
+}
+
+} // namespace caffeine

--- a/src/Solver/Solver.cpp
+++ b/src/Solver/Solver.cpp
@@ -4,6 +4,7 @@
 #include "caffeine/IR/Visitor.h"
 #include "caffeine/Interpreter/Context.h"
 #include "caffeine/Solver/CanonicalizingSolver.h"
+#include "caffeine/Solver/EarlyExitSolver.h"
 #include "caffeine/Solver/ModelEval.h"
 #include "caffeine/Solver/SimplifyingSolver.h"
 #include "caffeine/Solver/SlicingSolver.h"
@@ -137,6 +138,7 @@ SolverBuilder::SolverBuilder(const BaseFn& base) : base(base) {}
 
 SolverBuilder SolverBuilder::with_default() {
   auto builder = SolverBuilder(std::make_shared<Z3Solver>);
+  builder.with<EarlyExitSolver>();
   builder.with<SimplifyingSolver>();
   builder.with<CanonicalizingSolver>();
   builder.with<SlicingSolver>();


### PR DESCRIPTION
This adds a solver that recognizes some fixed cases and bails out early when they're recognized. Those cases are:
- The extra assertion is the literal false -> just return UNSAT
- The extra assertion is the literal true and all other assertions within the path condition are known to be satisfiable -> return SAT if this is a `check` call.

These checks are cheap to make and can potentially save a lot of time so doing them is definitely worthwhile.