### PR TITLE
Switch caffeine over to the new memory heap implementation

### DIFF
--- a/include/caffeine/IR/OperationBuilder.h
+++ b/include/caffeine/IR/OperationBuilder.h
@@ -100,6 +100,8 @@ public:
 
   OpRef createSelect(const OpRef& cond, const OpRef& true_value,
                      const OpRef& false_value);
+  OpRef createSelect(const OpRef& cond, const Pointer& true_value,
+                     const Pointer& false_value);
   LLVMValue createSelect(const LLVMValue& cond, const LLVMValue& true_value,
                          const LLVMValue& false_value);
 

--- a/include/caffeine/Interpreter/Context.h
+++ b/include/caffeine/Interpreter/Context.h
@@ -4,6 +4,7 @@
 #include "caffeine/IR/Assertion.h"
 #include "caffeine/IR/EGraph.h"
 #include "caffeine/Interpreter/StackFrame.h"
+#include "caffeine/Memory/Heap.h"
 #include "caffeine/Memory/MemHeap.h"
 #include "caffeine/Model/AssertionList.h"
 #include "caffeine/Model/GraphAssertionList.h"
@@ -27,7 +28,7 @@ class Context {
 public:
   std::vector<StackFrame> stack;
   std::unordered_map<llvm::GlobalValue*, LLVMValue> globals;
-  MemHeapMgr heaps;
+  MultiHeap heaps;
   GraphAssertionList assertions;
   immer::map<std::string, OpRef> constants;
 
@@ -77,7 +78,6 @@ public:
    * Note: This method also deallocates all stack-allocated allocations within
    *       the current frame.
    */
-  void pop();
   void push(StackFrame&& frame);
   void push(const StackFrame& frame);
 

--- a/include/caffeine/Interpreter/InterpreterContext.h
+++ b/include/caffeine/Interpreter/InterpreterContext.h
@@ -126,6 +126,18 @@ public:
                             const OpRef& byte, unsigned address_space,
                             AllocationKind kind, AllocationPermissions perms);
 
+  /**
+   * Deallocate the allocation pointed to by ptr or specified by the combination
+   * of the allocation id and heap.
+   *
+   * This will trigger an assertion failure if ptr is not a resolved pointer.
+   */
+  void deallocate(const Pointer& ptr);
+  void deallocate(AllocId alloc, unsigned heap);
+
+  // Retrieve the actual location in memory that the pointer points to.
+  OpRef ptr_value(const Pointer& ptr);
+
   // Utilities for performing common control flow operations
 
   /**
@@ -373,6 +385,8 @@ private:
   // Set the current context as dead and emit the appropriate notifications.
   void set_dead(ExecutionPolicy::ExitStatus status,
                 const Assertion& assertion = Assertion::constant(true));
+
+  void pop_frame();
 
 public:
   // Interfaces used by the scheduler to interact with InterpreterContext

--- a/src/IR/OperationBuilder.cpp
+++ b/src/IR/OperationBuilder.cpp
@@ -174,6 +174,26 @@ DEF_CONVERT(Bitcast);
 DEF_CONVERT(TruncOrZExt);
 DEF_CONVERT(TruncOrSExt);
 
+OpRef OperationBuilder::createSelect(const OpRef& cond, const OpRef& true_value,
+                                     const OpRef& false_value) {
+  return to_egraph(SelectOp::Create(cond, true_value, false_value));
+}
+OpRef OperationBuilder::createSelect(const OpRef& cond,
+                                     const Pointer& true_value,
+                                     const Pointer& false_value) {
+  return createSelect(cond, to_expr(true_value), to_expr(false_value));
+}
+LLVMValue OperationBuilder::createSelect(const LLVMValue& cond,
+                                         const LLVMValue& true_value,
+                                         const LLVMValue& false_value) {
+  return transform_elements(
+      [&](const LLVMScalar& c, const LLVMScalar& t,
+          const LLVMScalar& f) -> LLVMScalar {
+        return this->createSelect(to_expr(c), to_expr(t), to_expr(f));
+      },
+      cond, true_value, false_value);
+}
+
 LLVMValue OperationBuilder::createICmp(ICmpOpcode opcode, const LLVMValue& lhs,
                                        const LLVMValue& rhs) {
   return transform_elements(

--- a/src/IR/OperationBuilder.cpp
+++ b/src/IR/OperationBuilder.cpp
@@ -266,7 +266,7 @@ OpRef OperationBuilder::to_expr(const LLVMScalar& scalar) {
   return to_expr(scalar.pointer());
 }
 OpRef OperationBuilder::to_expr(const Pointer& ptr) {
-  return ptr.value(ctx->heaps);
+  return ctx->heaps.ptr_value(ptr);
 }
 
 OpRef OperationBuilder::to_egraph(const OpRef& op) {

--- a/src/Interpreter/ExprEval.cpp
+++ b/src/Interpreter/ExprEval.cpp
@@ -45,7 +45,7 @@ ExprEvaluator::ExprEvaluator(InterpreterContext* interp, Options options)
 OpRef ExprEvaluator::scalarize(const LLVMScalar& scalar) const {
   if (scalar.is_expr())
     return scalar.expr();
-  return scalar.pointer().value(interp->context().heaps);
+  return interp->ptr_value(scalar.pointer());
 }
 
 LLVMValue ExprEvaluator::visit(llvm::Value* val) {
@@ -702,10 +702,7 @@ LLVMScalar ExprEvaluator::select(const LLVMScalar& cond,
         t_ptr.heap());
   }
 
-  return Pointer(SelectOp::Create(cond.expr(),
-                                  t_ptr.value(interp->context().heaps),
-                                  f_ptr.value(interp->context().heaps)),
-                 t_ptr.heap());
+  return Pointer(interp->createSelect(cond.expr(), t_ptr, f_ptr), t_ptr.heap());
 }
 LLVMValue ExprEvaluator::visitSelectInst(llvm::SelectInst& op) {
   auto cond = visit(op.getCondition());

--- a/src/Interpreter/ExternalFuncs/CaffeineBuiltinResolve.cpp
+++ b/src/Interpreter/ExternalFuncs/CaffeineBuiltinResolve.cpp
@@ -49,8 +49,7 @@ namespace {
           fork.context().backprop(mem, ptr);
         }
 
-        fork.add_assertion(ICmpOp::CreateICmpEQ(
-            mem.value(fork.context().heaps), ptr.value(fork.context().heaps)));
+        fork.add_assertion(fork.createICmpEQ(mem, ptr));
         fork.jump_return(LLVMValue(ptr));
       }
     }

--- a/src/Interpreter/ExternalFuncs/Free.cpp
+++ b/src/Interpreter/ExternalFuncs/Free.cpp
@@ -41,10 +41,8 @@ namespace {
       ctx.kill();
       for (auto ptr : resolved) {
         auto fork = ctx.fork();
-        fork.add_assertion(
-            ICmpOp::CreateICmpEQ(memptr.value(fork.context().heaps),
-                                 ptr.value(fork.context().heaps)));
-        fork.context().heaps[ptr.heap()].deallocate(ptr.alloc());
+        fork.add_assertion(fork.createICmpEQ(memptr, ptr));
+        fork.deallocate(ptr);
       }
     }
   };

--- a/src/Interpreter/ExternalFuncs/GenericUnwinding.cpp
+++ b/src/Interpreter/ExternalFuncs/GenericUnwinding.cpp
@@ -77,12 +77,10 @@ bool GenericUnwinding::getPossibleStates(InterpreterContext& ctx) {
 
         OpRef matches_any_ele = ConstantInt::Create(false);
         for (size_t i = 0; i < clause_value.aggregate().size(); i++) {
-          matches_any_ele = BinaryOp::CreateOr(
+          matches_any_ele = ctx.createOr(
               matches_any_ele,
-              ICmpOp::CreateICmpEQ(
-                  clause_value.aggregate()[i].scalar().pointer().value(
-                      ctx.context().heaps),
-                  args[0].scalar().pointer().value(ctx.context().heaps)));
+              ctx.createICmpEQ(clause_value.aggregate()[i].scalar().pointer(),
+                               args[0].scalar().pointer()));
         }
 
         Assertion should_enter = !Assertion(matches_any_ele);

--- a/src/Interpreter/ExternalFuncs/SetJmp.cpp
+++ b/src/Interpreter/ExternalFuncs/SetJmp.cpp
@@ -63,9 +63,7 @@ namespace {
 
       for (const Pointer& ptr : resolved) {
         auto fork = ctx.fork();
-        fork.add_assertion(
-            ICmpOp::CreateICmpEQ(unresolved.value(ctx.context().heaps),
-                                 ptr.value(ctx.context().heaps)));
+        fork.add_assertion(fork.createICmpEQ(unresolved, ptr));
         fork.mem_write(ptr, jmpbuf_ty, jmpbuf);
         fork.jump_return(LLVMValue(ConstantInt::CreateZero(
             func->getReturnType()->getIntegerBitWidth())));

--- a/src/Interpreter/Interpreter.cpp
+++ b/src/Interpreter/Interpreter.cpp
@@ -344,8 +344,7 @@ void Interpreter::visitIndirectCall(llvm::CallBase& call) {
   for (auto& ptr : resolved) {
     auto fork = interp->fork();
     Allocation& alloc = fork.context().heaps.ptr_allocation(ptr);
-    fork.add_assertion(ICmpOp::CreateICmpEQ(
-        alloc.address(), pointer.value(fork.context().heaps)));
+    fork.add_assertion(fork.createICmpEQ(alloc.address(), pointer));
 
     newcall->setCalledFunction(
         llvm::cast<FunctionObject>(*alloc.data()).function());
@@ -385,9 +384,7 @@ void Interpreter::visitStoreInst(llvm::StoreInst& inst) {
   interp->kill();
   for (const Pointer& ptr : resolved) {
     auto fork = interp->fork();
-    fork.add_assertion(
-        ICmpOp::CreateICmpEQ(ptr.value(interp->context().heaps),
-                             unresolved.value(interp->context().heaps)));
+    fork.add_assertion(fork.createICmpEQ(ptr, unresolved));
 
     Allocation* alloc = fork.ptr_allocation(ptr);
     CAFFEINE_ASSERT(alloc);

--- a/src/Solver/Solver.cpp
+++ b/src/Solver/Solver.cpp
@@ -56,7 +56,7 @@ Value Model::evaluate(const LLVMScalar& scalar, Context& ctx) const {
   ModelEvaluator evaluator{this, &ctx.egraph};
 
   if (scalar.is_pointer())
-    return evaluator.visit(*scalar.pointer().value(ctx.heaps));
+    return evaluator.visit(*ctx.heaps.ptr_value(scalar.pointer()));
   return evaluator.visit(*scalar.expr());
 }
 

--- a/tools/caffeine/main.cpp
+++ b/tools/caffeine/main.cpp
@@ -8,6 +8,7 @@
 #include "caffeine/Interpreter/Store/CountLimitedStore.h"
 #include "caffeine/Interpreter/Store/TimeLimitedStore.h"
 #include "caffeine/Interpreter/ThreadQueueStore.h"
+#include "caffeine/Memory/BumpAllocator.h"
 #include "caffeine/Solver/InterruptSolver.h"
 #include "caffeine/Solver/LoggingSolver.h"
 #include "caffeine/Solver/Solver.h"
@@ -234,7 +235,8 @@ int main(int argc, char** argv) {
   }
 
   auto context = Context(function);
-  context.heaps.set_concrete(!force_symbolic_allocator);
+  if (force_symbolic_allocator)
+    context.heaps = MultiHeap();
   caffeine.store()->add_context(std::move(context));
 
   llvm::sys::SetInterruptFunction(&caffeine::signals::stop_context);


### PR DESCRIPTION
As in title. This changes everything to use `MultiHeap` which is cleaner and also has access to the `EGraph` when doing pointer resolutions.