### PR TITLE
Fix bad shift combination test case

### DIFF
--- a/src/IR/EMatching/Rewrites/ShiftCombination.cpp
+++ b/src/IR/EMatching/Rewrites/ShiftCombination.cpp
@@ -34,8 +34,8 @@ namespace {
           op = ConstantInt::CreateZero(shiftop->type().bitwidth());
         }
       } else {
-        op = BinaryOp::CreateLShr(egraph.get_op(shiftop->operands[0]),
-                                  ConstantInt::Create(total));
+        op = BinaryOp::Create(opcode, egraph.get_op(shiftop->operands[0]),
+                              ConstantInt::Create(total));
       }
       egraph.add_merge(eclass_id, op);
     };


### PR DESCRIPTION
It turns out that the rewrite introduced in #768 was converting everything to `lshr` operations. This is obviously not correct and it was caught by CI after it merged (not sure why it wasn't caught before). This PR fixes that by generating expressions with the correct opcode.