### PR TITLE
Fix some bugs around using LMDB

### DIFF
--- a/src/Solver/CachingSolver.cpp
+++ b/src/Solver/CachingSolver.cpp
@@ -27,9 +27,14 @@ SolverResult CachingSolver::check(AssertionList& assertions,
       key.size() > (size_t)mdb_env_get_maxkeysize(*env_))
     return result;
 
-  txn = env_->begin_txn(dbi_);
-  txn.put(key, result.kind() == SolverResult::SAT ? "SAT" : "UNSAT");
-  txn.commit();
+  try {
+    txn = env_->begin_txn(dbi_);
+    txn.put(key, result.kind() == SolverResult::SAT ? "SAT" : "UNSAT");
+    txn.commit();
+  } catch (lmdb::MDBException& e) {
+    if (e.code() != MDB_MAP_FULL)
+      throw;
+  }
 
   return result;
 }
@@ -44,9 +49,14 @@ SolverResult CachingSolver::resolve(AssertionList& assertions,
   if (key.empty() || key.length() > (size_t)mdb_env_get_maxkeysize(*env_))
     return result;
 
-  lmdb::txn txn = env_->begin_txn(dbi_);
-  txn.put(key, result.kind() == SolverResult::SAT ? "SAT" : "UNSAT");
-  txn.commit();
+  try {
+    lmdb::txn txn = env_->begin_txn(dbi_);
+    txn.put(key, result.kind() == SolverResult::SAT ? "SAT" : "UNSAT");
+    txn.commit();
+  } catch (lmdb::MDBException& e) {
+    if (e.code() != MDB_MAP_FULL)
+      throw;
+  }
 
   return result;
 }

--- a/src/Support/LMDB.cpp
+++ b/src/Support/LMDB.cpp
@@ -18,15 +18,14 @@ env::env(const char* path, unsigned int flags, mdb_mode_t mode) {
   if (int error = mdb_env_create(&env_))
     throw MDBException(error);
 
-  if (int error = mdb_env_set_maxdbs(env_, 1)) {
-    mdb_env_close(env_);
+  if (int error = mdb_env_set_maxdbs(env_, 1))
     throw MDBException(error);
-  }
 
-  if (int error = mdb_env_open(env_, path, flags, mode)) {
-    mdb_env_close(env_);
+  if (int error = mdb_env_set_mapsize(env_, (size_t)1 * 1024 * 1024 * 1024))
     throw MDBException(error);
-  }
+
+  if (int error = mdb_env_open(env_, path, flags, mode))
+    throw MDBException(error);
 }
 env::~env() {
   if (env_)

--- a/tools/caffeine/main.cpp
+++ b/tools/caffeine/main.cpp
@@ -124,7 +124,7 @@ cl::opt<std::string> test_output_dir{
     cl::cat(caffeine_options)};
 cl::opt<std::string> cache_dir{
     "cache-dir", cl::desc("The directory to which to store the on-disk cache"),
-    cl::init("~/.cache/caffeine"), cl::cat(caffeine_options)};
+    cl::init(".cache/caffeine"), cl::cat(caffeine_options)};
 
 static ExitOnError exit_on_err;
 


### PR DESCRIPTION
Turns there were some issues with how I was using LMDB:
- The max size of the database was limited to 10MB so it would crash once it filled up due to an unhandled exception, and
- It was storing the cache in a directory literally named `~/.cache/caffeine` instead of `.cache/caffeine` under the home dir.

I've gone and fixed both of these issues so it should hopefully be robust at this point.