### PR TITLE
Implement a caching solver on top of LMDB

### DIFF
--- a/.github/workflows/build-apt.yml
+++ b/.github/workflows/build-apt.yml
@@ -29,7 +29,8 @@ jobs:
             libgtest-dev \
             libfmt-dev \
             libboost-all-dev \
-            capnproto libcapnp-dev
+            capnproto libcapnp-dev \
+            liblmdb-dev
           sudo ./.github/scripts/update-alternatives-llvm.sh 12 20
           go get github.com/SRI-CSL/gllvm/cmd/...
 

--- a/.github/workflows/find-coverage.yml
+++ b/.github/workflows/find-coverage.yml
@@ -24,7 +24,8 @@ jobs:
             libgtest-dev \
             libfmt-dev \
             libboost-all-dev \
-            capnproto libcapnp-dev
+            capnproto libcapnp-dev \
+            liblmdb-dev
           sudo ./.github/scripts/update-alternatives-llvm.sh 12 20
           go get github.com/SRI-CSL/gllvm/cmd/...
 

--- a/BUILD
+++ b/BUILD
@@ -110,6 +110,7 @@ cc_library(
         "@boost//:thread",
         "@llvm//llvm:Core",
         "@llvm//llvm:Support",
+        "@lmdb",
     ],
 )
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -122,6 +122,7 @@ find_package(Z3 4.8.7 REQUIRED)
 find_package(Boost COMPONENTS thread filesystem REQUIRED)
 find_package(fmt REQUIRED)
 find_package(CapnProto REQUIRED)
+find_package(LMDB REQUIRED)
 
 include(CaffeineDependencies)
 

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -7,6 +7,7 @@ load("@caffeine//third_party/boost:setup.bzl", "setup_boost")
 load("@caffeine//third_party/musl:setup.bzl", "setup_musl")
 load("@caffeine//third_party/libcxx:setup.bzl", "setup_libcxx")
 load("@caffeine//third_party/afl:setup.bzl", "setup_afl")
+load("@caffeine//third_party/lmdb:setup.bzl", "setup_lmdb")
 
 SKYLIB_VERSION = "1.1.1"
 
@@ -48,6 +49,8 @@ setup_musl(name = "musl")
 setup_libcxx(name = "libcxx")
 
 setup_afl(name = "afl")
+
+setup_lmdb(name = "lmdb")
 
 # Some dependencies require multiple setup stages. These are added here.
 

--- a/cmake/FindLMDB.cmake
+++ b/cmake/FindLMDB.cmake
@@ -1,0 +1,29 @@
+
+include(FindPackageHandleStandardArgs)
+
+find_package(LMDB QUIET NO_MODULE)
+
+if (LMDB_FOUND)
+  find_package_handle_standard_args(LMDB CONFIG_MODE)
+  return()
+endif()
+
+set(_LMDB_PKG_ARGS )
+
+if (LMDB_FIND_REQUIRED)
+  list(APPEND _LMDB_PKG_ARGS REQUIRED)
+endif()
+if (LMDB_FIND_QUIET)
+  list(APPEND _LMDB_PKG_ARGS REQUIRED)
+endif()
+
+find_package(PkgConfig REQUIRED)
+pkg_check_modules(LMDB
+  ${_LMDB_PKG_ARGS}
+  IMPORTED_TARGET GLOBAL
+  lmdb
+)
+
+add_library(lmdb ALIAS PkgConfig::LMDB)
+
+unset(_LMDB_PKG_ARGS)

--- a/include/caffeine/Solver/CachingSolver.h
+++ b/include/caffeine/Solver/CachingSolver.h
@@ -1,0 +1,42 @@
+#pragma once
+
+#include "caffeine/Solver/Solver.h"
+#include "caffeine/Support/LMDB.h"
+#include <exception>
+
+namespace caffeine {
+
+class CachingSolver : public Solver {
+public:
+  CachingSolver(const std::shared_ptr<Solver>& solver,
+                const std::shared_ptr<lmdb::env>& env, MDB_dbi dbi);
+
+  SolverResult check(AssertionList& assertions,
+                     const Assertion& extra) override;
+  SolverResult resolve(AssertionList& assertions,
+                       const Assertion& extra) override;
+
+  void interrupt() override;
+
+private:
+  std::string cache_key(AssertionList& assertions, const Assertion& extra);
+
+private:
+  MDB_dbi dbi_;
+  std::shared_ptr<lmdb::env> env_;
+  std::shared_ptr<Solver> solver_;
+};
+
+class CachingSolverBuilder {
+public:
+  CachingSolverBuilder(const char* path, unsigned flags = 0);
+
+  std::shared_ptr<Solver>
+  operator()(const std::shared_ptr<Solver>& solver) const;
+
+private:
+  std::shared_ptr<lmdb::env> env_;
+  MDB_dbi dbi_;
+};
+
+} // namespace caffeine

--- a/include/caffeine/Support/LMDB.h
+++ b/include/caffeine/Support/LMDB.h
@@ -4,6 +4,7 @@
 #include <exception>
 #include <memory>
 #include <optional>
+#include <string_view>
 
 namespace caffeine::lmdb {
 

--- a/include/caffeine/Support/LMDB.h
+++ b/include/caffeine/Support/LMDB.h
@@ -1,0 +1,73 @@
+#pragma once
+
+#include "lmdb.h"
+#include <exception>
+#include <memory>
+#include <optional>
+
+namespace caffeine::lmdb {
+
+class env;
+class txn;
+
+class MDBException : public std::exception {
+public:
+  MDBException(int err);
+
+  const char* what() const noexcept override;
+  int code() const noexcept {
+    return error;
+  }
+
+private:
+  int error;
+};
+
+class env {
+public:
+  env(MDB_env* env);
+  env(const char* path, unsigned int flags = 0, mdb_mode_t mode = 0644);
+  ~env();
+
+  env(const env&) = delete;
+  env& operator=(const env&) = delete;
+  env(env&&);
+  env& operator=(env&&);
+
+  operator MDB_env*() const;
+
+  MDB_dbi open_db(const char* name, unsigned flags);
+
+  txn begin_txn(MDB_dbi dbi, unsigned flags = 0);
+
+private:
+  MDB_env* env_ = nullptr;
+};
+
+class txn {
+public:
+  txn(MDB_txn* txn, MDB_dbi dbi);
+  ~txn();
+
+  txn(txn&& t);
+  txn& operator=(txn&& t);
+
+  txn(const txn&) = delete;
+  txn& operator=(const txn&) = delete;
+
+  operator MDB_txn*() const;
+
+  // Note: The string_view here is only valid until the end of the
+  //       transaction.
+  std::optional<std::string_view> get(std::string_view key);
+  void put(std::string_view key, std::string_view val, unsigned flags = 0);
+
+  void commit();
+  void abort();
+
+private:
+  MDB_txn* txn_;
+  MDB_dbi dbi_;
+};
+
+} // namespace caffeine::lmdb

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -65,6 +65,7 @@ target_link_libraries(caffeine PUBLIC
   Boost::filesystem
   tsl::hopscotch_map
   divine
+  lmdb
 )
 
 install(

--- a/src/Solver/CachingSolver.cpp
+++ b/src/Solver/CachingSolver.cpp
@@ -1,5 +1,5 @@
 #include "caffeine/Solver/CachingSolver.h"
-#include "include/caffeine/Support/LMDB.h"
+#include "caffeine/Support/LMDB.h"
 #include <fmt/format.h>
 #include <fmt/ostream.h>
 

--- a/src/Solver/CachingSolver.cpp
+++ b/src/Solver/CachingSolver.cpp
@@ -23,7 +23,8 @@ SolverResult CachingSolver::check(AssertionList& assertions,
   txn.abort();
 
   auto result = solver_->check(assertions, extra);
-  if (result == SolverResult::Unknown || key.empty())
+  if (result == SolverResult::Unknown ||
+      key.size() > (size_t)mdb_env_get_maxkeysize(*env_))
     return result;
 
   txn = env_->begin_txn(dbi_);

--- a/src/Solver/CachingSolver.cpp
+++ b/src/Solver/CachingSolver.cpp
@@ -1,0 +1,82 @@
+#include "caffeine/Solver/CachingSolver.h"
+#include "include/caffeine/Support/LMDB.h"
+#include <fmt/format.h>
+#include <fmt/ostream.h>
+
+namespace caffeine {
+
+CachingSolver::CachingSolver(const std::shared_ptr<Solver>& solver,
+                             const std::shared_ptr<lmdb::env>& env, MDB_dbi dbi)
+    : dbi_(dbi), env_(env), solver_(solver) {}
+
+SolverResult CachingSolver::check(AssertionList& assertions,
+                                  const Assertion& extra) {
+  std::string key = cache_key(assertions, extra);
+  lmdb::txn txn = env_->begin_txn(dbi_);
+
+  if (auto val = txn.get(key)) {
+    if (val == "SAT")
+      return SolverResult::SAT;
+    if (val == "UNSAT")
+      return SolverResult::UNSAT;
+  }
+  txn.abort();
+
+  auto result = solver_->check(assertions, extra);
+  if (result == SolverResult::Unknown || key.empty())
+    return result;
+
+  txn = env_->begin_txn(dbi_);
+  txn.put(key, result.kind() == SolverResult::SAT ? "SAT" : "UNSAT");
+  txn.commit();
+
+  return result;
+}
+
+SolverResult CachingSolver::resolve(AssertionList& assertions,
+                                    const Assertion& extra) {
+  auto result = solver_->resolve(assertions, extra);
+  if (result == SolverResult::Unknown)
+    return result;
+
+  std::string key = cache_key(assertions, extra);
+  if (key.empty() || key.length() > (size_t)mdb_env_get_maxkeysize(*env_))
+    return result;
+
+  lmdb::txn txn = env_->begin_txn(dbi_);
+  txn.put(key, result.kind() == SolverResult::SAT ? "SAT" : "UNSAT");
+  txn.commit();
+
+  return result;
+}
+
+void CachingSolver::interrupt() {
+  solver_->interrupt();
+}
+
+std::string CachingSolver::cache_key(AssertionList& assertions,
+                                     const Assertion& extra) {
+  std::vector<std::string> exprs;
+
+  for (const auto& assertion : assertions) {
+    exprs.push_back(fmt::format(FMT_STRING("{}"), assertion));
+  }
+
+  if (!extra.is_constant_value(true))
+    exprs.push_back(fmt::format(FMT_STRING("{}"), extra));
+
+  std::sort(exprs.begin(), exprs.end());
+  return fmt::format("{}", fmt::join(exprs, "\n"));
+}
+
+CachingSolverBuilder::CachingSolverBuilder(const char* path, unsigned flags)
+    : env_(std::make_shared<lmdb::env>(path, flags)) {
+  dbi_ = env_->open_db("caffeine-cache", MDB_CREATE);
+}
+
+std::shared_ptr<Solver>
+CachingSolverBuilder::operator()(const std::shared_ptr<Solver>& solver) const {
+  return std::make_shared<CachingSolver>(solver, env_, dbi_);
+}
+
+} // namespace caffeine

--- a/src/Support/LMDB.cpp
+++ b/src/Support/LMDB.cpp
@@ -1,0 +1,142 @@
+#include "caffeine/Support/LMDB.h"
+#include "caffeine/Support/Assert.h"
+#include <cstdlib>
+#include <exception>
+#include <string>
+#include <string_view>
+
+namespace caffeine::lmdb {
+
+MDBException::MDBException(int err) : error(err) {}
+
+const char* MDBException::what() const noexcept {
+  return mdb_strerror(error);
+}
+
+env::env(MDB_env* env) : env_(env) {}
+env::env(const char* path, unsigned int flags, mdb_mode_t mode) {
+  if (int error = mdb_env_create(&env_))
+    throw MDBException(error);
+
+  if (int error = mdb_env_set_maxdbs(env_, 1)) {
+    mdb_env_close(env_);
+    throw MDBException(error);
+  }
+
+  if (int error = mdb_env_open(env_, path, flags, mode)) {
+    mdb_env_close(env_);
+    throw MDBException(error);
+  }
+}
+env::~env() {
+  if (env_)
+    mdb_env_close(env_);
+}
+
+env::env(env&& e) : env_(e.env_) {
+  e.env_ = nullptr;
+}
+env& env::operator=(env&& e) {
+  if (env_)
+    mdb_env_close(env_);
+  env_ = e.env_;
+  e.env_ = nullptr;
+  return *this;
+}
+
+env::operator MDB_env*() const {
+  return env_;
+}
+
+MDB_dbi env::open_db(const char* name, unsigned flags) {
+  MDB_txn* txn;
+  if (int error = mdb_txn_begin(*this, nullptr, 0, &txn))
+    throw MDBException(error);
+
+  MDB_dbi dbi = 0;
+  if (int error = mdb_dbi_open(txn, name, flags, &dbi)) {
+    mdb_txn_abort(txn);
+    throw MDBException(error);
+  }
+
+  if (int error = mdb_txn_commit(txn)) {
+    mdb_txn_abort(txn);
+    throw MDBException(error);
+  }
+
+  return dbi;
+}
+
+txn env::begin_txn(MDB_dbi dbi, unsigned flags) {
+  MDB_txn* mtxn;
+  if (int error = mdb_txn_begin(*this, nullptr, flags, &mtxn))
+    throw MDBException(error);
+
+  return txn(mtxn, dbi);
+}
+
+txn::txn(MDB_txn* txn, MDB_dbi dbi) : txn_(txn), dbi_(dbi) {}
+txn::~txn() {
+  abort();
+}
+
+txn::txn(txn&& t) : txn_(t.txn_), dbi_(t.dbi_) {
+  t.txn_ = nullptr;
+}
+txn& txn::operator=(txn&& t) {
+  abort();
+
+  txn_ = t.txn_;
+  dbi_ = t.dbi_;
+  t.txn_ = nullptr;
+
+  return *this;
+}
+
+txn::operator MDB_txn*() const {
+  return txn_;
+}
+
+std::optional<std::string_view> txn::get(std::string_view key) {
+  MDB_val mkey, mval{0, 0};
+
+  mkey.mv_data = (void*)key.data();
+  mkey.mv_size = key.size();
+
+  if (int error = mdb_get(*this, dbi_, &mkey, &mval)) {
+    if (error == MDB_NOTFOUND)
+      return std::nullopt;
+
+    throw MDBException(error);
+  }
+
+  return std::string_view((const char*)mval.mv_data, mval.mv_size);
+}
+void txn::put(std::string_view key, std::string_view val, unsigned flags) {
+  MDB_val mkey, mval;
+
+  mkey.mv_data = (void*)key.data();
+  mkey.mv_size = key.size();
+  mval.mv_data = (void*)val.data();
+  mval.mv_size = val.size();
+
+  if (int error = mdb_put(*this, dbi_, &mkey, &mval, flags))
+    throw MDBException(error);
+}
+
+void txn::commit() {
+  CAFFEINE_ASSERT(txn_);
+
+  if (int error = mdb_txn_commit(txn_))
+    throw MDBException(error);
+  txn_ = nullptr;
+}
+void txn::abort() {
+  if (!txn_)
+    return;
+
+  mdb_txn_abort(txn_);
+  txn_ = nullptr;
+}
+
+} // namespace caffeine::lmdb

--- a/third_party/lmdb/lmdb.BUILD
+++ b/third_party/lmdb/lmdb.BUILD
@@ -1,0 +1,11 @@
+cc_library(
+    name = "lmdb",
+    srcs = [
+        "mdb.c",
+        "midl.c",
+        "midl.h",
+    ],
+    hdrs = ["lmdb.h"],
+    copts = ["-DMDB_MAXKEYSIZE=4096"],
+    visibility = ["//visibility:public"],
+)

--- a/third_party/lmdb/setup.bzl
+++ b/third_party/lmdb/setup.bzl
@@ -1,0 +1,14 @@
+""
+
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
+def setup_lmdb(name):
+    version = "0.9.29"
+
+    http_archive(
+        name = name,
+        build_file = "@caffeine//third_party/lmdb:lmdb.BUILD",
+        strip_prefix = "lmdb-LMDB_{}/libraries/liblmdb".format(version),
+        url = "https://github.com/LMDB/lmdb/archive/refs/tags/LMDB_{}.tar.gz".format(version),
+        sha256 = "22054926b426c66d8f2bc22071365df6e35f3aacf19ad943bc6167d4cae3bebb",
+    )

--- a/tools/caffeine/main.cpp
+++ b/tools/caffeine/main.cpp
@@ -9,6 +9,7 @@
 #include "caffeine/Interpreter/Store/TimeLimitedStore.h"
 #include "caffeine/Interpreter/ThreadQueueStore.h"
 #include "caffeine/Memory/BumpAllocator.h"
+#include "caffeine/Solver/CachingSolver.h"
 #include "caffeine/Solver/InterruptSolver.h"
 #include "caffeine/Solver/LoggingSolver.h"
 #include "caffeine/Solver/Solver.h"
@@ -18,6 +19,7 @@
 #include "caffeine/Support/SyncOStream.h"
 #include "caffeine/Support/Tracing.h"
 #include <atomic>
+#include <boost/filesystem.hpp>
 #include <csignal>
 #include <cstdlib>
 #include <exception>
@@ -222,6 +224,10 @@ int main(int argc, char** argv) {
   auto solver_builder = SolverBuilder::with_default();
   if (log_queries)
     solver_builder.with<LoggingSolver>();
+
+  boost::filesystem::create_directories(".cache/caffeine");
+  solver_builder.with(CachingSolverBuilder(".cache/caffeine", MDB_NOMETASYNC));
+
   solver_builder.with<InterruptSolver>(should_stop);
 
   auto counter = std::make_unique<CountingFailureLogger>();

--- a/tools/caffeine/main.cpp
+++ b/tools/caffeine/main.cpp
@@ -122,6 +122,9 @@ cl::opt<uint64_t> limit_time_seconds{
 cl::opt<std::string> test_output_dir{
     "test-output-dir", cl::desc("The directory to output test case files to."),
     cl::cat(caffeine_options)};
+cl::opt<std::string> cache_dir{
+    "cache-dir", cl::desc("The directory to which to store the on-disk cache"),
+    cl::init("~/.cache/caffeine"), cl::cat(caffeine_options)};
 
 static ExitOnError exit_on_err;
 
@@ -225,8 +228,8 @@ int main(int argc, char** argv) {
   if (log_queries)
     solver_builder.with<LoggingSolver>();
 
-  boost::filesystem::create_directories(".cache/caffeine");
-  solver_builder.with(CachingSolverBuilder(".cache/caffeine", MDB_NOMETASYNC));
+  boost::filesystem::create_directories(cache_dir);
+  solver_builder.with(CachingSolverBuilder(cache_dir.c_str(), MDB_NOMETASYNC));
 
   solver_builder.with<InterruptSolver>(should_stop);
 


### PR DESCRIPTION
This is the simplest possible implementation of a caching solver built on top of LMDB. All it does is convert each expression in the solver to a string, sort them, and then use them as the cache key. LMDB isn't optimal for this since it has a compile-time upper bound on the length of a key but I've bumped that up somewhat so that it works okay enough for now.

In the future it would be better to use a kv-store that supports arbitrary-length keys but I haven't found a local one as-of yet. RocksDB would probably be a good option for this.