### PR TITLE
Write a context store based on boost's `lockfree::queue`

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -106,6 +106,7 @@ cc_library(
         "//third_party:z3",
         "//third_party/capnp",
         "@boost//:filesystem",
+        "@boost//:lockfree",
         "@boost//:thread",
         "@llvm//llvm:Core",
         "@llvm//llvm:Support",

--- a/include/caffeine/Interpreter/Store/LockfreeStore.h
+++ b/include/caffeine/Interpreter/Store/LockfreeStore.h
@@ -1,0 +1,32 @@
+#pragma once
+
+#include "caffeine/Interpreter/Store.h"
+#include <atomic>
+#include <boost/lockfree/queue.hpp>
+#include <condition_variable>
+
+namespace caffeine {
+
+class LockfreeContextStore : public ExecutionContextStore {
+public:
+  LockfreeContextStore(size_t num_readers);
+  ~LockfreeContextStore();
+
+  std::optional<Context> next_context() override;
+
+  void add_context(Context&& ctx) override;
+  void shutdown() override;
+
+  LockfreeContextStore(const LockfreeContextStore&) = delete;
+  LockfreeContextStore& operator=(const LockfreeContextStore&) = delete;
+
+private:
+  size_t num_readers_;
+  size_t blocked_{0};
+  std::atomic<bool> done_{false};
+  boost::lockfree::queue<Context*> queue_{32};
+  std::condition_variable cond_;
+  std::mutex mutex_;
+};
+
+} // namespace caffeine

--- a/src/Interpreter/Store/LockfreeStore.cpp
+++ b/src/Interpreter/Store/LockfreeStore.cpp
@@ -1,0 +1,60 @@
+#include "caffeine/Interpreter/Store/LockfreeStore.h"
+#include "caffeine/ADT/Guard.h"
+
+namespace caffeine {
+
+std::optional<Context> LockfreeContextStore::next_context() {
+  do {
+    if (done_.load(std::memory_order_relaxed)) {
+      return std::nullopt;
+    }
+
+    Context* ptr;
+    if (queue_.pop(ptr)) {
+      std::unique_ptr<Context> ctx{ptr};
+      return std::move(*ctx);
+    }
+
+    std::unique_lock lock{mutex_};
+    blocked_ += 1;
+
+    if (blocked_ == num_readers_) {
+      blocked_ -= 1;
+      shutdown();
+      return std::nullopt;
+    }
+
+    cond_.wait_for(lock, std::chrono::milliseconds(100));
+  } while (true);
+}
+
+void LockfreeContextStore::add_context(Context&& ctx) {
+  if (done_.load(std::memory_order_relaxed))
+    return;
+
+  auto ctxptr = std::make_unique<Context>(std::move(ctx));
+  if (queue_.push(ctxptr.get())) {
+    (void)ctxptr.release();
+    cond_.notify_one();
+  } else {
+    CAFFEINE_ABORT("Failed to push to main queue");
+  }
+}
+
+void LockfreeContextStore::shutdown() {
+  done_.store(true);
+  cond_.notify_all();
+}
+
+LockfreeContextStore::LockfreeContextStore(size_t num_readers)
+    : num_readers_(num_readers) {}
+LockfreeContextStore::~LockfreeContextStore() {
+  CAFFEINE_ASSERT(blocked_ == 0);
+
+  Context* ptr;
+  while (queue_.unsynchronized_pop(ptr)) {
+    delete ptr;
+  }
+}
+
+} // namespace caffeine


### PR DESCRIPTION
I'm still trying to get some last-minute optimizations in. Boost has a lockfree queue which should be a lot more efficient than our existing queue implementations. I've tested this in the complete set of commits I'll be putting up but I don't know how to test it on its own here.