### PR TITLE
Add graceful interrupt handling

### DIFF
--- a/include/caffeine/Interpreter/Executor.h
+++ b/include/caffeine/Interpreter/Executor.h
@@ -1,7 +1,9 @@
 #ifndef CAFFEINE_INTERP_EXECUTOR_H
 #define CAFFEINE_INTERP_EXECUTOR_H
 
+#include <atomic>
 #include <cstdint>
+#include <mutex>
 
 #include "caffeine/Interpreter/Context.h"
 #include "caffeine/Interpreter/FailureLogger.h"
@@ -26,14 +28,23 @@ private:
   ExecutionContextStore* store;
   FailureLogger* logger;
   ExecutorOptions options;
+  std::vector<std::shared_ptr<Solver>> solvers;
+  std::mutex mutex_;
 
 public:
-  Executor(CaffeineContext* caffeine, const ExecutorOptions& options = {});
+  std::shared_ptr<std::atomic_bool> should_stop;
+  Executor(CaffeineContext* caffeine, const ExecutorOptions& options = {},
+           std::shared_ptr<std::atomic_bool> should_stop = nullptr);
 
   /**
    * Runs the contexts in its possesion until there are none left
    */
   void run();
+
+  /**
+   * Interrupts the Executor. Forces `run` to return as soon as possible
+   */
+  void interrupt();
 
 private:
   void run_worker();

--- a/include/caffeine/Solver/InterruptSolver.h
+++ b/include/caffeine/Solver/InterruptSolver.h
@@ -1,12 +1,15 @@
 #pragma once
 
+#include <atomic>
+
 #include "caffeine/Solver/Solver.h"
 
 namespace caffeine {
 
-class EarlyExitSolver : public Solver {
+class InterruptSolver : public Solver {
 public:
-  EarlyExitSolver(const std::shared_ptr<Solver>& solver);
+  InterruptSolver(const std::shared_ptr<Solver>& solver,
+                  const std::shared_ptr<std::atomic<bool>> should_stop);
 
   SolverResult check(AssertionList& assertions,
                      const Assertion& extra) override;
@@ -17,6 +20,7 @@ public:
 
 private:
   std::shared_ptr<Solver> inner;
+  std::shared_ptr<std::atomic<bool>> should_stop;
 };
 
 } // namespace caffeine

--- a/include/caffeine/Solver/LoggingSolver.h
+++ b/include/caffeine/Solver/LoggingSolver.h
@@ -15,8 +15,11 @@ private:
   void log_result(const SolverResult& result);
 
 public:
-  SolverResult check(AssertionList& assertions, const Assertion& extra);
-  SolverResult resolve(AssertionList& assertions, const Assertion& extra);
+  SolverResult check(AssertionList& assertions,
+                     const Assertion& extra) override;
+  SolverResult resolve(AssertionList& assertions,
+                       const Assertion& extra) override;
+  void interrupt() override;
 
   LoggingSolver(const std::shared_ptr<Solver>& solver);
 };

--- a/include/caffeine/Solver/SlicingSolver.h
+++ b/include/caffeine/Solver/SlicingSolver.h
@@ -16,8 +16,11 @@ private:
 public:
   SlicingSolver(const std::shared_ptr<Solver>& inner);
 
-  SolverResult check(AssertionList& assertions, const Assertion& extra);
-  SolverResult resolve(AssertionList& assertions, const Assertion& extra);
+  SolverResult check(AssertionList& assertions,
+                     const Assertion& extra) override;
+  SolverResult resolve(AssertionList& assertions,
+                       const Assertion& extra) override;
+  void interrupt() override;
 };
 
 } // namespace caffeine

--- a/include/caffeine/Solver/Solver.h
+++ b/include/caffeine/Solver/Solver.h
@@ -238,13 +238,6 @@ public:
   // Add a new solver to the top of the solver stack.
   SolverBuilder& with(const InterFn& func);
 
-  // template <typename T>
-  // SolverBuilder& with() {
-  //   return with([](const std::shared_ptr<Solver>& solver) {
-  //     return std::make_shared<T>(solver);
-  //   });
-  // }
-
   template <typename T, typename... Params>
   SolverBuilder& with(Params... args) {
     auto func = [](const std::shared_ptr<Solver>& solver, Params... args) {

--- a/include/caffeine/Solver/Solver.h
+++ b/include/caffeine/Solver/Solver.h
@@ -176,6 +176,11 @@ public:
   // Calls resolve with an empty extra assertion.
   SolverResult resolve(AssertionList& assertions);
 
+  /**
+   * Attempt to interrupt solver recursively
+   */
+  virtual void interrupt() = 0;
+
   Solver(const Solver&) = default;
   Solver(Solver&&) = default;
 
@@ -208,6 +213,8 @@ protected:
   SolverResult resolve(AssertionList& assertions,
                        const Assertion& extra) override;
 
+  void interrupt() override;
+
 protected:
   std::shared_ptr<Solver> base;
 };
@@ -231,11 +238,23 @@ public:
   // Add a new solver to the top of the solver stack.
   SolverBuilder& with(const InterFn& func);
 
-  template <typename T>
-  SolverBuilder& with() {
-    return with([](const std::shared_ptr<Solver>& solver) {
-      return std::make_shared<T>(solver);
-    });
+  // template <typename T>
+  // SolverBuilder& with() {
+  //   return with([](const std::shared_ptr<Solver>& solver) {
+  //     return std::make_shared<T>(solver);
+  //   });
+  // }
+
+  template <typename T, typename... Params>
+  SolverBuilder& with(Params... args) {
+    auto func = [](const std::shared_ptr<Solver>& solver, Params... args) {
+      return std::make_shared<T>(solver, std::forward<Params>(args)...);
+    };
+
+    InterFn bound = std::bind(std::move(func), std::placeholders::_1,
+                              std::forward<Params>(args)...);
+
+    return with(bound);
   }
 
   // Build the full solver.

--- a/include/caffeine/Solver/Z3Solver.h
+++ b/include/caffeine/Solver/Z3Solver.h
@@ -36,6 +36,8 @@ public:
   SolverResult resolve(AssertionList& assertions,
                        const Assertion& extra) override;
 
+  void interrupt() override;
+
   // Evaluate an expression to a z3::expr. This is exposed for testing purposes.
   z3::context& context();
   z3::expr evaluate(const OpRef& expr, z3::solver& solver);

--- a/include/caffeine/Support/Signal.h
+++ b/include/caffeine/Support/Signal.h
@@ -1,6 +1,15 @@
 #pragma once
 
+#include <atomic>
+
+#include "caffeine/Interpreter/Executor.h"
+
 namespace caffeine {
+
+namespace signals {
+  extern caffeine::Executor* executor;
+  void stop_context();
+} // namespace signals
 
 // Register a global signal handler that augments the existing one registered by
 // LLVM to also print out the symbolic call stack.

--- a/src/Solver/EarlyExitSolver.cpp
+++ b/src/Solver/EarlyExitSolver.cpp
@@ -25,4 +25,8 @@ SolverResult EarlyExitSolver::resolve(AssertionList& assertions,
   return inner->resolve(assertions, extra);
 }
 
+void EarlyExitSolver::interrupt() {
+  inner->interrupt();
+}
+
 } // namespace caffeine

--- a/src/Solver/InterruptSolver.cpp
+++ b/src/Solver/InterruptSolver.cpp
@@ -1,0 +1,31 @@
+#include "caffeine/Solver/InterruptSolver.h"
+#include "caffeine/Model/AssertionList.h"
+
+namespace caffeine {
+
+InterruptSolver::InterruptSolver(
+    const std::shared_ptr<Solver>& solver,
+    const std::shared_ptr<std::atomic<bool>> should_stop)
+    : inner(solver), should_stop(should_stop) {}
+
+SolverResult InterruptSolver::check(AssertionList& assertions,
+                                    const Assertion& extra) {
+  if (should_stop->load())
+    return SolverResult::Unknown;
+
+  return inner->check(assertions, extra);
+}
+
+SolverResult InterruptSolver::resolve(AssertionList& assertions,
+                                      const Assertion& extra) {
+  if (should_stop->load())
+    return SolverResult::Unknown;
+
+  return inner->resolve(assertions, extra);
+}
+
+void InterruptSolver::interrupt() {
+  inner->interrupt();
+}
+
+} // namespace caffeine

--- a/src/Solver/LoggingSolver.cpp
+++ b/src/Solver/LoggingSolver.cpp
@@ -61,4 +61,8 @@ SolverResult LoggingSolver::resolve(AssertionList& assertions,
   return result;
 }
 
+void LoggingSolver::interrupt() {
+  solver->interrupt();
+}
+
 } // namespace caffeine

--- a/src/Solver/SlicingSolver.cpp
+++ b/src/Solver/SlicingSolver.cpp
@@ -17,4 +17,8 @@ SolverResult SlicingSolver::resolve(AssertionList& assertions,
   return inner->resolve(assertions, extra);
 }
 
+void SlicingSolver::interrupt() {
+  inner->interrupt();
+}
+
 } // namespace caffeine

--- a/src/Solver/Solver.cpp
+++ b/src/Solver/Solver.cpp
@@ -134,6 +134,10 @@ SolverResult TransformSolver::resolve(AssertionList& assertions,
   CAFFEINE_UNREACHABLE();
 }
 
+void TransformSolver::interrupt() {
+  base->interrupt();
+}
+
 SolverBuilder::SolverBuilder(const BaseFn& base) : base(base) {}
 
 SolverBuilder SolverBuilder::with_default() {

--- a/src/Solver/Z3Solver.cpp
+++ b/src/Solver/Z3Solver.cpp
@@ -248,6 +248,10 @@ SolverResult Z3Solver::resolve(AssertionList& assertions,
   }
 }
 
+void Z3Solver::interrupt() {
+  context().interrupt();
+}
+
 z3::context& Z3Solver::context() {
   return impl->ctx;
 }

--- a/src/Support/Signal.cpp
+++ b/src/Support/Signal.cpp
@@ -58,7 +58,9 @@ namespace {
   struct sigaction sigactions[max_signal + 1] = {};
 
   void signal_handler(int sig) {
-    alarm(30);
+    if (sig != SIGINT) {
+      alarm(30);
+    }
 
     if (sigactions[sig].sa_handler)
       sigactions[sig].sa_handler(sig);

--- a/src/Support/Signal.cpp
+++ b/src/Support/Signal.cpp
@@ -35,7 +35,7 @@ namespace {
 
 #ifdef __unix__
   // clang-format off
-  static constexpr const int signals[] = {
+  static constexpr const int sys_signals[] = {
     SIGHUP, SIGINT, SIGTERM, SIGUSR2,
     SIGILL, SIGTRAP, SIGABRT, SIGFPE, SIGBUS, SIGSEGV, SIGQUIT
 #ifdef SIGSYS
@@ -54,7 +54,7 @@ namespace {
   // clang-format on
 
   static constexpr int max_signal =
-      *std::max_element(std::begin(signals), std::end(signals));
+      *std::max_element(std::begin(sys_signals), std::end(sys_signals));
   struct sigaction sigactions[max_signal + 1] = {};
 
   void signal_handler(int sig) {
@@ -63,11 +63,27 @@ namespace {
     if (sigactions[sig].sa_handler)
       sigactions[sig].sa_handler(sig);
 
+    if (sig == SIGINT) {
+      // Don't want to raise SIGINT because we exit gracefully
+      return;
+    }
+
     if (sigactions[sig].sa_flags & SA_RESETHAND)
       raise(sig);
   }
 #endif
 } // namespace
+
+namespace signals {
+  caffeine::Executor* executor = nullptr;
+  void stop_context() {
+    std::cout.flush();
+
+    if (executor) {
+      executor->interrupt();
+    }
+  }
+} // namespace signals
 
 void RegisterSignalHandlers() {
   llvm::sys::AddSignalHandler(&dump_symbolic_backtrace, nullptr);
@@ -76,7 +92,7 @@ void RegisterSignalHandlers() {
   // Wrap all existing signal handlers with one that reraises the signal with
   // the default handler at the end if it is a fatal signal.
   std::memset(sigactions, 0, sizeof(sigactions));
-  for (int sig : signals) {
+  for (int sig : sys_signals) {
     sigaction(sig, nullptr, &sigactions[sig]);
 
     struct sigaction new_handler;


### PR DESCRIPTION
This PR implements graceful exit of caffeine if a user sends the SIGINT
signal. This is useful if we run with the `--coverage` flag because then
the line coverage will be dumped at the end of the run

Closes #637