### PR TITLE
Update CI to no longer use a cache server

### DIFF
--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -54,7 +54,7 @@ jobs:
         with:
           path: |
             ~/.cache/bazel-disk-cache
-          key: bazel-build-disk-cache--${{ matrix.mode }}-${{ matrix.compiler}}-${{ hashFiles('bazel-deps') }}
+          key: bazel-build-disk-cache--${{ matrix.mode }}-${{ matrix.compiler }}-${{ hashFiles('bazel-deps') }}
 
       - name: Run all tests
         run: |
@@ -109,7 +109,7 @@ jobs:
         with:
           path: |
             ~/.cache/bazel-disk-cache
-          key: bazel-fmt-disk-cache--${{ matrix.mode }}-${{ matrix.compiler}}-${{ hashFiles('bazel-deps') }}
+          key: bazel-fmt-disk-cache--${{ matrix.mode }}-${{ matrix.compiler }}-${{ hashFiles('bazel-deps') }}
 
       - name: Check formatting of all targets
         run: bazelisk run -- //:check-format

--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -43,19 +43,6 @@ jobs:
           build --config=${{ matrix.compiler }}
           EOF
 
-      # - name: Avoid uploading if we don't have credentials
-      #   if: env.CACHE_CREDENTIALS == null
-      #   shell: bash
-      #   run: |
-      #     echo build --remote_cache=grpc://bazel-cache.airmash.cc:9092/ >> local.bazelrc
-      #     echo build --remote_upload_local_results=false       >> local.bazelrc
-
-      # - name: Pass credentials
-      #   if: env.CACHE_CREDENTIALS != null
-      #   shell: bash
-      #   run: |
-      #     echo "build '--remote_cache=grpc://bazel:${{ env.CACHE_CREDENTIALS }}@bazel-cache.airmash.cc:9092/'" >> local.bazelrc
-
       - name: Find all external dependencies
         shell: bash
         run: |
@@ -110,19 +97,6 @@ jobs:
           cat >> local.bazelrc <<- EOF
           build --compilation_mode=${{ matrix.mode }}
           EOF
-
-      # - name: Avoid uploading if we don't have credentials
-      #   if: env.CACHE_CREDENTIALS == null
-      #   shell: bash
-      #   run: |
-      #     echo build --remote_cache=grpc://bazel-cache.airmash.cc:9092/ >> local.bazelrc
-      #     echo build --remote_upload_local_results=false       >> local.bazelrc
-
-      # - name: Pass credentials
-      #   if: env.CACHE_CREDENTIALS != null
-      #   shell: bash
-      #   run: |
-      #     echo "build '--remote_cache=grpc://bazel:${{ env.CACHE_CREDENTIALS }}@bazel-cache.airmash.cc:9092/'" >> local.bazelrc
       
       - name: Find all external dependencies
         shell: bash

--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -58,7 +58,7 @@ jobs:
 
       - name: Run all tests
         run: |
-          bazelisk test --config=ci -- //... //:tarball-dev \
+          bazelisk test -- //... //:tarball-dev \
             $(bazelisk query 'kind(".*_test", //...) intersect attr("tags", "manual", //...)') \
             -//:format
 
@@ -112,7 +112,7 @@ jobs:
           key: bazel-fmt-disk-cache--${{ matrix.mode }}-${{ matrix.compiler}}-${{ hashFiles('bazel-deps') }}
 
       - name: Check formatting of all targets
-        run: bazelisk run --config=ci -- //:check-format
+        run: bazelisk run -- //:check-format
 
   all-test-pass:
     name: Verify all tests pass

--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -43,18 +43,31 @@ jobs:
           build --config=${{ matrix.compiler }}
           EOF
 
-      - name: Avoid uploading if we don't have credentials
-        if: env.CACHE_CREDENTIALS == null
-        shell: bash
-        run: |
-          echo build --remote_cache=grpc://bazel-cache.airmash.cc:9092/ >> local.bazelrc
-          echo build --remote_upload_local_results=false       >> local.bazelrc
+      # - name: Avoid uploading if we don't have credentials
+      #   if: env.CACHE_CREDENTIALS == null
+      #   shell: bash
+      #   run: |
+      #     echo build --remote_cache=grpc://bazel-cache.airmash.cc:9092/ >> local.bazelrc
+      #     echo build --remote_upload_local_results=false       >> local.bazelrc
 
-      - name: Pass credentials
-        if: env.CACHE_CREDENTIALS != null
+      # - name: Pass credentials
+      #   if: env.CACHE_CREDENTIALS != null
+      #   shell: bash
+      #   run: |
+      #     echo "build '--remote_cache=grpc://bazel:${{ env.CACHE_CREDENTIALS }}@bazel-cache.airmash.cc:9092/'" >> local.bazelrc
+
+      - name: Find all external dependencies
         shell: bash
         run: |
-          echo "build '--remote_cache=grpc://bazel:${{ env.CACHE_CREDENTIALS }}@bazel-cache.airmash.cc:9092/'" >> local.bazelrc
+          # Get a list of all external dependencies
+          bazel query 'deps(//...)' | grep -ve '^//.*$' > bazel-deps
+
+      - name: Restore bazel disk cache
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cache/bazel-disk-cache
+          key: bazel-build-disk-cache--${{ matrix.mode }}-${{ matrix.compiler}}-${{ hashFiles('bazel-deps') }}
 
       - name: Run all tests
         run: |
@@ -98,18 +111,31 @@ jobs:
           build --compilation_mode=${{ matrix.mode }}
           EOF
 
-      - name: Avoid uploading if we don't have credentials
-        if: env.CACHE_CREDENTIALS == null
-        shell: bash
-        run: |
-          echo build --remote_cache=grpc://bazel-cache.airmash.cc:9092/ >> local.bazelrc
-          echo build --remote_upload_local_results=false       >> local.bazelrc
+      # - name: Avoid uploading if we don't have credentials
+      #   if: env.CACHE_CREDENTIALS == null
+      #   shell: bash
+      #   run: |
+      #     echo build --remote_cache=grpc://bazel-cache.airmash.cc:9092/ >> local.bazelrc
+      #     echo build --remote_upload_local_results=false       >> local.bazelrc
 
-      - name: Pass credentials
-        if: env.CACHE_CREDENTIALS != null
+      # - name: Pass credentials
+      #   if: env.CACHE_CREDENTIALS != null
+      #   shell: bash
+      #   run: |
+      #     echo "build '--remote_cache=grpc://bazel:${{ env.CACHE_CREDENTIALS }}@bazel-cache.airmash.cc:9092/'" >> local.bazelrc
+      
+      - name: Find all external dependencies
         shell: bash
         run: |
-          echo "build '--remote_cache=grpc://bazel:${{ env.CACHE_CREDENTIALS }}@bazel-cache.airmash.cc:9092/'" >> local.bazelrc
+          # Get a list of all external dependencies
+          bazel query 'deps(//:check-format)' | grep -ve '^//.*$' > bazel-deps
+
+      - name: Restore bazel disk cache
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cache/bazel-disk-cache
+          key: bazel-fmt-disk-cache--${{ matrix.mode }}-${{ matrix.compiler}}-${{ hashFiles('bazel-deps') }}
 
       - name: Check formatting of all targets
         run: bazelisk run --config=ci -- //:check-format

--- a/bazel/ci.bazelrc
+++ b/bazel/ci.bazelrc
@@ -1,19 +1,4 @@
 
-# Allow many remote connections so that we can do lots of downloads
-# in parallel
-build:ci --remote_max_connections=1000
-
-# Github runners have limited CPU but we still need lots of jobs running
-# in parallel in order to download everything.
-build:ci --local_cpu_resources=2
-build:ci --jobs=64
-
-# Reduce network traffic by compressing things with zstd.
-build:ci --experimental_remote_cache_async
-
-# Avoid downloading artifacts that aren't needed.
-# build:ci --remote_download_toplevel
-
 build:clang --action_env=CC=clang-12
 build:clang --action_env=CXX=clang++-12
 build:clang --linkopt=-fuse-ld=lld-12

--- a/bazel/ci.bazelrc
+++ b/bazel/ci.bazelrc
@@ -12,7 +12,7 @@ build:ci --jobs=64
 build:ci --experimental_remote_cache_async
 
 # Avoid downloading artifacts that aren't needed.
-build:ci --remote_download_toplevel
+# build:ci --remote_download_toplevel
 
 build:clang --action_env=CC=clang-12
 build:clang --action_env=CXX=clang++-12


### PR DESCRIPTION
Now that the cache server is no longer running, CI needs to be updated to instead use the cache from github actions.