### PR TITLE
Add additional utility functions to `MultiHeap`

### DIFF
--- a/include/caffeine/Memory/Allocation.h
+++ b/include/caffeine/Memory/Allocation.h
@@ -11,6 +11,7 @@ class MemHeap;
 class MemHeapMgr;
 class LLVMScalar;
 class LLVMValue;
+class MultiHeap;
 
 /**
  * An allocation category.
@@ -123,10 +124,16 @@ public:
    */
   void write(const OpRef& offset, const OpRef& value,
              const llvm::DataLayout& layout);
+
   void write(const OpRef& offset, const LLVMScalar& value,
              const MemHeapMgr& heapmgr, const llvm::DataLayout& layout);
   void write(const OpRef& offset, llvm::Type* type, const LLVMValue& value,
              const MemHeapMgr& heapmgr, const llvm::DataLayout& layout);
+
+  void write(const OpRef& offset, const LLVMScalar& value,
+             const MultiHeap& heap, const llvm::DataLayout& layout);
+  void write(const OpRef& offset, llvm::Type* type, const LLVMValue& value,
+             const MultiHeap& heap, const llvm::DataLayout& layout);
 
   void DebugPrint() const;
 };

--- a/include/caffeine/Memory/Allocation.h
+++ b/include/caffeine/Memory/Allocation.h
@@ -114,7 +114,7 @@ public:
   OpRef read(const OpRef& offset, const Type& t,
              const llvm::DataLayout& layout) const;
   LLVMValue read(const OpRef& offset, llvm::Type* type,
-                 const llvm::DataLayout& layout);
+                 const llvm::DataLayout& layout) const;
 
   /**
    * Write the value to the array at the given offset.

--- a/include/caffeine/Memory/Heap.h
+++ b/include/caffeine/Memory/Heap.h
@@ -144,6 +144,13 @@ public:
 
   llvm::SmallVector<Pointer, 1> resolve(const Pointer& value,
                                         InterpreterContext& ctx) const;
+
+  void write_to(const Pointer& ptr, const OpRef& value,
+                const llvm::DataLayout& layout);
+  void write_to(const Pointer& ptr, const LLVMScalar& value,
+                const llvm::DataLayout& layout);
+  void write_to(const Pointer& ptr, llvm::Type* type, const LLVMValue& value,
+                const llvm::DataLayout& layout);
 };
 
 } // namespace caffeine

--- a/include/caffeine/Memory/Heap.h
+++ b/include/caffeine/Memory/Heap.h
@@ -145,6 +145,11 @@ public:
   llvm::SmallVector<Pointer, 1> resolve(const Pointer& value,
                                         InterpreterContext& ctx) const;
 
+  OpRef read_from(const Pointer& ptr, const Type& t,
+                  const llvm::DataLayout& layout) const;
+  LLVMValue read_from(const Pointer& ptr, llvm::Type* type,
+                      const llvm::DataLayout& layout) const;
+
   void write_to(const Pointer& ptr, const OpRef& value,
                 const llvm::DataLayout& layout);
   void write_to(const Pointer& ptr, const LLVMScalar& value,

--- a/include/caffeine/Memory/Heap.h
+++ b/include/caffeine/Memory/Heap.h
@@ -111,6 +111,9 @@ public:
   MultiHeap();
   explicit MultiHeap(AllocFactory factory);
 
+  // Access a heap by index.
+  const Heap& operator[](unsigned index) const;
+
   // Create a new allocation that has a distinct address from all currently live
   // allocations. In addition, it will also add corresponding assertions to the
   // context as well.

--- a/include/caffeine/Memory/Heap.h
+++ b/include/caffeine/Memory/Heap.h
@@ -108,7 +108,7 @@ public:
   static constexpr unsigned FUNCTION_INDEX = UINT_MAX - 2;
 
 public:
-  explicit MultiHeap();
+  MultiHeap();
   explicit MultiHeap(AllocFactory factory);
 
   // Create a new allocation that has a distinct address from all currently live
@@ -132,6 +132,8 @@ public:
   // resolved.
   Allocation& ptr_allocation(const Pointer& ptr);
   const Allocation& ptr_allocation(const Pointer& ptr) const;
+
+  OpRef ptr_value(const Pointer& ptr) const;
 
   Assertion check_valid(const Pointer& value, uint32_t width) const;
   Assertion check_valid(const Pointer& value, const OpRef& width) const;

--- a/src/Memory/Allocation.cpp
+++ b/src/Memory/Allocation.cpp
@@ -145,7 +145,7 @@ OpRef Allocation::read(const OpRef& offset, const Type& t,
   return UnaryOp::CreateBitcast(t, bitresult);
 }
 LLVMValue Allocation::read(const OpRef& offset, llvm::Type* type,
-                           const llvm::DataLayout& layout) {
+                           const llvm::DataLayout& layout) const {
   if (!(perms_ & AllocationPermissions::Read)) {
     throw AllocationException("tried to read unreadable allocation");
   }

--- a/src/Memory/Heap.cpp
+++ b/src/Memory/Heap.cpp
@@ -303,6 +303,17 @@ MultiHeap::resolve(const Pointer& value, InterpreterContext& ctx) const {
   return it->second.resolve(value, ctx);
 }
 
+OpRef MultiHeap::read_from(const Pointer& ptr, const Type& t,
+                           const llvm::DataLayout& layout) const {
+  const Allocation& alloc = ptr_allocation(ptr);
+  return alloc.read(ptr.offset(), t, layout);
+}
+LLVMValue MultiHeap::read_from(const Pointer& ptr, llvm::Type* type,
+                               const llvm::DataLayout& layout) const {
+  const Allocation& alloc = ptr_allocation(ptr);
+  return alloc.read(ptr.offset(), type, layout);
+}
+
 void MultiHeap::write_to(const Pointer& ptr, const OpRef& value,
                          const llvm::DataLayout& layout) {
   auto& alloc = ptr_allocation(ptr);

--- a/src/Memory/Heap.cpp
+++ b/src/Memory/Heap.cpp
@@ -262,6 +262,13 @@ Allocation& MultiHeap::ptr_allocation(const Pointer& ptr) {
       const_cast<const MultiHeap*>(this)->ptr_allocation(ptr));
 }
 
+OpRef MultiHeap::ptr_value(const Pointer& ptr) const {
+  if (!ptr.is_resolved())
+    return ptr.offset();
+
+  return heaps_.at(ptr.heap()).ptr_value(ptr);
+}
+
 Assertion MultiHeap::check_valid(const Pointer& value,
                                  const OpRef& width) const {
   auto it = heaps_.find(value.heap());

--- a/src/Memory/Heap.cpp
+++ b/src/Memory/Heap.cpp
@@ -303,4 +303,21 @@ MultiHeap::resolve(const Pointer& value, InterpreterContext& ctx) const {
   return it->second.resolve(value, ctx);
 }
 
+void MultiHeap::write_to(const Pointer& ptr, const OpRef& value,
+                         const llvm::DataLayout& layout) {
+  auto& alloc = ptr_allocation(ptr);
+  alloc.write(ptr.offset(), value, layout);
+}
+void MultiHeap::write_to(const Pointer& ptr, const LLVMScalar& value,
+                         const llvm::DataLayout& layout) {
+  auto& alloc = ptr_allocation(ptr);
+  alloc.write(ptr.offset(), value, *this, layout);
+}
+void MultiHeap::write_to(const Pointer& ptr, llvm::Type* type,
+                         const LLVMValue& value,
+                         const llvm::DataLayout& layout) {
+  auto& alloc = ptr_allocation(ptr);
+  alloc.write(ptr.offset(), type, value, *this, layout);
+}
+
 } // namespace caffeine

--- a/src/Memory/Heap.cpp
+++ b/src/Memory/Heap.cpp
@@ -219,6 +219,10 @@ llvm::SmallVector<Pointer, 1> Heap::resolve(const Pointer& ptr,
 MultiHeap::MultiHeap() {}
 MultiHeap::MultiHeap(AllocFactory factory) : factory_(factory) {}
 
+const Heap& MultiHeap::operator[](unsigned int index) const {
+  return heaps_.at(index);
+}
+
 Pointer MultiHeap::allocate(const OpRef& size, const OpRef& alignment,
                             const OpRef& data, AllocationKind kind,
                             AllocationPermissions permissions,


### PR DESCRIPTION
This PR introduces a bunch of functions around reading and writing memory to `MultiHeap` along with corresponding overloads within `Allocation`. These were functions that I found I needed when trying to convert the rest of the codebase to use `MultiHeap` instead of `MemHeapMgr`.

/stack #740 