### PR TITLE
Add a rewrite to eliminate `(icmp.eq (select ?a ?x ?y) ?z)` expressions

### DIFF
--- a/src/IR/EMatching/Rewrites/ICmpElimination.cpp
+++ b/src/IR/EMatching/Rewrites/ICmpElimination.cpp
@@ -1,6 +1,7 @@
 #include "caffeine/IR/EGraph.h"
 #include "caffeine/IR/EGraphMatching.h"
 #include "caffeine/IR/EMatching/Filters.h"
+#include "caffeine/IR/Operation.h"
 #include "caffeine/IR/OperationData.h"
 
 namespace caffeine::ematching::reductions {
@@ -18,6 +19,32 @@ static void eliminate_to_bool(EMatcherBuilder& builder,
   builder.add_matcher(clause, std::move(matcher));
 }
 
+// (icmp.eq (select ?a ?x ?y) ?x/?y) -> ?a/(not ?a)
+// where ?x and ?y are constant integers
+static void icmpeq_select_elimination(EMatcherBuilder& builder) {
+  size_t any = builder.add_any();
+  size_t iconst = builder.add_clause(Operation::ConstantInt);
+  size_t select = builder.add_capture(Operation::Select, {any, iconst, iconst});
+  size_t icmpeq = builder.add_capture(Operation::ICmpEq, {select, iconst});
+
+  auto matcher = [=](GraphAccessor& egraph, size_t eclass_id, size_t) {
+    const ENode* inode = egraph.capture(icmpeq);
+    const ENode* snode = egraph.capture(select);
+
+    if (snode->operands[1] == snode->operands[2]) {
+      // Do nothing, this case will be handled by eliminating the select
+      // entirely.
+    } else if (snode->operands[1] == inode->operands[1]) {
+      egraph.merge(eclass_id, snode->operands[0]);
+    } else if (snode->operands[2] == inode->operands[1]) {
+      auto op = UnaryOp::CreateNot(egraph.get_op(snode->operands[0]));
+      egraph.add_merge(eclass_id, op);
+    }
+  };
+
+  builder.add_matcher(icmpeq, std::move(matcher));
+}
+
 void icmp_eliminations(EMatcherBuilder& builder) {
   eliminate_to_bool(builder, Operation::ICmpEq, true);
   eliminate_to_bool(builder, Operation::ICmpNe, false);
@@ -29,6 +56,8 @@ void icmp_eliminations(EMatcherBuilder& builder) {
   eliminate_to_bool(builder, Operation::ICmpSge, true);
   eliminate_to_bool(builder, Operation::ICmpSlt, false);
   eliminate_to_bool(builder, Operation::ICmpSle, true);
+
+  icmpeq_select_elimination(builder);
 }
 
 } // namespace caffeine::ematching::reductions


### PR DESCRIPTION
This is another independent rewrite similar to #734. All of these are patterns I've seen while trying to optimize the runtime for fuzzing zlib.

Note that this only works when `?x`, `?y` and `?z` are constant expressions.