### PR TITLE
Assorted bugfixes for `clone_ptr`

### DIFF
--- a/include/caffeine/ADT/ClonePointer.h
+++ b/include/caffeine/ADT/ClonePointer.h
@@ -24,13 +24,15 @@ public:
 
   clone_ptr() = default;
   clone_ptr(clone_ptr<T>&&) = default;
-  clone_ptr(const clone_ptr<T>& other) : pointer(other.pointer->clone()) {}
+  clone_ptr(const clone_ptr<T>& other)
+      : pointer(other ? other->clone() : nullptr) {}
   clone_ptr(std::unique_ptr<T>&& p) : pointer(std::move(p)) {}
+  clone_ptr(std::nullptr_t) : pointer(nullptr) {}
 
   clone_ptr& operator=(clone_ptr<T>&&) = default;
 
   clone_ptr& operator=(const clone_ptr<T>& other) {
-    pointer = other.pointer->clone();
+    pointer = other ? other->clone() : nullptr;
     return *this;
   }
   clone_ptr& operator=(std::nullptr_t) {

--- a/include/caffeine/ADT/ClonePointer.h
+++ b/include/caffeine/ADT/ClonePointer.h
@@ -1,3 +1,5 @@
+#pragma once
+
 #include <memory>
 
 namespace caffeine {
@@ -29,6 +31,10 @@ public:
 
   clone_ptr& operator=(const clone_ptr<T>& other) {
     pointer = other.pointer->clone();
+    return *this;
+  }
+  clone_ptr& operator=(std::nullptr_t) {
+    pointer = nullptr;
     return *this;
   }
 

--- a/test/unit/ADT/ClonePointer.cpp
+++ b/test/unit/ADT/ClonePointer.cpp
@@ -87,3 +87,10 @@ TEST(clone_ptr, virtual_things_in_a_class_actually_copy) {
   ASSERT_EQ(vec2[0]->get_i(), 5);
   ASSERT_EQ(vec2[1]->get_i(), 8);
 }
+
+TEST(clone_ptr, working_with_nulls) {
+  clone_ptr<Basic> a = nullptr;
+  clone_ptr<Basic> b = a;
+  clone_ptr<Basic> c;
+  c = b;
+}


### PR DESCRIPTION
I found a couple of different issues with `clone_ptr` that hadn't been exercised by our codebase yet. This PR goes and fixes them. The specific issues I found were:
- `ClonePointer.h` has no `#pragma once` directive
- Copying a null `clone_ptr` results in a segfault

I've fixed both and added a test case verifying that the second bug is actually fixed.