### PR TITLE
Modify cache options to avoid requiring a cache

### DIFF
--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -43,18 +43,18 @@ jobs:
           build --config=${{ matrix.compiler }}
           EOF
 
-      - name: Avoid uploading if we don't have credentials
-        if: env.CACHE_CREDENTIALS == null
-        shell: bash
-        run: |
-          echo build --remote_cache=grpc://bazel-cache.airmash.cc:9092/ >> local.bazelrc
-          echo build --remote_upload_local_results=false       >> local.bazelrc
+      # - name: Avoid uploading if we don't have credentials
+      #   if: env.CACHE_CREDENTIALS == null
+      #   shell: bash
+      #   run: |
+      #     echo build --remote_cache=grpc://bazel-cache.airmash.cc:9092/ >> local.bazelrc
+      #     echo build --remote_upload_local_results=false       >> local.bazelrc
 
-      - name: Pass credentials
-        if: env.CACHE_CREDENTIALS != null
-        shell: bash
-        run: |
-          echo "build '--remote_cache=grpc://bazel:${{ env.CACHE_CREDENTIALS }}@bazel-cache.airmash.cc:9092/'" >> local.bazelrc
+      # - name: Pass credentials
+      #   if: env.CACHE_CREDENTIALS != null
+      #   shell: bash
+      #   run: |
+      #     echo "build '--remote_cache=grpc://bazel:${{ env.CACHE_CREDENTIALS }}@bazel-cache.airmash.cc:9092/'" >> local.bazelrc
 
       - name: Run all tests
         run: |
@@ -98,18 +98,18 @@ jobs:
           build --compilation_mode=${{ matrix.mode }}
           EOF
 
-      - name: Avoid uploading if we don't have credentials
-        if: env.CACHE_CREDENTIALS == null
-        shell: bash
-        run: |
-          echo build --remote_cache=grpc://bazel-cache.airmash.cc:9092/ >> local.bazelrc
-          echo build --remote_upload_local_results=false       >> local.bazelrc
+      # - name: Avoid uploading if we don't have credentials
+      #   if: env.CACHE_CREDENTIALS == null
+      #   shell: bash
+      #   run: |
+      #     echo build --remote_cache=grpc://bazel-cache.airmash.cc:9092/ >> local.bazelrc
+      #     echo build --remote_upload_local_results=false       >> local.bazelrc
 
-      - name: Pass credentials
-        if: env.CACHE_CREDENTIALS != null
-        shell: bash
-        run: |
-          echo "build '--remote_cache=grpc://bazel:${{ env.CACHE_CREDENTIALS }}@bazel-cache.airmash.cc:9092/'" >> local.bazelrc
+      # - name: Pass credentials
+      #   if: env.CACHE_CREDENTIALS != null
+      #   shell: bash
+      #   run: |
+      #     echo "build '--remote_cache=grpc://bazel:${{ env.CACHE_CREDENTIALS }}@bazel-cache.airmash.cc:9092/'" >> local.bazelrc
 
       - name: Check formatting of all targets
         run: bazelisk run --config=ci -- //:check-format

--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -56,6 +56,19 @@ jobs:
       #   run: |
       #     echo "build '--remote_cache=grpc://bazel:${{ env.CACHE_CREDENTIALS }}@bazel-cache.airmash.cc:9092/'" >> local.bazelrc
 
+      - name: Find all external dependencies
+        shell: bash
+        run: |
+          # Get a list of all external dependencies
+          bazel query 'deps(//...)' | grep -ve '^//.*$' > bazel-deps
+
+      - name: Restore bazel disk cache
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cache/bazel-disk-cache
+          key: bazel-build-disk-cache--${{ matrix.mode }}-${{ matrix.compiler}}-${{ hashFiles('bazel-deps') }}
+
       - name: Run all tests
         run: |
           bazelisk test --config=ci -- //... \
@@ -110,6 +123,19 @@ jobs:
       #   shell: bash
       #   run: |
       #     echo "build '--remote_cache=grpc://bazel:${{ env.CACHE_CREDENTIALS }}@bazel-cache.airmash.cc:9092/'" >> local.bazelrc
+      
+      - name: Find all external dependencies
+        shell: bash
+        run: |
+          # Get a list of all external dependencies
+          bazel query 'deps(//:check-format)' | grep -ve '^//.*$' > bazel-deps
+
+      - name: Restore bazel disk cache
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cache/bazel-disk-cache
+          key: bazel-fmt-disk-cache--${{ matrix.mode }}-${{ matrix.compiler}}-${{ hashFiles('bazel-deps') }}
 
       - name: Check formatting of all targets
         run: bazelisk run --config=ci -- //:check-format

--- a/bazel/ci.bazelrc
+++ b/bazel/ci.bazelrc
@@ -12,7 +12,7 @@ build:ci --jobs=64
 build:ci --experimental_remote_cache_async
 
 # Avoid downloading artifacts that aren't needed.
-build:ci --remote_download_toplevel
+# build:ci --remote_download_toplevel
 
 build:clang --action_env=CC=clang-12
 build:clang --action_env=CXX=clang++-12


### PR DESCRIPTION
This PR makes a couple of changes to CI now that the bazel cache isn't working. As long as no targets are modified then the build should be pretty fast.