### PR TITLE
Write a demo that counts the digits in an integer

### DIFF
--- a/bench/BUILD
+++ b/bench/BUILD
@@ -19,3 +19,8 @@ bitcode_binary(
     name = "cpp_bench",
     srcs = ["cpp_bench.cpp"],
 )
+
+bitcode_binary(
+    name = "digitcount",
+    srcs = ["digitcount.c"],
+)

--- a/bench/digitcount.c
+++ b/bench/digitcount.c
@@ -1,0 +1,50 @@
+
+#include "caffeine.h"
+#include <stdint.h>
+
+uint32_t ilog2(uint32_t x) {
+  return 31 - __builtin_clz(x | 1);
+}
+
+uint32_t count1(uint32_t x) {
+  static uint64_t table[] = {
+      4294967296,  8589934582,  8589934582,  8589934582,  12884901788,
+      12884901788, 12884901788, 17179868184, 17179868184, 17179868184,
+      21474826480, 21474826480, 21474826480, 21474826480, 25769703776,
+      25769703776, 25769703776, 30063771072, 30063771072, 30063771072,
+      34349738368, 34349738368, 34349738368, 34349738368, 38554705664,
+      38554705664, 38554705664, 41949672960, 41949672960, 41949672960,
+      42949672960, 42949672960};
+  return (x + table[ilog2(x)]) >> 32;
+}
+
+uint32_t count2(uint32_t x) {
+  static uint32_t table[] = {9,      99,      999,      9999,     99999,
+                             999999, 9999999, 99999999, 999999999};
+  uint32_t y = (9 * ilog2(x)) >> 5;
+  y += x > table[y];
+  return y + 1;
+}
+
+uint32_t count3(uint32_t x) {
+  uint32_t cnt = 1;
+  while (x >= 10) {
+    cnt += 1;
+    x /= 10;
+  }
+  return cnt;
+}
+
+int main(int argc, char** argv) {
+  uint32_t x;
+  caffeine_make_symbolic(&x, sizeof(x), "x");
+
+  uint32_t c1 = count1(x);
+  uint32_t c2 = count2(x);
+  uint32_t c3 = count3(x);
+
+  caffeine_assert(c1 == c3);
+  caffeine_assert(c2 == c3);
+
+  return 0;
+}


### PR DESCRIPTION
As in the title. This demo compares a couple of different ways of counting the base 10 digits in an integer (from a blog post by Daniel Lemire) to a reference implementation to ensure that they are all equivalent for all inputs.

Note that this can't actually be run without #757 but that's not needed for CI so I haven't included it here.