### PR TITLE
Reduce page size of LMDB database to prevent internal errors

### DIFF
--- a/src/Solver/CachingSolver.cpp
+++ b/src/Solver/CachingSolver.cpp
@@ -31,10 +31,7 @@ SolverResult CachingSolver::check(AssertionList& assertions,
     txn = env_->begin_txn(dbi_);
     txn.put(key, result.kind() == SolverResult::SAT ? "SAT" : "UNSAT");
     txn.commit();
-  } catch (lmdb::MDBException& e) {
-    if (e.code() != MDB_MAP_FULL)
-      throw;
-  }
+  } catch (lmdb::MDBException& e) {}
 
   return result;
 }
@@ -53,10 +50,7 @@ SolverResult CachingSolver::resolve(AssertionList& assertions,
     lmdb::txn txn = env_->begin_txn(dbi_);
     txn.put(key, result.kind() == SolverResult::SAT ? "SAT" : "UNSAT");
     txn.commit();
-  } catch (lmdb::MDBException& e) {
-    if (e.code() != MDB_MAP_FULL)
-      throw;
-  }
+  } catch (lmdb::MDBException& e) {}
 
   return result;
 }

--- a/third_party/lmdb/lmdb.BUILD
+++ b/third_party/lmdb/lmdb.BUILD
@@ -6,6 +6,6 @@ cc_library(
         "midl.h",
     ],
     hdrs = ["lmdb.h"],
-    copts = ["-DMDB_MAXKEYSIZE=4096"],
+    copts = ["-DMDB_MAXKEYSIZE=2048"],
     visibility = ["//visibility:public"],
 )


### PR DESCRIPTION
I ran into an error and this PR fixes + avoids it showing up again in case of failures.